### PR TITLE
l3doc.cls: fix bug when trying to read l3doc.cfg

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1474,11 +1474,9 @@ and all files in that bundle must be distributed together.
   { Local~config~file~l3doc.cfg~loaded. }
 \file_if_exist:nT { l3doc.cfg }
   {
-    \file_input:nT { l3doc.cfg }
-      {
-        \cs_if_exist:cF { ExplMakeTitle }
-          { \msg_info:nn { l3doc } { input-cfg } }
-      }
+    \file_input:n { l3doc.cfg }
+    \cs_if_exist:cF { ExplMakeTitle }
+      { \msg_info:nn { l3doc } { input-cfg } }
   }
 %    \end{macrocode}
 %


### PR DESCRIPTION
Don't use `\file_input:nT`, which has been removed in commit ecd4174da983941f30d3231e44b526c079d674ec. Use `\file_input:n` instead.