### PR TITLE
\tl_range:nnn accepts integer expressions

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -1086,7 +1086,7 @@
 %   Leaves in the input stream the items from the \meta{start index} to the
 %   \meta{end index} inclusive.  Spaces and braces are preserved between
 %   the items returned (but never at either end of the list).
-%   Here \meta{start index} and \meta{end index} should be integer denotations.
+%   Here \meta{start index} and \meta{end index} should be \meta{integer expressions}.
 %   For describing in detail the functions' behavior, let $m$ and $n$ be the start
 %   and end index respectively. If either is $0$, the result is empty. A positive
 %   index means `start counting from the left end', and a negative index means


### PR DESCRIPTION
Hello,

AFAICT, `\tl_range:nnn` accepts integer expressions for its second and third arguments. This is because of:

```latex
\cs_new:Npn \@@_range:nnnNn #1#2#3
  {
    \exp_args:Nff \@@_range:nnNn
      {
        \exp_args:Nf \@@_range_normalize:nn
          { \int_eval:n { #2 - 1 } } {#1}
      }
      {
        \exp_args:Nf \@@_range_normalize:nn
          { \int_eval:n {#3} } {#1}
      }
  }
```

Thanks!