### PR TITLE
Fix documentations

### DIFF
--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -436,7 +436,7 @@
 %
 % \subsubsection{Variables: guidance}
 %
-% Both comma lists and sequences both have similar characteristics.
+% Both comma lists and sequences have similar characteristics.
 % They both use special delimiters to mark out one entry from the
 % next, and are both accessible at both ends. In general, it is
 % easier to create comma lists `by hand' as they can be typed

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -590,7 +590,7 @@
 %     \cs_generate_from_arg_count:Ncnn
 %   }
 %   \begin{syntax}
-%     \cs{cs_generate_from_arg_count:NNnn} \meta{function} \meta{creator} \meta{number} \meta{code}
+%     \cs{cs_generate_from_arg_count:NNnn} \meta{function} \meta{creator} \Arg{number} \Arg{code}
 %   \end{syntax}
 %   Uses the \meta{creator} function (which should have signature
 %   |Npn|, for example \cs{cs_new:Npn}) to define a \meta{function}
@@ -1036,8 +1036,8 @@
 %
 % \begin{function}[EXP,pTF]{\cs_if_eq:NN}
 %   \begin{syntax}
-%     \cs{cs_if_eq_p:NN} \Arg{cs_1} \Arg{cs_2}
-%     \cs{cs_if_eq:NNTF} \Arg{cs_1} \Arg{cs_2} \Arg{true code} \Arg{false code}
+%     \cs{cs_if_eq_p:NN} \meta{cs_1} \meta{cs_2}
+%     \cs{cs_if_eq:NNTF} \meta{cs_1} \meta{cs_2} \Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   Compares the definition of two \meta{control sequences} and
 %   is logically \texttt{true} if they are the same, \emph{i.e.}~if they have exactly
@@ -1295,7 +1295,7 @@
 %
 % \begin{function}{\__debug_patch_conditional:nNNpnn}
 %   \begin{syntax}
-%     \cs{__debug_patch_conditional:nNNpn} \Arg{before}
+%     \cs{__debug_patch_conditional:nNNpnn} \Arg{before}
 %     \meta{definition} \meta{conditional} \meta{parameters} \Arg{type} \Arg{code}
 %   \end{syntax}
 %   Similar to \cs{__debug_patch:nnNNpn} for conditionals, namely

--- a/l3kernel/l3box.dtx
+++ b/l3kernel/l3box.dtx
@@ -336,7 +336,7 @@
 %
 % \begin{function}[added = 2012-05-11]{\box_show:Nnn, \box_show:cnn}
 %   \begin{syntax}
-%      \cs{box_show:Nnn} \meta{box} \meta{intexpr_1} \meta{intexpr_2}
+%      \cs{box_show:Nnn} \meta{box} \Arg{intexpr_1} \Arg{intexpr_2}
 %   \end{syntax}
 %   Display the contents of \meta{box} in the terminal, showing the first
 %   \meta{intexpr_1} items of the box, and descending into \meta{intexpr_2}
@@ -352,7 +352,7 @@
 %
 % \begin{function}[added = 2012-05-11]{\box_log:Nnn, \box_log:cnn}
 %   \begin{syntax}
-%      \cs{box_log:Nnn} \meta{box} \meta{intexpr_1} \meta{intexpr_2}
+%      \cs{box_log:Nnn} \meta{box} \Arg{intexpr_1} \Arg{intexpr_2}
 %   \end{syntax}
 %   Writes the contents of \meta{box} to the log, showing the first
 %   \meta{intexpr_1} items of the box, and descending into \meta{intexpr_2}

--- a/l3kernel/l3drivers.dtx
+++ b/l3kernel/l3drivers.dtx
@@ -405,7 +405,7 @@
 %     \__driver_draw_color_rgb_stroke:nnn
 %   }
 %   \begin{syntax}
-%     \cs{__driver_draw_color_gray:n} \Arg{red} \Arg{green} \Arg{blue}
+%     \cs{__driver_draw_color_rgb:nnn} \Arg{red} \Arg{green} \Arg{blue}
 %   \end{syntax}
 %   Sets the color for drawing to the RGB values specified, all of which are
 %   fp expressions which should evaluate to between $0$ and $1$. The

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -475,7 +475,7 @@
 %     \exp_last_unbraced:NnNo
 %     }
 %   \begin{syntax}
-%     \cs{exp_last_unbraced:Nno} \meta{token} \meta{tokens_1} \meta{tokens_2}
+%     \cs{exp_last_unbraced:Nno} \meta{token} \Arg{tokens_1} \Arg{tokens_2}
 %   \end{syntax}
 %   These functions absorb the number of arguments given by their
 %   specification, carry out the expansion
@@ -503,7 +503,7 @@
 %
 % \begin{function}[EXP]{\exp_last_two_unbraced:Noo}
 %   \begin{syntax}
-%     \cs{exp_last_two_unbraced:Noo} \meta{token} \meta{tokens_1} \Arg{tokens_2}
+%     \cs{exp_last_two_unbraced:Noo} \meta{token} \Arg{tokens_1} \Arg{tokens_2}
 %   \end{syntax}
 %   This function absorbs three arguments and expand the second and third
 %   once. The first argument of the function is then the next item on the

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -348,7 +348,7 @@
 %
 % \begin{function}[added = 2012-02-11]{\ior_str_map_inline:Nn}
 %   \begin{syntax}
-%     \cs{ior_str_map_inline:Nn} \Arg{stream} \Arg{inline function}
+%     \cs{ior_str_map_inline:Nn} \meta{stream} \Arg{inline function}
 %   \end{syntax}
 %   Applies the \meta{inline function} to every \meta{line}
 %   in the \meta{stream}. The material is read from the \meta{stream}

--- a/l3kernel/l3fp-aux.dtx
+++ b/l3kernel/l3fp-aux.dtx
@@ -689,7 +689,7 @@
 % ^^A begin[todo]
 % \begin{macro}[int, EXP]{\@@_decimate:nNnnnn}
 %   \begin{syntax}
-%     \cs{@@_decimate:nNnnnn} \Arg{shift} \Arg{f_1}
+%     \cs{@@_decimate:nNnnnn} \Arg{shift} \meta{f_1}
 %     ~~\Arg{X_1} \Arg{X_2} \Arg{X_3} \Arg{X_4}
 %   \end{syntax}
 %   Each \meta{X_i} consists in $4$ digits exactly,

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -584,7 +584,7 @@
 %   \begin{syntax}
 %     \cs{int_to_symbols:nnn}
 %     ~~\Arg{integer expression} \Arg{total symbols}
-%     ~~\meta{value to symbol mapping}
+%     ~~\Arg{value to symbol mapping}
 %   \end{syntax}
 %   This is the low-level function for conversion of an
 %   \meta{integer expression} into a symbolic form (often

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -755,8 +755,8 @@
 % \begin{function}[updated = 2012-09-09]
 %   {\__msg_show_item:n, \__msg_show_item:nn, \__msg_show_item_unbraced:nn}
 %   \begin{syntax}
-%     \cs{__msg_show_item:n}  \meta{item}
-%     \cs{__msg_show_item:nn} \meta{item-key} \meta{item-value}
+%     \cs{__msg_show_item:n}  \Arg{item}
+%     \cs{__msg_show_item:nn} \Arg{item-key} \Arg{item-value}
 %   \end{syntax}
 %   Auxiliary functions used within the last argument of
 %   \cs{__msg_show_variable:NNNnn} or \cs{__msg_show_wrap:n}

--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -679,7 +679,7 @@
 %
 % \begin{function}[EXP]{\__prg_break_point:Nn}
 %   \begin{syntax}
-%     \cs{__prg_break_point:Nn} \cs[no-index]{\meta{type}_map_break:} \meta{tokens}
+%     \cs{__prg_break_point:Nn} \cs[no-index]{\meta{type}_map_break:} \Arg{tokens}
 %   \end{syntax}
 %   Used to mark the end of a recursion or mapping: the functions
 %   \cs[no-index]{\meta{type}_map_break:} and \cs[no-index]{\meta{type}_map_break:n} use

--- a/l3kernel/l3skip.dtx
+++ b/l3kernel/l3skip.dtx
@@ -655,7 +655,7 @@
 % \begin{function}[EXP,pTF]{\skip_if_eq:nn}
 %   \begin{syntax}
 %     \cs{skip_if_eq_p:nn} \Arg{skipexpr_1} \Arg{skipexpr_2}
-%     \cs{dim_compare:nTF}
+%     \cs{dim_compare:nnTF}
 %     ~~\Arg{skipexpr_1} \Arg{skipexpr_2}
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -408,7 +408,7 @@
 % \begin{function}[added = 2017-10-08, rEXP]
 %   {\str_map_function:nN}
 %   \begin{syntax}
-%     \cs{str_map_function:nN} \meta{string} \meta{function}
+%     \cs{str_map_function:nN} \Arg{string} \meta{function}
 %   \end{syntax}
 %   Applies \meta{function} to every \meta{item} in the \meta{string}.
 %   See also \cs{str_map_function:nN}.
@@ -428,7 +428,7 @@
 % \begin{function}[added = 2017-10-08]
 %   {\str_map_inline:nn}
 %   \begin{syntax}
-%     \cs{str_map_inline:Nn} \meta{string} \Arg{inline function}
+%     \cs{str_map_inline:nn} \Arg{string} \Arg{inline function}
 %   \end{syntax}
 %   Applies the \meta{inline function} to every \meta{item} in the
 %   \meta{string}. The \meta{inline function} should consist of code which
@@ -451,7 +451,7 @@
 % \begin{function}[added = 2017-10-08]
 %   {\str_map_variable:nNn}
 %   \begin{syntax}
-%     \cs{str_map_variable:nNn} \meta{string} \meta{variable} \Arg{function}
+%     \cs{str_map_variable:nNn} \Arg{string} \meta{variable} \Arg{function}
 %   \end{syntax}
 %   Applies the \meta{function} to every \meta{item} in the \meta{string}.
 %   The \meta{function} should consist of code

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -498,7 +498,7 @@
 %
 % \begin{function}[updated = 2012-06-29, rEXP]{\tl_map_function:nN}
 %   \begin{syntax}
-%     \cs{tl_map_function:nN} \meta{token list} \meta{function}
+%     \cs{tl_map_function:nN} \Arg{token list} \meta{function}
 %   \end{syntax}
 %   Applies \meta{function} to every \meta{item} in the \meta{token list},
 %   The \meta{function} receives one argument for each iteration.
@@ -520,7 +520,7 @@
 %
 % \begin{function}[updated = 2012-06-29]{\tl_map_inline:nn}
 %   \begin{syntax}
-%     \cs{tl_map_inline:nn} \meta{token list} \Arg{inline function}
+%     \cs{tl_map_inline:nn} \Arg{token list} \Arg{inline function}
 %   \end{syntax}
 %   Applies the \meta{inline function} to every \meta{item} stored within the
 %   \meta{token list}. The \meta{inline function}  should consist of code which
@@ -542,7 +542,7 @@
 %
 % \begin{function}[updated = 2012-06-29]{\tl_map_variable:nNn}
 %   \begin{syntax}
-%     \cs{tl_map_variable:nNn} \meta{token list} \meta{variable} \Arg{function}
+%     \cs{tl_map_variable:nNn} \Arg{token list} \meta{variable} \Arg{function}
 %   \end{syntax}
 %   Applies the \meta{function} to every \meta{item} stored
 %   within the \meta{token list}. The \meta{function} should consist of code
@@ -1003,7 +1003,7 @@
 %
 % \begin{function}[updated = 2015-08-07]{\tl_show:n}
 %   \begin{syntax}
-%     \cs{tl_show:n} \meta{token list}
+%     \cs{tl_show:n} \Arg{token list}
 %   \end{syntax}
 %   Displays the \meta{token list} on the terminal.
 %   \begin{texnote}


### PR DESCRIPTION
Using the information which can be corrected from `<arg-spec>` of each functions, we can detect the form of the arguments (e.g. number of arguments, `\Arg` or `\meta`). Based on this concept, I wrote a simple Python3 script to analyze all `syntax` environments in `interface3.pdf`:

- <https://gist.github.com/wtsnjp/c5eac5ce080716818f00238443024362>

Then I fixed every mistakes in the document which I found with the script.