### PR TITLE
Two typos in XeTeX primitive renaming

### DIFF
--- a/l3kernel/l3names.dtx
+++ b/l3kernel/l3names.dtx
@@ -699,7 +699,7 @@
 %    \begin{macrocode}
   \__kernel_primitive:NN \suppressfontnotfounderror \xetex_suppressfontnotfounderror:D
   \__kernel_primitive:NN \XeTeXcharclass            \xetex_charclass:D
-  \__kernel_primitive:NN \XeTeXcharglyph            \xetex_charcglyph:D
+  \__kernel_primitive:NN \XeTeXcharglyph            \xetex_charglyph:D
   \__kernel_primitive:NN \XeTeXcountfeatures        \xetex_countfeatures:D
   \__kernel_primitive:NN \XeTeXcountglyphs          \xetex_countglyphs:D
   \__kernel_primitive:NN \XeTeXcountselectors       \xetex_countselectors:D
@@ -727,7 +727,7 @@
   \__kernel_primitive:NN \XeTeXlinebreakskip        \xetex_linebreakskip:D
   \__kernel_primitive:NN \XeTeXlinebreaklocale      \xetex_linebreaklocale:D
   \__kernel_primitive:NN \XeTeXlinebreakpenalty     \xetex_linebreakpenalty:D
-  \__kernel_primitive:NN \XeTeXOTcountfeatures      \xetex_OTcounfeatures:D
+  \__kernel_primitive:NN \XeTeXOTcountfeatures      \xetex_OTcountfeatures:D
   \__kernel_primitive:NN \XeTeXOTcountlanguages     \xetex_OTcountlanguages:D
   \__kernel_primitive:NN \XeTeXOTcountscripts       \xetex_OTcountscripts:D
   \__kernel_primitive:NN \XeTeXOTfeaturetag         \xetex_OTfeaturetag:D


### PR DESCRIPTION
`\xetex_charglyph:D` is required in `xeCJK`. So I would be very grateful for a new CTAN release.