### PR TITLE
xparse: fix typo [ci skip]

### DIFF
--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -4336,6 +4336,7 @@
       { \@@_peek_nonspace_aux:nNNTF { #1 ~ } #2 #3 {#4} {#5} }
       { #2 #3 { #4 } { #5 #1 } }
   }
+%    \end{macrocode}
 % \end{macro}
 %
 % \subsection{Messages}


### PR DESCRIPTION
Missing `\end{macrocode}`.