### PR TITLE
Search for trailing underscore in @@-replacement

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1699,8 +1699,8 @@ Do not distribute a modified version of this file.
 %    itself the \verb|@@| search string needs to be protected from 
 %    replacement by l3docstrip! This is easy to do by adding a space.
 %    \begin{macrocode}
-    \tl_replace_all:Nox #1 { _@ @ } { __ \g_@@_module_name_tl }
-    \tl_replace_all:Nox #1 { @ @ } { __ \g_@@_module_name_tl }
+    \tl_replace_all:Nox #1 { _@ @_ } { __ \g_@@_module_name_tl _ }
+    \tl_replace_all:Nox #1 { @ @_ } { __ \g_@@_module_name_tl _ }
    }
  }
 \cs_generate_variant:Nn \tl_replace_all:Nnn { Non, Nox }


### PR DESCRIPTION
In the documentation for `l3names`, some primitives which LaTeX2e renames are displayed incorrectly; e.g., the line

```
\tex_let:D \tex_end:D               \@@end
```

displays as

```
\tex_let:D \tex_end:D               \__explend
```

instead.

[Currently `l3docstrip` produces the correct output `\@@end` here; this bug applies to `l3doc` alone.]
