### PR TITLE
Fix documentation error

### DIFF
--- a/l3kernel/l3drivers.dtx
+++ b/l3kernel/l3drivers.dtx
@@ -2025,6 +2025,7 @@
 \int_new:N \g_@@_draw_scope_int
 \int_new:N \l_@@_draw_scope_int
 %    \end{macrocode}
+% \end{variable}
 % \end{macro}
 % \end{macro}
 %
@@ -2086,6 +2087,7 @@
 % \end{macro}
 % \end{macro}
 % \end{macro}
+% \end{macro}
 %
 % \begin{macro}[int]{\@@_draw_evenodd_rule:, \@@_draw_nonzero_rule:}
 %   The fill rules here have to be handled as scopes.
@@ -2095,7 +2097,6 @@
 \cs_new_protected_nopar:Npn \@@_draw_nonzero_rule:
   { \@@_draw_scope:n { fill-rule="nonzero" } }
 %    \end{macrocode}
-% \end{variable}
 % \end{macro}
 %
 % \begin{macro}[aux]{\@@_draw_path:n}


### PR DESCRIPTION
There were mismatched environments in the documentation of `l3kernel/l3drivers.dtx`.
