### PR TITLE
End sentence with a period

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1743,6 +1743,7 @@ Do not distribute a modified version of this file.
       {
         \seq_use:Nnnn \g_@@_tmpa_seq
           { \,~and~ } { \,,~ } { \,,~and~ }
+        \@.
       }
       { \seq_item:Nn \g_@@_tmpa_seq {1}\,~and~others. }
       


### PR DESCRIPTION
Explicit space-factor correction is included for functions whose names end in capital letters like `\foo:N` or `\bar:TF`.
