### PR TITLE
Add variants of `\tl_if_eq:nn`

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -402,7 +402,12 @@
 %   yields \texttt{false}.
 % \end{function}
 %
-% \begin{function}[TF]{\tl_if_eq:nn}
+% \begin{function}[TF, added = 2018-03-24]
+%   {
+%     \tl_if_eq:nn, \tl_if_eq:Vn, \tl_if_eq:on, \tl_if_eq:xn,
+%     \tl_if_eq:nV, \tl_if_eq:no, \tl_if_eq:nx, \tl_if_eq:VV,
+%     \tl_if_eq:xx
+%   }
 %   \begin{syntax}
 %     \cs{tl_if_eq:nnTF} \Arg{token list_1} \Arg{token list_2} \Arg{true code} \Arg{false code}
 %   \end{syntax}
@@ -2007,11 +2012,16 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}[TF]{\tl_if_eq:nn}
+% \begin{macro}[TF]
+%   {
+%     \tl_if_eq:nn, \tl_if_eq:Vn, \tl_if_eq:on, \tl_if_eq:xn,
+%     \tl_if_eq:nV, \tl_if_eq:no, \tl_if_eq:nx, \tl_if_eq:VV,
+%     \tl_if_eq:xx
+%   }
 % \begin{variable}{\l_@@_internal_a_tl, \l_@@_internal_b_tl}
 %   A simple store and compare routine.
 %    \begin{macrocode}
-\prg_new_protected_conditional:Npnn \tl_if_eq:nn #1#2 { T , F ,  TF }
+\prg_new_protected_conditional:Npnn \tl_if_eq:nn #1#2 { T , F , TF }
   {
     \group_begin:
       \tl_set:Nn \l_@@_internal_a_tl {#1}
@@ -2024,6 +2034,8 @@
         \prg_return_false:
       \fi:
   }
+\prg_generate_conditional_variant:Nnn \tl_if_eq:nn
+  { V , o , x , nV , no , nx , VV , xx } { T , F , TF }
 \tl_new:N \l_@@_internal_a_tl
 \tl_new:N \l_@@_internal_b_tl
 %    \end{macrocode}
@@ -2061,7 +2073,7 @@
 %   The \cs{if_false:} constructions are a faster way to do
 %   \cs{group_align_safe_begin:} and \cs{group_align_safe_end:}.
 %    \begin{macrocode}
-\prg_new_protected_conditional:Npnn \tl_if_in:nn #1#2 { T  , F , TF }
+\prg_new_protected_conditional:Npnn \tl_if_in:nn #1#2 { T , F , TF }
   {
     \if_false: { \fi:
     \cs_set:Npn \@@_tmp:w ##1 #2 { }


### PR DESCRIPTION
I think these functions maybe useful, for example, see https://tex.stackexchange.com/q/55600/136923.

By the way, why there is no `\tl_if_eq_p:nn`?