### PR TITLE
introduce a docfiledir

### DIFF
--- a/l3build/l3build.dtx
+++ b/l3build/l3build.dtx
@@ -88,6 +88,7 @@
 \luavarset{textfiles}       {\{"*.md", "*.txt"\}}{Plain text files to send to CTAN as-is.}
 \luavarset{typesetdemofiles}{\{~\}}       {Files to typeset before the documentation (as demos), but where the PDF results are not included in the release.}
 \luavarset{typesetfiles}    {\{"*.dtx"\}} {Files to typeset for documentation.}
+\luavarset{docfiledir}      {maindir .. "/doc"}{Where to look for the |typesetfiles|.}
 \luavarset{typesetsuppfiles}{\{~\}}       {Files needed to support typesetting when \enquote{sandboxed}.}
 \luavarset{unpackfiles}     {\{"*.ins"\}} {Files to run to perform unpacking.}
 \luavarset{unpacksuppfiles} {\{~\}}       {Files needed to support unpacking when \enquote{sandboxed}.}

--- a/l3build/l3build.lua
+++ b/l3build/l3build.lua
@@ -101,6 +101,7 @@ sourcefiles      = sourcefiles      or {"*.dtx", "*.ins"}
 textfiles        = textfiles        or {"*.md", "*.txt"}
 typesetdemofiles = typesetdemofiles or { }
 typesetfiles     = typesetfiles     or {"*.dtx"}
+docfiledir       = docfiledir       or maindir .. "/doc"
 typesetsuppfiles = typesetsuppfiles or { }
 unpackfiles      = unpackfiles      or {"*.ins"}
 unpacksuppfiles  = unpacksuppfiles  or { }
@@ -1859,7 +1860,7 @@ function doc(files)
     cp(i, supportdir, typesetdir)
   end
   depinstall(typesetdeps)
-  unpack()
+  unpack({".", docfiledir})
   -- Main loop for doc creation
   for _, typesetfiles in ipairs({typesetdemofiles, typesetfiles}) do
     for _,i in ipairs(typesetfiles) do
@@ -2068,12 +2069,12 @@ end
 
 -- Unpack the package files using an 'isolated' system: this requires
 -- a copy of the 'basic' DocStrip program, which is used then removed
-function unpack()
+function unpack(sourcedir)
   local errorlevel = depinstall(unpackdeps)
   if errorlevel ~= 0 then
     return errorlevel
   end
-  errorlevel = bundleunpack()
+  errorlevel = bundleunpack(sourcedir)
   if errorlevel ~= 0 then
     return errorlevel
   end


### PR DESCRIPTION
This table essentially does for the *doc* command what the `testfiledir` dos for *check*: This directory is searched for matching files to copy into any process only when typesetting the documentation. This allows to move more complex documentation sources into their own directory, improving project structure.