### PR TITLE
Fix typos in l3keys documentation [ci skip]

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -453,7 +453,7 @@
 % them into several sub-groups for a given module. This can be achieved
 % either by adding a sub-division to the module name:
 % \begin{verbatim}
-%   \keys_define:nn { module / subgroup }
+%   \keys_define:nn { mymodule / subgroup }
 %     { key .code:n = code }
 % \end{verbatim}
 % or to the key name:
@@ -464,7 +464,7 @@
 % As illustrated, the best choice of token for sub-dividing keys in
 % this way is |/|. This is because of the method that is
 % used to represent keys internally. Both of the above code fragments
-% set the same key, which has full name \texttt{module/subgroup/key}.
+% set the same key, which has full name \texttt{mymodule/subgroup/key}.
 %
 % As illustrated in the next section, this subdivision is
 % particularly relevant to making multiple choices.


### PR DESCRIPTION
Found this while migrating from `pgfkeys`.