### PR TITLE
Also typeset unpacked files

### DIFF
--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -1840,22 +1840,24 @@ function doc(files)
   unpack()
   -- Main loop for doc creation
   for _,i in ipairs(typesetfiles) do
-    for _,j in ipairs(filelist(".", i)) do
-      -- Allow for command line selection of files
-      local typeset = true
-      if files and next(files) then
-        typeset = false
-        for _,k in ipairs(files) do
-          if k == stripext(j) then
-            typeset = true
-            break
+    for _, dir in ipairs({unpackdir, typesetdir}) do
+      for _,j in ipairs(filelist(dir, i)) do
+        -- Allow for command line selection of files
+        local typeset = true
+        if files and next(files) then
+          typeset = false
+          for _,k in ipairs(files) do
+            if k == stripext(j) then
+              typeset = true
+              break
+            end
           end
         end
-      end
-      if typeset then
-        local errorlevel = typesetpdf(j)
-        if errorlevel ~= 0 then
-          return errorlevel
+        if typeset then
+          local errorlevel = typesetpdf(relpath(dir, ".") .. "/" .. j)
+          if errorlevel ~= 0 then
+            return errorlevel
+          end
         end
       end
     end

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -1396,6 +1396,12 @@ function stripext(file)
   return name or file
 end
 
+-- Strip the path from a file name (if present)
+function basename(file)
+  local name = string.match(file, "^.*/([^/]*)$")
+  return name or file
+end
+
 -- Look for a test: could be in the testfiledir or the unpackdir
 function testexists(test)
   return(locate({testfiledir, unpackdir}, {test .. lvtext}))
@@ -1488,7 +1494,7 @@ function tex(file)
 end
 
 function typesetpdf(file)
-  local name = stripext(file)
+  local name = stripext(basename(file))
   print("Typesetting " .. name)
   local errorlevel = typeset(file)
   if errorlevel == 0 then
@@ -1505,7 +1511,7 @@ typeset = typeset or function(file)
   if errorlevel ~= 0 then
     return errorlevel
   else
-    local name = stripext(file)
+    local name = stripext(basename(file))
     errorlevel = biber(name) + bibtex(name)
     if errorlevel == 0 then
       local function cycle(name)


### PR DESCRIPTION
Usually, documentation is generated by simply typesetting a `dtx` file. In more complex cases, the file to typeset may first have to be unpacked from this `dtx`. The commits proposed herein allow for this scenario by searching for `typesetfiles` among the unpacked content, too.