### PR TITLE
l3drivers: remove extra \c_space_tl

### DIFF
--- a/l3kernel/l3drivers.dtx
+++ b/l3kernel/l3drivers.dtx
@@ -678,7 +678,7 @@
       { rgb~ \fp_eval:n {#1} ~ \fp_eval:n {#2} ~ \fp_eval:n {#3} }
   }
 \cs_new_protected:Npn \driver_color_spot:nn #1#2
-  { \@@_color_select:n { \c_space_tl #1 } }
+  { \@@_color_select:n { #1 } }
 \cs_new_protected:Npn \@@_color_select:n #1
   {
     \@@_literal:n { color~push~ #1 }


### PR DESCRIPTION
`\c_space_tl` is passed to a function (`\@@_color_select:n`) which does not
expand its argument, and results in `xxx "color push \c_space_tl Black"`
with the dvipdfmx backend. `\@@_color_select:n` already inserts appropriate
~, so `\c_space_tl` is unnecessary anyway.

To reproduce this bug, build source3 with the (x)dvipdfmx backend using
lualatex/xelatex. (x)dvipdfmx should complain about the incorrect color
specials.