### PR TITLE
Function definition did not match explanation

### DIFF
--- a/l3kernel/source3body.tex
+++ b/l3kernel/source3body.tex
@@ -347,8 +347,8 @@ without repetition, this information is given in a shortened form:
     |\sys_if_engine_xetex:TF| \Arg{true code} \Arg{false code}
   \end{syntax}
   The underlining and italic of \texttt{TF} indicates that
-  |\xetex_if_engine:T|, |\xetex_if_engine:F| and
-  |\xetex_if_engine:TF| are all available. Usually, the illustration
+  |\sys_if_engine_xetex:T|, |\sys_if_engine_xetex:F| and
+  |\sys_if_engine_xetex:TF| are all available. Usually, the illustration
   will use the \texttt{TF} variant, and so both \meta{true code}
   and \meta{false code} will be shown. The two variant forms \texttt{T} and
   \texttt{F} take only \meta{true code} and \meta{false code}, respectively.


### PR DESCRIPTION
Furthermore the mentioned `\xetex_if_engine:TF` is deprecated.