### PR TITLE
Doc typo [ci skip]

### DIFF
--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -78,7 +78,7 @@
 % \begin{function}[added = 2011-08-17, updated = 2019-01-21]
 %  {
 %    \coffin_set_eq:NN, \coffin_set_eq:Nc,
-%    \coffin_set_eq:cN, \coffin_set_eq:cc
+%    \coffin_set_eq:cN, \coffin_set_eq:cc,
 %    \coffin_gset_eq:NN, \coffin_gset_eq:Nc,
 %    \coffin_gset_eq:cN, \coffin_gset_eq:cc
 %  }

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -432,7 +432,7 @@ and all files in that bundle must be distributed together.
 % necessary to highlight it as much and you also don't need to check it
 % for, say, having a test function and having a documentation chunk
 % earlier in a \env{function} environment.  \pkg{l3doc} will pick up these
-% cases form the presence of |__| in the name, or you may force marking
+% cases from the presence of |__| in the name, or you may force marking
 % as internal by using |\begin{macro}[int]| to mark it as such. The margin
 % call-out is then printed in grey for such cases.
 %

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -439,7 +439,7 @@
 % \subsection{Wrapping lines in output}
 %
 % \begin{function}[added = 2012-06-28, updated = 2017-12-04]
-%   {\iow_wrap:nnnN \iow_wrap:nxnN}
+%   {\iow_wrap:nnnN, \iow_wrap:nxnN}
 %   \begin{syntax}
 %     \cs{iow_wrap:nnnN} \Arg{text} \Arg{run-on text} \Arg{set up} \meta{function}
 %   \end{syntax}

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -888,7 +888,7 @@
 % specified, providing a tuple as an argument of any other operation
 % yields the \enquote{invalid operation} exception and a \nan{} result.
 %
-% \begin{function}[tested = m3fp-logic002, module = ]{?:}
+% \begin{function}[tested = m3fp-logic002]{?:}
 %   \begin{syntax}
 %     \cs{fp_eval:n} \{ \meta{operand_1} |?| \meta{operand_2} |:| \meta{operand_3} \}
 %   \end{syntax}


### PR DESCRIPTION
Apologize for using "[l3doc]" prefix in the commit messages. I have misunderstood the meaning of that tag at that time.