### PR TITLE
Change the flag of the early LaTeX2e format.

### DIFF
--- a/l3kernel/l3names.dtx
+++ b/l3kernel/l3names.dtx
@@ -1037,7 +1037,7 @@
 % (depending on the format-building date). There are a few primitives
 % that get the right names anyway so are missing here!
 %    \begin{macrocode}
-\etex_ifdefined:D \luatexcatcodetable
+\etex_ifdefined:D \luatexsuppressfontnotfounderror
   \tex_let:D \luatex_alignmark:D                 \luatexalignmark
   \tex_let:D \luatex_aligntab:D                  \luatexaligntab
   \tex_let:D \luatex_attribute:D                 \luatexattribute


### PR DESCRIPTION
`\luatexsuppressfontnotfounderror` is chosen becase this issue is inspired by it:
```TeX
\documentclass{article}
\usepackage{luatexbase}
\usepackage{fontspec}
\setmainfont{cmunrm.otf}
```
There will be a `\xetex_suppressfontnotfounderror:D` undefined error again :-).