### PR TITLE
Allow multiple <@@= in one macrocode (fixes #595)

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -3786,9 +3786,9 @@ and all files in that bundle must be distributed together.
 %   name automatically.  We need to be careful: no |<@@=| should appear
 %   as such in the code below since \pkg{l3doc} is also typeset using
 %   this code.
-%   TODO: right now, in a line containing |<@@=|\meta{module}|>|, the
-%   |@@| are replaced (using different values of the \meta{module}
-%   before and after the assignment).  Is this a waste?
+%   At each |<@@=| found, replace the \meta{module} in the code behind
+%   it, update the \meta{module}, and loop to check for further
+%   occurrences of |<@@=|.
 %    \begin{macrocode}
 \group_begin:
   \char_set_catcode_other:N \^^A
@@ -3813,8 +3813,9 @@ and all files in that bundle must be distributed together.
   \char_set_catcode_active:N \>
   \cs_new_protected:Npn \@@_xmacro_code:n #1
     {
+      \tl_clear:N \l_@@_tmpa_tl
       \tl_if_in:nnTF {#1} { < @ @ = }
-        { \@@_xmacro_code:w #1 \q_stop }
+        { \@@_xmacro_code:w #1 < @ @ = \q_recursion_tail > \q_recursion_stop }
         {
           \tl_set:Nn \l_@@_tmpa_tl {#1}
           \@@_detect_internals:N \l_@@_tmpa_tl
@@ -3822,21 +3823,21 @@ and all files in that bundle must be distributed together.
           \tl_use:N \l_@@_tmpa_tl
         }
     }
-  \cs_new_protected:Npn \@@_xmacro_code:w #1 < @ @ = #2 > #3 \q_stop
+  \cs_new_protected:Npn \@@_xmacro_code:w #1 < @ @ = #2 >
     {
-      \tl_set:Nn \l_@@_tmpa_tl {#1}
-      \@@_detect_internals:N \l_@@_tmpa_tl
-      \@@_replace_at_at:N \l_@@_tmpa_tl
-
-      \tl_gset:Nn \g_@@_module_name_tl {#2}
-      \tl_put_right:Nn \l_@@_tmpa_tl { < \text { \verbatim@font @ @ = #2 } > }
-
-      \tl_set:Nn \l_@@_tmpb_tl {#3}
+      % Add code before <@@=...>
+      \tl_set:Nn \l_@@_tmpb_tl {#1}
       \@@_detect_internals:N \l_@@_tmpb_tl
       \@@_replace_at_at:N \l_@@_tmpb_tl
-      \tl_put_right:No \l_@@_tmpa_tl { \l_@@_tmpb_tl }
-
-      \tl_use:N \l_@@_tmpa_tl
+      \tl_put_right:NV \l_@@_tmpa_tl \l_@@_tmpb_tl
+      % Check for \q_recursion_tail
+      \quark_if_recursion_tail_stop_do:nn {#2}
+        { \tl_use:N \l_@@_tmpa_tl }
+      % Change module name and add <@@=#2> to typeset output
+      \tl_gset:Nn \g_@@_module_name_tl {#2}
+      \tl_put_right:Nn \l_@@_tmpa_tl { < \text { \verbatim@font @ @ = #2 } > }
+      % Loop
+      \@@_xmacro_code:w
     }
 \group_end:
 %    \end{macrocode}


### PR DESCRIPTION
Changed `\@@_xmacro_code:n` and `\@@_xmacro_code:w` to loop through the `<@@=` in the `macrocode` block allowing arbitrarily many changes of module name.