### PR TITLE
Add token counting argument specifier to xparse

### DIFF
--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -174,6 +174,9 @@
 %   \item[t] An optional \meta{char}, which will result in a value
 %     \cs{BooleanTrue} if \meta{char} is present and \cs{BooleanFalse}
 %     otherwise. Given as \texttt{t}\meta{char}.
+%   \item[c] Multiple optional \meta{char}s, which will result in a number
+%     representing the number of found \meta{char}s. Given as
+%     \texttt{c}\meta{char}.
 %   \item[e] Given as \texttt{e}\marg{chars}, a set of optional
 %     \emph{embellishments}, each of which requires a \emph{value}.
 %     If an embellishment is not present, |-NoValue-| is returned.  Each
@@ -247,8 +250,8 @@
 % same delimiter, \pkg{xparse} issues a warning because the optional
 % argument could not be omitted by the user, thus becoming in effect
 % mandatory.  This can apply to \texttt{o}, \texttt{d}, \texttt{O},
-% \texttt{D}, \texttt{s}, \texttt{t}, \texttt{e}, and \texttt{E} type
-% arguments followed by \texttt{r} or \texttt{R}-type required
+% \texttt{D}, \texttt{s}, \texttt{t}, \texttt{c}, \texttt{e}, and \texttt{E}
+% type arguments followed by \texttt{r} or \texttt{R}-type required
 % arguments, but also to \texttt{g} or \texttt{G} type arguments
 % followed by \texttt{m} type arguments.
 %
@@ -1123,7 +1126,7 @@
 %   The other two are used to check whether all short arguments appear
 %   before long arguments: this is needed to grab arguments expandably.
 %   As soon as the first long argument is seen (other than
-%   \texttt{t}-type, whose long status is ignored) the
+%   \texttt{t}-type or \texttt{c}-type, whose long status is ignored) the
 %   \texttt{some_long} flag is set.  The \texttt{some_short} flag is
 %   used for expandable commands, to know whether to define a short
 %   auxiliary too.
@@ -1925,6 +1928,21 @@
     \bool_set_false:N \l_@@_long_bool
     \@@_normalize_arg_spec_loop:n
   }
+\cs_new_protected:Npn \@@_normalize_type_c:w #1
+  {
+    \quark_if_recursion_tail_stop_do:Nn #1 { \@@_bad_arg_spec:wn }
+    \@@_single_char_check:n {#1}
+    \tl_put_right:Nx \l_@@_arg_spec_tl
+      {
+        \bool_if:NT \l_@@_obey_spaces_bool { ! }
+        c \exp_not:n {#1}
+      }
+    \tl_put_right:Nn \l_@@_last_delimiters_tl {#1}
+    \bool_set_false:N \l_@@_grab_expandably_bool
+    \bool_set_false:N \l_@@_obey_spaces_bool
+    \bool_set_false:N \l_@@_long_bool
+    \@@_normalize_arg_spec_loop:n
+  }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -2379,6 +2397,21 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\@@_add_type_c:w}
+%   At the set up stage, the \texttt{c} type argument is identical to the
+%   \texttt{t} type except for the name of the grabber function.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_add_type_c:w #1
+  {
+    \@@_flush_m_args:
+    \@@_add_default:
+    \@@_add_grabber:N c
+    \tl_put_right:Nn \l_@@_signature_tl {#1}
+    \@@_prepare_signature:N
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{\@@_add_type_u:w}
 %   At the set up stage, the \texttt{u} type argument is identical to the
 %   \texttt{G} type except for the name of the grabber function.
@@ -2646,6 +2679,24 @@
     \@@_add_default:
     \@@_get_grabber:NN #1 \l_@@_tmpa_tl
     \@@_add_expandable_grabber:nn { t }
+      {
+        \exp_not:o \l_@@_tmpa_tl
+        \exp_not:N #1
+      }
+    \@@_prepare_signature:N
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_add_expandable_type_c:w}
+%   The \texttt{c}-type works just like the \texttt{t}-type
+%   at this stage.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_add_expandable_type_c:w #1
+  {
+    \@@_add_default:
+    \@@_get_grabber:NN #1 \l_@@_tmpa_tl
+    \@@_add_expandable_grabber:nn { c }
       {
         \exp_not:o \l_@@_tmpa_tl
         \exp_not:N #1
@@ -3270,6 +3321,37 @@
         #1 #2
           { \@@_add_arg:n { \BooleanTrue } }
           { \@@_add_arg:n { \BooleanFalse } }
+      }
+    \l_@@_fn_tl
+  }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\@@_grab_c:w}
+% \begin{macro}{\@@_grab_c_obey_spaces:w}
+% \begin{macro}{\@@_grab_c_aux:NNw}
+%   Scanning for multiple identical tokens is done in a recursive way:
+%   Initially, the count is zero. Whenever a match is found, just add one
+%   and repeat. If there is no match, add the final count to the output.
+%    \begin{macrocode}
+\int_new:N \l_@@_c_int
+\cs_new_protected:Npn \@@_grab_c:w
+  { \@@_grab_c_aux:NNw \@@_peek_nonspace_remove:NTF }
+\cs_new_protected:Npn \@@_grab_c_obey_spaces:w
+  { \@@_grab_c_aux:NNw \peek_meaning_remove:NTF }
+\cs_new_protected:Npn \@@_grab_c_aux:NNw #1#2#3 \@@_run_code:
+  {
+    \tl_set:Nn \l_@@_signature_tl {#3}
+    \int_zero:N \l_@@_c_int
+    \exp_after:wN \cs_set_protected:Npn \l_@@_fn_tl
+      {
+        #1 #2
+          {
+            \int_incr:N \l_@@_c_int
+            \l_@@_fn_tl
+          }
+          { \@@_add_arg:V { \l_@@_c_int } }
       }
     \l_@@_fn_tl
   }
@@ -3943,6 +4025,24 @@
     \str_if_eq:onTF { #1 { } #6 #2 } {#2}
       { #3 { \BooleanTrue } \q_@@ #4 #5 }
       { #3 { \BooleanFalse } \q_@@ #4 #5 {#6} }
+  }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\@@_expandable_grab_c:w}
+% \begin{macro}[EXP]{\@@_expandable_grab_c_aux:NNwn}
+%   In every step, consume one token and add \texttt{+ 1} to an integer
+%   expression.  When there is no token left to match, evaluate the expression
+%   to get the number of consumed tokens.
+%    \begin{macrocode}
+\cs_new:Npn \@@_expandable_grab_c:w #1 \q_@@ #2#3
+  { #2 { \@@_expandable_grab_c_aux:NNwn #1 \q_@@ { 0 } #2 #3 } }
+\cs_new:Npn \@@_expandable_grab_c_aux:NNwn #1#2#3 \q_@@ #4#5#6#7
+  {
+    \str_if_eq:onTF { #1 { } #7 #2 } {#2}
+      { \@@_expandable_grab_c_aux:NNwn #1#2#3 \q_@@ { #4 + 1 } #5#6 }
+      { \exp_args:Nnf \use:n {#3} { \int_eval:n {#4} } \q_@@ #5 #6 {#7} }
   }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
Add a new argument type "`c`ount" for `xparse` which behaves like `t` arguments, except that instead of scanning *up to one* token, an *arbitrary number* of matching tokens is scanned and the number used as the argument.

For example

```
\NewDocumentCommand \primes {m c'} {{#1}^{(#2)}}
```
would result in `\primes{f}'''''` being expanded to `{f}^{(5)}`.