### PR TITLE
actually utilize example test from documentation

### DIFF
--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -583,7 +583,7 @@ function checkinit()
   for _,i in ipairs(filelist(localdir)) do
     cp(i, localdir, testdir)
   end
-  bundleunpack()
+  bundleunpack({".", testfiledir})
   for _,i in ipairs(installfiles) do
     cp(i, unpackdir, testdir)
   end
@@ -1503,11 +1503,14 @@ end
 
 -- Split off from the main unpack so it can be used on a bundle and not
 -- leave only one modules files
-bundleunpack = bundleunpack or function()
+bundleunpack = bundleunpack or function(sourcedir)
   mkdir(localdir)
   cleandir(unpackdir)
-  for _,i in ipairs(sourcefiles) do
-    cp(i, ".", unpackdir)
+  for _,i in ipairs(sourcedir or {"."}) do
+    for _,j in ipairs(sourcefiles) do
+      print(j, i, unpackdir)
+      cp(j, i, unpackdir)
+    end
   end
   for _,i in ipairs(unpacksuppfiles) do
     cp(i, supportdir, localdir)

--- a/l3build/testfiles/01-expect.dtx
+++ b/l3build/testfiles/01-expect.dtx
@@ -1,0 +1,15 @@
+\input regression-test.tex\relax
+\START
+\TEST{counter-math}{
+%<*test>
+  \OMIT
+  \newcounter{numbers}
+  \setcounter{numbers}{2}
+  \addtocounter{numbers}{2}
+  \stepcounter{numbers}
+  \TIMO
+  \typeout{\arabic{numbers}}
+%</test>
+%<expect>  \typeout{5}
+}
+\END

--- a/l3build/testfiles/01-expect.ins
+++ b/l3build/testfiles/01-expect.ins
@@ -1,0 +1,6 @@
+\input docstrip.tex
+\generate{
+  \file{\jobname-1.lvt}{\from{\jobname.dtx}{test}}
+  \file{\jobname-1.lve}{\from{\jobname.dtx}{expect}}
+}
+\endbatchfile


### PR DESCRIPTION
Adding the example test from the manual as an actual test does not only ensure that the example is actually valid, it also helps the user to understand the feature as he can observe it in action right within the sources of latex3 itself.

Doing so, I recognized that l3build should be able to find tests in the `testdir` also when they are packed.