### PR TITLE
l3doc provides \saved@indexname.

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -2252,13 +2252,12 @@ Do not distribute a modified version of this file.
 %     \item Macro/function/whatever name; input has already been
 %       sanitised.
 %   \end{arguments}
-%   The assignment to \cs{saved@macroname} is used by \pkg{doc}'s
-%   \cs{changes} mechanism.
+%   The assignments to \cs{saved@macroname} and \cs{saved@indexname}
+%   are used by \pkg{doc}'s \cs{changes} mechanism.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_macro_single:n #1
   {
     \tl_set:Nn \saved@macroname {#1}
-
     \@@_macro_typeset_one:n {#1}
     \exp_args:Nx \@@_macro_index:n
       {
@@ -2270,15 +2269,15 @@ Do not distribute a modified version of this file.
   {
     \bool_if:NF \l_@@_macro_aux_bool
       { \seq_gput_right:Nn \g_doc_macros_seq {#1} }
-    \hbox_set:Nn \l_@@_macro_index_box
-      {
-        % This box only contains targets... it seems inefficient.
-        \hbox_unpack_clear:N \l_@@_macro_index_box
-        \int_gincr:N \c@CodelineNo
-        \@@_special_index:nn {#1} { main }
-        \DoNotIndex {#1}
-        \int_gdecr:N \c@CodelineNo
-      }
+    \hbox_set:Nw \l_@@_macro_index_box
+      % This box only contains targets... it seems inefficient.
+      \hbox_unpack_clear:N \l_@@_macro_index_box
+      \int_gincr:N \c@CodelineNo
+      \@@_special_index:nn {#1} { main }
+      \DoNotIndex {#1}
+      \int_gdecr:N \c@CodelineNo
+    \exp_args:NNNo \hbox_set_end:
+      \tl_set:Nn \saved@indexname { \l_@@_index_key_tl }
   }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
`\saved@indexname` is introduced by `doc` 2016/02/15 v2.1g.