### PR TITLE
Typos in the intro to the l3tl documentation

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -59,9 +59,9 @@
 % \begin{verbatim}
 %   \foo:N \l_some_tl
 % \end{verbatim}
-% In both cases, functions are available to test an manipulate the lists
+% In both cases, functions are available to test and manipulate the lists
 % of tokens, and these have the module prefix \texttt{tl}.
-% In many cases, function which can be applied to token list variables
+% In many cases, functions which can be applied to token list variables
 % are paired with similar functions for application to explicit lists
 % of tokens: the two \enquote{views} of a token list are therefore collected
 % together here.

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -866,7 +866,7 @@
 %     \cs{tl_tail:n} \Arg{token list}
 %   \end{syntax}
 %   Discards all leading explicit space characters
-%   (explicit tokens with character code~$32$ and category code~$10$)
+%   (tokens with category code~$10$)
 %   and the first \meta{item} in the \meta{token list}, and leaves the
 %   remaining tokens in the input stream.  Thus for example
 %   \begin{verbatim}
@@ -943,7 +943,7 @@
 %   Tests if the first \meta{token} in the \meta{token list}
 %   is a normal \texttt{N}-type argument. In other words,
 %   it is neither an explicit space character
-%   (explicit token with character code~$32$ and category code~$10$)
+%   (token with category code~$10$)
 %   nor an explicit begin-group character
 %   (with category code~1 and any character code). An empty
 %   argument yields \texttt{false}, as it does not have a \enquote{normal}
@@ -959,7 +959,7 @@
 %   \end{syntax}
 %   Tests if the first \meta{token} in the \meta{token list}
 %   is an explicit space character
-%   (explicit token with character code~$12$ and category code~$10$).
+%   (token with category code~$10$).
 %   In particular, the test is \texttt{false} if the \meta{token list}
 %   starts with an implicit token such as \cs{c_space_token}, or if it
 %   is empty.


### PR DESCRIPTION
Corrected a couple typos in the introduction to the l3tl documentation.