### PR TITLE
[file:l3token.dtx, section:7 Decomposing a macro definition, introduc…

### DIFF
--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -930,7 +930,7 @@
 %
 % These functions decompose \TeX{} macros into their constituent
 % parts: if the \meta{token} passed is not a macro then no decomposition
-% can occur. In the later case, all three functions leave \cs{scan_stop:}
+% can occur. In the latter case, all three functions leave \cs{scan_stop:}
 % in the input stream.
 %
 % \begin{function}[EXP]{\token_get_arg_spec:N}


### PR DESCRIPTION
…tion] typo: later -> latter