### PR TITLE
Use \luafunction or \luadef for \str__if_eq:nn

### DIFF
--- a/l3kernel/l3bootstrap.dtx
+++ b/l3kernel/l3bootstrap.dtx
@@ -230,6 +230,9 @@
       local charcat_table = \number\ucharcat@table\space
       l3kernel.charcat_table = charcat_table
     }%
+    \expandafter\newluafunction\csname
+      c__str_cmp_func_int%
+    \endcsname
 %</package>
     \directlua{require("expl3")}%
 %    \end{macrocode}

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -314,6 +314,11 @@ local tex     = tex
 local unicode = unicode
 %    \end{macrocode}
 %
+%   Local copy of the Lua function table
+%    \begin{macrocode}
+local luafunctions = lua.get_functions_table()
+%    \end{macrocode}
+%
 %   Local copies of standard functions.
 %    \begin{macrocode}
 local abs        = math.abs
@@ -492,6 +497,9 @@ local function strcmp(A, B)
   end
 end
 l3kernel.strcmp = strcmp
+luafunctions[token.create'c__str_cmp_func_int'.mode] = function()
+  strcmp(token.scan_string(), token.scan_string())
+end
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -1085,17 +1085,31 @@
    {
      \cs_set_eq:NN \lua_escape:e \tex_luaescapestring:D
      \cs_set_eq:NN \lua_now:e    \tex_directlua:D
-     \cs_set:Npn \@@_if_eq:nn #1#2
-       {
-          \lua_now:e
-            {
-              l3kernel.strcmp
-                (
-                  " \@@_escape:n {#1} " ,
-                  " \@@_escape:n {#2} "
-                )
-            }
-       }
+     \if_int_compare:w
+       \lua_now:e { tex.sprint(token~and~token.scan_string~and '1' or '0') }
+       = 0 \exp_stop_f:
+       \cs_set:Npn \@@_if_eq:nn #1#2
+         {
+            \lua_now:e
+              {
+                l3kernel.strcmp
+                  (
+                    " \@@_escape:n {#1} " ,
+                    " \@@_escape:n {#2} "
+                  )
+              }
+         }
+       \else:
+         \cs_if_exist:NTF \tex_luadef:D
+           {
+             \tex_luadef:D \@@_if_eq:nn \c_@@_cmp_func_int
+           } {
+             \cs_set:Npn \@@_if_eq:nn
+               {
+                 \tex_luafunction:D \c_@@_cmp_func_int
+               }
+           }
+       \fi:
      \cs_new:Npn \@@_escape:n #1
        {
          \lua_escape:e


### PR DESCRIPTION
This provides significant speedups for modern LuaTeX versions. There are some TODOs:

- [ ] How should the allocation of `\luafunction` ids be handled in `expl3`? Currently it just uses `\newluafunction` which will only work if `ltluatex` is loaded.
- [ ] Also `\tex_luadef:D` and `\tex_luafunction:D` should get "real" names. Probably they belong into the `\lua_` module but at least without allocation support they might be more appropriate as local interfaces. Are l3kernel modules allowed to use local functions from other modules?
- [ ] Do the same for the other functions in `expl3.lua`.