### PR TITLE
Fix `undo-recent-deprecations` to reload l3deprecation.def

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- `undo-recent-deprecations` would not reload the deprecation code
+
 ## [2020-02-14]
 
 ### Fixed

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1274,8 +1274,8 @@
       } ,
     undo-recent-deprecations .code:n =
       {
-        \sys_load_deprecation:
         \bool_gset_true:N \g__kernel_deprecation_undo_recent_bool
+        \sys_load_deprecation:
       }
   }
 %    \end{macrocode}

--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -558,6 +558,10 @@
 % \subsection{Loading the patches}
 %
 % When loaded first, the patches are simply read here.
+% Here the deprecation code is loaded with the lower-level |\__kernel_...|
+% macro because we don't want it to flip the \cs{g__sys_deprecation_bool}
+% boolean, so that the deprecation code can be re-loaded later (when using
+% \texttt{undo-recent-deprecations}).
 %
 %    \begin{macrocode}
 \group_begin:
@@ -575,7 +579,7 @@
   }
 \cs_gset_protected:Npn \__kernel_sys_configuration_load:n #1
   { \file_input:n { #1 .def } }
-\sys_load_deprecation:
+\__kernel_sys_configuration_load:n { l3deprecation }
 %    \end{macrocode}
 %
 %    \begin{macrocode}
@@ -1060,7 +1064,7 @@
 % \begin{macro}[EXP, deprecated = 2021-07-01]{\c_term_ior}
 %    \begin{macrocode}
 \__kernel_patch_deprecation:nnNNpn { 2021-01-01 } { -1 }
-\cs_new_protected:Npn \c_term_ior { -1 \scan_stop: }
+\cs_gset_protected:Npn \c_term_ior { -1 \scan_stop: }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/testfiles/m3deprecation004.lvt
+++ b/l3kernel/testfiles/m3deprecation004.lvt
@@ -1,0 +1,32 @@
+%
+% Copyright (C) 2020 The LaTeX3 Project
+%
+\input{regression-test}
+
+\RequirePackage[check-declarations,log-functions]{expl3}
+
+\START
+\AUTHOR{Phelype Oleinik}
+
+\ExplSyntaxOn
+% \bool_gset_false:N \g__sys_deprecation_bool
+% \cs_undefine:N \c_term_ior
+% This should raise a deprecation error (within the 6-month grace period)
+\msg_term:n
+
+% Trick LaTeX into loading expl3.sty again
+\cs_undefine:c { ver@expl3.sty }
+\cs_undefine:N \l__expl_options_clist
+% \bool_gset_true:N \g__kernel_deprecation_undo_recent_bool
+\ExplSyntaxOff
+
+\OMIT % now with undo-recent-deprecations
+\RequirePackage[check-declarations,log-functions,undo-recent-deprecations]{expl3}
+\TIMO
+
+\ExplSyntaxOn
+% And now this should work
+\msg_term:n { ABC }
+\ExplSyntaxOff
+
+\END

--- a/l3kernel/testfiles/m3deprecation004.tlg
+++ b/l3kernel/testfiles/m3deprecation004.tlg
@@ -1,0 +1,17 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Phelype Oleinik
+! LaTeX3 Error: '\msg_term:n' deprecated on ....-..-... Use '\iow_term:n '.
+(LaTeX3)        For 6 months after that date one can restore a deprecated
+(LaTeX3)        command by loading the expl3 package with the option
+(LaTeX3)        'undo-recent-deprecations'.
+Type <return> to continue.
+ ...                                              
+l. ...\msg_term:n
+LaTeX does not know anything more about this error, sorry.
+Try typing <return> to proceed.
+If that doesn't work, type X <return> to quit.
+LaTeX3 Warning: '\msg_term:n' deprecated on ....-..-... Use '\iow_term:n '.
+*************************************************
+* ABC
+*************************************************


### PR DESCRIPTION
I'm not entirely sure about this one...

The `undo-recent-deprecations` seemed to have no effect: when doing
`\sys_load_deprecation:` at the end the kernel, `l3deprecation.def` would
be loaded without `undo-recent-deprecations` and then the boolean
`\g__sys_deprecation_bool` would be set to true, thus it would not load
the deprecation code again if `undo-recent-deprecations` was used (that
is, if my analysis it correct).

I think this commit should fix that...

Also, I'm not sure how do we test this type of thing. The test I added uses
`\msg_term:n`, but in 6 months this will not work anymore...