### PR TITLE
Fix some typos in l3fp docs

### DIFF
--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -96,7 +96,7 @@
 %     $\operatorname{asech} x$, $\operatorname{acsch} x$.
 %   \item Extrema: $\max(x_{1},x_{2},\ldots)$, $\min(x_{1},x_{2},\ldots)$,
 %     $\operatorname{abs}(x)$.
-%   \item Rouning functions, controlled by two optional
+%   \item Rounding functions, controlled by two optional
 %     values,  $n$ (number of places, $0$ by default) and
 %       $t$ (behavior on a tie, $\nan$ by default):
 %     \begin{itemize}
@@ -446,10 +446,10 @@
 %   \end{syntax}
 %   Evaluates the \meta{floating point expressions} as described for
 %   \cs{fp_eval:n} and compares consecutive result using the
-%   corresponding \meta{relation}, namely it compares \meta{intexpr_1}
-%   and \meta{intexpr_2} using the \meta{relation_1}, then
-%   \meta{intexpr_2} and \meta{intexpr_3} using the \meta{relation_2},
-%   until finally comparing \meta{intexpr_N} and \meta{intexpr_{N+1}}
+%   corresponding \meta{relation}, namely it compares \meta{fpexpr_1}
+%   and \meta{fpexpr_2} using the \meta{relation_1}, then
+%   \meta{fpexpr_2} and \meta{fpexpr_3} using the \meta{relation_2},
+%   until finally comparing \meta{fpexpr_N} and \meta{fpexpr_{N+1}}
 %   using the \meta{relation_N}.  The test yields \texttt{true} if all
 %   comparisons are \texttt{true}.  Each \meta{floating point
 %     expression} is evaluated only once.  Contrarily to


### PR DESCRIPTION
- Misnamed arguments in `fp_compare_p:n` and `fp_compare_p:nTF`
- Misspelling in rounding section