### PR TITLE
establish a typesetsourcefiles variable

### DIFF
--- a/l3build/l3build.dtx
+++ b/l3build/l3build.dtx
@@ -89,6 +89,7 @@
 \luavarset{typesetdemofiles}{\{~\}}       {Files to typeset before the documentation (as demos), but where the PDF results are not included in the release.}
 \luavarset{typesetfiles}    {\{"*.dtx"\}} {Files to typeset for documentation.}
 \luavarset{typesetsuppfiles}{\{~\}}       {Files needed to support typesetting when \enquote{sandboxed}.}
+\luavarset{typesetsourcefiles}{\{~\}}     {Files to copy to unpacking when typesetting.}
 \luavarset{unpackfiles}     {\{"*.ins"\}} {Files to run to perform unpacking.}
 \luavarset{unpacksuppfiles} {\{~\}}       {Files needed to support unpacking when \enquote{sandboxed}.}
 \luavarset{versionfiles}    {\{"*.dtx"\}} {Files for automatic version editing.}

--- a/l3build/l3build.dtx
+++ b/l3build/l3build.dtx
@@ -71,28 +71,28 @@
 \luavarset{tdsdir}     {distribdir .. "/tds"}       {Generated folder where files are organised for a TDS.}
 \luavarset{tdsroot}    {"latex"}{Root directory of the TDS structure for the bundle/module to be installed into.}
 \luavarseparator
-\luavarset{bibfiles}        {\{"*.bib"\}}{\BibTeX{} database files.}
-\luavarset{binaryfiles}     {\{"*.pdf", "*.zip"\}}
-                            {Files to be added in binary mode to zip files.}
-\luavarset{bstfiles}        {\{"*.bst"\}}{\BibTeX{} style files.}
-\luavarset{checkfiles}      {\{~\}}{Extra files unpacked purely for tests}
-\luavarset{checksuppfiles}  { }{Files needed for performing regression tests.}
-\luavarset{cmdchkfiles}     {\{~\}}{Files need to perform command checking (\cls{l3doc}-based documentation only).}
-\luavarset{cleanfiles}      {\{"*.log", "*.pdf", "*.zip"\}}{Files to delete when cleaning.}
-\luavarset{demofiles}       {\{~\}}{Files which show how to use a module.}
-\luavarset{docfiles}        {\{~\}}{Files which are part of the documentation but should not be typeset.}
-\luavarset{excludefiles}    {\{"*\string~"\}}            {Files to ignore entirely (default for Emacs backup files).}
-\luavarset{installfiles}    {\{"*.sty"\}}         {Files to install to the \TeX{} tree and similar tasks.}
-\luavarset{makeindexfiles}  {\{"*.ist"\}}{MakeIndex files to be included in a TDS-style zip}
-\luavarset{sourcefiles}     {\{"*.dtx", "*.ins"\}}{Files to copy for unpacking.}
-\luavarset{textfiles}       {\{"*.md", "*.txt"\}}{Plain text files to send to CTAN as-is.}
-\luavarset{typesetdemofiles}{\{~\}}       {Files to typeset before the documentation (as demos), but where the PDF results are not included in the release.}
-\luavarset{typesetfiles}    {\{"*.dtx"\}} {Files to typeset for documentation.}
-\luavarset{typesetsuppfiles}{\{~\}}       {Files needed to support typesetting when \enquote{sandboxed}.}
-\luavarset{typesetsourcefiles}{\{~\}}     {Files to copy to unpacking when typesetting.}
-\luavarset{unpackfiles}     {\{"*.ins"\}} {Files to run to perform unpacking.}
-\luavarset{unpacksuppfiles} {\{~\}}       {Files needed to support unpacking when \enquote{sandboxed}.}
-\luavarset{versionfiles}    {\{"*.dtx"\}} {Files for automatic version editing.}
+\luavarset{bibfiles}          {\{"*.bib"\}}{\BibTeX{} database files.}
+\luavarset{binaryfiles}       {\{"*.pdf", "*.zip"\}}
+                              {Files to be added in binary mode to zip files.}
+\luavarset{bstfiles}          {\{"*.bst"\}}{\BibTeX{} style files.}
+\luavarset{checkfiles}        {\{~\}}{Extra files unpacked purely for tests}
+\luavarset{checksuppfiles}    { }{Files needed for performing regression tests.}
+\luavarset{cmdchkfiles}       {\{~\}}{Files need to perform command checking (\cls{l3doc}-based documentation only).}
+\luavarset{cleanfiles}        {\{"*.log", "*.pdf", "*.zip"\}}{Files to delete when cleaning.}
+\luavarset{demofiles}         {\{~\}}{Files which show how to use a module.}
+\luavarset{docfiles}          {\{~\}}{Files which are part of the documentation but should not be typeset.}
+\luavarset{excludefiles}      {\{"*\string~"\}}            {Files to ignore entirely (default for Emacs backup files).}
+\luavarset{installfiles}      {\{"*.sty"\}}         {Files to install to the \TeX{} tree and similar tasks.}
+\luavarset{makeindexfiles}    {\{"*.ist"\}}{MakeIndex files to be included in a TDS-style zip}
+\luavarset{sourcefiles}       {\{"*.dtx", "*.ins"\}}{Files to copy for unpacking.}
+\luavarset{textfiles}         {\{"*.md", "*.txt"\}}{Plain text files to send to CTAN as-is.}
+\luavarset{typesetdemofiles}  {\{~\}}       {Files to typeset before the documentation (as demos), but where the PDF results are not included in the release.}
+\luavarset{typesetfiles}      {\{"*.dtx"\}} {Files to typeset for documentation.}
+\luavarset{typesetsuppfiles}  {\{~\}}       {Files needed to support typesetting when \enquote{sandboxed}.}
+\luavarset{typesetsourcefiles}{\{~\}}       {Files to copy to unpacking when typesetting.}
+\luavarset{unpackfiles}       {\{"*.ins"\}} {Files to run to perform unpacking.}
+\luavarset{unpacksuppfiles}   {\{~\}}       {Files needed to support unpacking when \enquote{sandboxed}.}
+\luavarset{versionfiles}      {\{"*.dtx"\}} {Files for automatic version editing.}
 \luavarseparator
 \luavarset{bakext} {".bak"} {Extension of backup files.}
 \luavarset{dviext} {".dvi"} {Extension of DVI files.}

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -85,27 +85,27 @@ end
 -- File types for various operations
 -- Use Unix-style globs
 -- All of these may be set earlier, so a initialised conditionally
-bibfiles         = bibfiles         or {"*.bib"}
-binaryfiles      = binaryfiles      or {"*.pdf", "*.zip"}
-bstfiles         = bstfiles         or {"*.bst"}
-checkfiles       = checkfiles       or { }
-checksuppfiles   = checksuppfiles   or { }
-cmdchkfiles      = cmdchkfiles      or { }
-cleanfiles       = cleanfiles       or {"*.log", "*.pdf", "*.zip"}
-demofiles        = demofiles        or { }
-docfiles         = docfiles         or { }
-excludefiles     = excludefiles     or {"*~"}
-installfiles     = installfiles     or {"*.sty"}
-makeindexfiles   = makeindexfiles   or {"*.ist"}
-sourcefiles      = sourcefiles      or {"*.dtx", "*.ins"}
-textfiles        = textfiles        or {"*.md", "*.txt"}
-typesetdemofiles = typesetdemofiles or { }
-typesetfiles     = typesetfiles     or {"*.dtx"}
-typesetsuppfiles = typesetsuppfiles or { }
+bibfiles           = bibfiles           or {"*.bib"}
+binaryfiles        = binaryfiles        or {"*.pdf", "*.zip"}
+bstfiles           = bstfiles           or {"*.bst"}
+checkfiles         = checkfiles         or { }
+checksuppfiles     = checksuppfiles     or { }
+cmdchkfiles        = cmdchkfiles        or { }
+cleanfiles         = cleanfiles         or {"*.log", "*.pdf", "*.zip"}
+demofiles          = demofiles          or { }
+docfiles           = docfiles           or { }
+excludefiles       = excludefiles       or {"*~"}
+installfiles       = installfiles       or {"*.sty"}
+makeindexfiles     = makeindexfiles     or {"*.ist"}
+sourcefiles        = sourcefiles        or {"*.dtx", "*.ins"}
+textfiles          = textfiles          or {"*.md", "*.txt"}
+typesetdemofiles   = typesetdemofiles   or { }
+typesetfiles       = typesetfiles       or {"*.dtx"}
+typesetsuppfiles   = typesetsuppfiles   or { }
 typesetsourcefiles = typesetsourcefiles or { }
-unpackfiles      = unpackfiles      or {"*.ins"}
-unpacksuppfiles  = unpacksuppfiles  or { }
-versionfiles     = versionfiles     or {"*.dtx"}
+unpackfiles        = unpackfiles        or {"*.ins"}
+unpacksuppfiles    = unpacksuppfiles    or { }
+versionfiles       = versionfiles       or {"*.dtx"}
 
 -- Roots which should be unpacked to support unpacking/testing/typesetting
 checkdeps   = checkdeps   or { }

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -102,6 +102,7 @@ textfiles        = textfiles        or {"*.md", "*.txt"}
 typesetdemofiles = typesetdemofiles or { }
 typesetfiles     = typesetfiles     or {"*.dtx"}
 typesetsuppfiles = typesetsuppfiles or { }
+typesetsourcefiles = typesetsourcefiles or { }
 unpackfiles      = unpackfiles      or {"*.ins"}
 unpacksuppfiles  = unpacksuppfiles  or { }
 versionfiles     = versionfiles     or {"*.dtx"}
@@ -1859,7 +1860,7 @@ function doc(files)
     cp(i, supportdir, typesetdir)
   end
   depinstall(typesetdeps)
-  unpack()
+  unpack({sourcefiles, typesetsourcefiles})
   -- Main loop for doc creation
   for _, typesetfiles in ipairs({typesetdemofiles, typesetfiles}) do
     for _,i in ipairs(typesetfiles) do
@@ -2068,12 +2069,12 @@ end
 
 -- Unpack the package files using an 'isolated' system: this requires
 -- a copy of the 'basic' DocStrip program, which is used then removed
-function unpack()
+function unpack(sources)
   local errorlevel = depinstall(unpackdeps)
   if errorlevel ~= 0 then
     return errorlevel
   end
-  errorlevel = bundleunpack()
+  errorlevel = bundleunpack({"."}, sources)
   if errorlevel ~= 0 then
     return errorlevel
   end
@@ -2088,7 +2089,7 @@ end
 
 -- Split off from the main unpack so it can be used on a bundle and not
 -- leave only one modules files
-bundleunpack = bundleunpack or function(sourcedir)
+bundleunpack = bundleunpack or function(sourcedir, sources)
   local errorlevel = mkdir(localdir)
   if errorlevel ~=0 then
     return errorlevel
@@ -2098,10 +2099,12 @@ bundleunpack = bundleunpack or function(sourcedir)
     return errorlevel
   end
   for _,i in ipairs(sourcedir or {"."}) do
-    for _,j in ipairs(sourcefiles) do
-      errorlevel = cp(j, i, unpackdir)
-      if errorlevel ~=0 then
-        return errorlevel
+    for _,j in ipairs(sources or {sourcefiles}) do
+      for _,k in ipairs(j) do
+        errorlevel = cp(k, i, unpackdir)
+        if errorlevel ~=0 then
+          return errorlevel
+        end
       end
     end
   end


### PR DESCRIPTION
This table essentially does for the *doc* command what the `checkfiles` do for *check*: Files specified in there are treated like `sourcefiles`, which means they are pulled into the unpacking process, only when typesetting the documentation.

Moving files needed in the documentation from the `sourcefiles` to this variable keeps them from interfering with other processes and speeds them up.