### PR TITLE
Prevent expansion of pole in error message

### DIFF
--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -745,7 +745,7 @@
       { l_@@_poles_ \@@_to_value:N #1 _prop } {#2} #3
       {
         \__kernel_msg_error:nnxx { kernel } { unknown-coffin-pole }
-          {#2} { \token_to_str:N #1 }
+          { \exp_not:n {#2} } { \token_to_str:N #1 }
         \tl_set:Nn #3 { { 0pt } { 0pt } { 0pt } { 0pt } }
       }
   }


### PR DESCRIPTION
If an expandable token is passed as a pole, then the expanded version
would be printed rather than the exact token list that was searched.

---

I only ran into this particular case of the bug. It could well be that there are other similar cases and that it makes more sense to variants instead of using `\exp_not:n`.