### PR TITLE
[xparse] Define a set of validators

### DIFF
--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -3833,6 +3833,7 @@
         \__msg_kernel_error:nnxxx { xparse } { type-mismatch }
           { \tl_to_str:n {#1} } { int } { \iow_char:N \\ \l_@@_function_tl }
       }
+    \tl_set:Nn \ProcessedArgument { #1 }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -3847,6 +3848,7 @@
         \__msg_kernel_error:nnxxx { xparse } { type-mismatch }
           { \tl_to_str:n {#1} } { fp } { \iow_char:N \\ \l_@@_function_tl }
       }
+    \tl_set:Nn \ProcessedArgument { #1 }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -3861,6 +3863,7 @@
         \__msg_kernel_error:nnxxx { xparse } { type-mismatch }
           { \tl_to_str:n {#1} } { dim } { \iow_char:N \\ \l_@@_function_tl }
       }
+    \tl_set:Nn \ProcessedArgument { #1 }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -663,6 +663,48 @@
 %   \textbf{This function is experimental.}
 % \end{function}
 %
+% \begin{function}[added = 2017-07-14]{\AssertInt}
+%   \begin{syntax}
+%     \cs{AssertInt}
+%   \end{syntax}
+%   This processor checks if the supplied argument is a valid integer
+%   literal.
+%   \begin{verbatim}
+%     \NewDocumentCommand \foo { > { \AssertInt } m }
+%       {
+%         % ...
+%       }
+%   \end{verbatim}
+% \end{function}
+%
+% \begin{function}[added = 2017-07-14]{\AssertFp}
+%   \begin{syntax}
+%     \cs{AssertFp}
+%   \end{syntax}
+%   This processor checks if the supplied argument is a valid floating
+%   point literal.
+%   \begin{verbatim}
+%     \NewDocumentCommand \foo { > { \AssertFp } m }
+%       {
+%         % ...
+%       }
+%   \end{verbatim}
+% \end{function}
+%
+% \begin{function}[added = 2017-07-14]{\AssertDim}
+%   \begin{syntax}
+%     \cs{AssertDim}
+%   \end{syntax}
+%   This processor checks if the supplied argument is a valid
+%   dimension literal.
+%   \begin{verbatim}
+%     \NewDocumentCommand \foo { > { \AssertDim } m }
+%       {
+%         % ...
+%       }
+%   \end{verbatim}
+% \end{function}
+%
 % \subsection{Fully-expandable document commands}
 %
 % There are \emph{very rare} occasion when it may be useful to create
@@ -3781,6 +3823,48 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\@@_assert_int:n}
+%   Check if the argument is a valid integer literal.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_assert_int:n #1
+  {
+    \regex_match:nnF { ^[\+\-]?[\d]+$ } {#1} % $
+      {
+        \__msg_kernel_error:nnxxx { xparse } { type-mismatch }
+          { \tl_to_str:n {#1} } { int } { \iow_char:N \\ \l_@@_function_tl }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_assert_fp:n}
+%   Check if the argument is a valid floating point literal.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_assert_fp:n #1
+  {
+    \regex_match:nnF { ^[\+\-]?[\d]*\.?[\d]*([eE][\+\-]?[\d])?$ } {#1} % $
+      {
+        \__msg_kernel_error:nnxxx { xparse } { type-mismatch }
+          { \tl_to_str:n {#1} } { fp } { \iow_char:N \\ \l_@@_function_tl }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_assert_dim:n}
+%   Check if the argument is a valid dimension literal.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_assert_dim:n #1
+  {
+    \regex_match:nnF { ^[\+\-]?[\d]*\.?[\d]*\s*(pt|pc|in|bp|cm|mm|dd|cc|sp|em|ex)$ } {#1} % $
+      {
+        \__msg_kernel_error:nnxxx { xparse } { type-mismatch }
+          { \tl_to_str:n {#1} } { dim } { \iow_char:N \\ \l_@@_function_tl }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsection{Access to the argument specification}
 %
 % \begin{macro}{\@@_get_arg_spec_error:N, \@@_get_arg_spec_error:n}
@@ -4211,6 +4295,17 @@
     \\ \\
     LaTeX~will~ignore~'#2'.
   }
+\__msg_kernel_new:nnnn { xparse } { type-mismatch }
+  { The~type~of~'#1'~does~not~match~the~type~'#2'~expected~by~'#3'. }
+  {
+    \c__msg_coding_error_text_tl
+    The~argument~is~required~to~be~of~type~'#2'.~This~
+    requirement~was~not~met~by~the~input
+    \\ \\
+    '#1'
+    \\ \\
+    Please~make~sure~that~the argument~is~a~valid~'#2'~literal.
+  }
 %    \end{macrocode}
 %
 % Intended more for information.
@@ -4430,13 +4525,16 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\ReverseBoolean, \SplitArgument, \SplitList, \TrimSpaces}
+% \begin{macro}{\ReverseBoolean, \SplitArgument, \SplitList, \TrimSpaces, \AssertInt, \AssertFp, \AssertDim}
 %   Simple copies.
 %    \begin{macrocode}
 \cs_new_eq:NN \ReverseBoolean \@@_bool_reverse:N
 \cs_new_eq:NN \SplitArgument  \@@_split_argument:nnn
 \cs_new_eq:NN \SplitList      \@@_split_list:nn
 \cs_new_eq:NN \TrimSpaces     \@@_trim_spaces:n
+\cs_new_eq:NN \AssertInt \__xparse_assert_int:n
+\cs_new_eq:NN \AssertFp  \__xparse_assert_fp:n
+\cs_new_eq:NN \AssertDim \__xparse_assert_dim:n
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
Alternative approach at #373.

The regexes for floats and dimensions might look a little weird, but in fact `.pt` is a valid dimension in TeX (and thus `.` is a valid floating point literal as well).
```latex
\dimen0=.pt
\the\dimen0 % 0.0pt
```