### PR TITLE
Fix documentation of 'f' specifier in l3kernel/source3body.tex

### DIFF
--- a/l3kernel/source3body.tex
+++ b/l3kernel/source3body.tex
@@ -168,9 +168,10 @@ following argument specifiers:
     precisely in non-\LuaTeX{} engines older than 2019.
   \item[\texttt{f}] The \texttt{f} specifier stands for \emph{full
     expansion}, and in contrast to \texttt{x} stops at the first
-    non-expandable item (reading the argument from left to right) without
-    trying to expand it. For example, when setting a token list
-    variable (a macro used for storage), the sequence
+    non-expandable token (reading the argument from left to right) without
+    trying to expand it. If this token is a \meta{space token}, it is gobbled,
+    and thus won't be part of the resulting argument. For example, when
+    setting a token list variable (a macro used for storage), the sequence
     \begin{verbatim}
       \tl_set:Nn \l_mya_tl { A }
       \tl_set:Nn \l_myb_tl { B }


### PR DESCRIPTION
Regarding the 'f' argument specifier, mention the fact that if the first non-expandable token found during the expansion is a 〈space token〉, it is gobbled.

expl3.pdf says this, but not the _Naming functions and variables_ section in interface3.pdf. This commit adds the missing precision in source3body.tex.

Note: I used the \meta{space token} notation to mean the same thing as in the TeXbook, I hope this is okay for LaTeX3 docs.

Thanks!