### PR TITLE
Typo in documentation

### DIFF
--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -970,7 +970,7 @@
 %     \cs{sys_shell_cp:nn} \Arg{source} \Arg{dest}
 %   \end{syntax}
 %   Copies the files specified in the \meta{source} (which may include
-%   wildcards) to the \meat{dest}. The file paths should be specified using
+%   wildcards) to the \meta{dest}. The file paths should be specified using
 %   |/| as a path separator. Copying is \emph{not} recursive: only files at
 %   the path level given are copied.  If unrestricted shell escape is not
 %   enabled, no action is attempted.


### PR DESCRIPTION
I changed \meat to \meta in one place.