### PR TITLE
 copy recursively

### DIFF
--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -412,11 +412,11 @@ function cp(glob, source, dest)
     local source = source .. "/" .. i
     if os_windows then
       os.execute(
-          "copy /y " .. unix_to_win(source) .. " "
-            .. unix_to_win(dest) .. " > nul"
+          "xcopy /y /e /i" .. unix_to_win(source)
+            .. " " .. unix_to_win(dest) .. " > nul"
         )
     else
-      os.execute("cp -f " .. source .. " " .. dest)
+      os.execute("cp -rf " .. source .. " " .. dest)
     end
   end
 end


### PR DESCRIPTION
Some users may want to specify whole directories in `docfiles`, `supportfiles` or the like. Imagine for example a complex documentation that should be neatly hierarchically assorted by chapters and sections.

This patch teaches l3build's `cp` function to copy around directories and everything contained within.