### PR TITLE
Proposal package: high-level interface for metadata

### DIFF
--- a/l3experimental/l3meta/l3meta.sty
+++ b/l3experimental/l3meta/l3meta.sty
@@ -1,0 +1,341 @@
+% \begin{documentation}
+%
+% The \pkg{DocumentMetadata} package provides a high-level interface for specifying metadata.
+% 
+% The benefits of this package are:
+% \begin{itemize}
+%	\item Users need to learn only one interface.
+%	\item Remove the burden from document class writers to handle document metadata by providing a consistent interface.
+%	\item Document classes can be changed without modifying the way metadata is defined, 
+%		i.e. no need to customize it for different journals.
+% \end{itemize}
+%
+% At present, the following functions are provided:
+% \begin{itemize}
+%   \item \cs{Title}
+%   \item \cs{Author}
+%   \item \cs{Institution}
+% 	\item \cs{Abstract}
+%	\item \cs{Keywords}
+%	\item \cs{MSC}: Mathematics Subject Classification 2010
+% \end{itemize}
+%
+% \section{Simple example}
+% \begin{verbatim}
+%   \Title{A fairy tale}
+%
+%   \Institution{earth}{Under the Earth, Mountain}
+%   \Institution{tree}{Between Trees, Forest}
+%
+%   \Author[
+%	affiliation = earth,
+%	email = The.Dormant.One@snail-mail.mnt,
+%	funding = {Partially supported by the World Tree Yggdrasill.}
+%	]{dvalinn}{Dvalinn, One of the four Stags}
+%   \Author[
+%	affiliation = tree,
+%	email = Wide.Ruler@bird-mail.frs,
+%	funding = {Supported by leather pieces of shoes of various people.}
+%	]{vidarr}{Vidarr, Son of Odin}
+%
+%	\Keywords{Norse, Mythology}
+%
+%	\begin{Abstract}
+%		Once upon a time...well, not quite.
+%	\end{Abstract}
+% \end{verbatim}
+%
+% \section{User interface}
+% \begin{function}{\Author}
+%   \begin{syntax}
+%     \cs{Author} \oarg{extended information} \Arg{key} \Arg{name}
+%   \end{syntax}
+%   The \cs{Author} function is used to define one document author.
+%   The \meta{key} is a unique identifier of the author.
+%   The second mandatory argument \meta{name} specifies the complete author name.
+%   One or more additional pieces of information may be given as \meta{extended information}.
+%   This is made up of a key--value list, which will recognize the following keys
+%   \begin{itemize}[font = \ttfamily]
+%     \item[affiliation] the key of the affiliated institution (see \cs{Institution}),
+%     \item[email] the E-mail address,
+%     \item[funding] information about the funding/support.
+%   \end{itemize}
+% \end{function}
+%
+% \end{documentation}
+%
+%
+% \begin{implementation}
+% \section{\pkg{DocumentMetadata} implementation}
+%
+% \begin{macrocode}
+%   <*package>
+% \end{macrocode}
+%
+% \begin{macrocode}
+% \ProvidesExplPackage { \ExplFileName }{ \ExplFileDate }{ \ExplFileVersion }{ \ExplFileDescription }
+% \end{macrocode}
+% \begin{variable}{\g_documentmetadata_authors_seq}
+% 	List of all authors.
+%	\begin{macrocode}
+\seq_new:N \g_documentmetadata_authors_seq
+%	\end{macrocode}
+% \end{variable}
+% \begin{variable}{\g_documentmetadata_title_tl}
+% 	The main title of the document.
+%	\begin{macrocode}
+\tl_new:N \g_documentmetadata_title_tl
+%	\end{macrocode}
+% \end{variable}
+% \begin{variable}{\g_documentmetadata_institution_prop}
+% 	The list of institutions, stored as a key-value map.
+%	The key is the key of the institution (as used in the \Author command) and the value its address.
+%	\begin{macrocode}
+\prop_new:N \g_documentmetadata_institution_prop
+%	\end{macrocode}
+% \end{variable}
+% \begin{variable}{\g_documentmetadata_abstract_tl}
+% 	The abstract.
+%	\begin{macrocode}
+\tl_new:N \g_documentmetadata_abstract_tl
+%	\end{macrocode}
+% \end{variable}
+% \begin{variable}{\g_documentmetadata_keywords_tl}
+% 	The keywords.
+%	\begin{macrocode}
+\tl_new:N \g_documentmetadata_keywords_tl
+%	\end{macrocode}
+% \end{variable}
+% \begin{macro}{\documentmetadata_new_author:n}
+% 	Simple helper method to create a new author.
+% 	\begin{macrocode}
+\cs_new_protected:Npn \documentmetadata_new_author #1
+{
+	\prop_new:c {g_author_#1_prop}
+	\seq_gput_right:Nn \g_documentmetadata_authors_seq {#1}
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\documentmetadata_set_author_info:nnn}
+% 	Simple helper method which stores a particular information about the author.
+% 	\begin{macrocode}
+\cs_new_protected:Npn \documentmetadata_set_author_info #1#2#3
+{
+	\prop_gput:cnn {g_author_#1_prop} {#2} {#3}
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\documentmetadata_get_author_info:nn}
+% 	Simple helper method which stores a particular information about the author.
+% 	\begin{macrocode}
+\cs_new:Npn \documentmetadata_get_author_info #1#2
+{
+	\prop_item:cn {g_author_#1_prop} {#2}
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macrocode}
+\tl_new:N  \documentmetadata_current_author_tl
+\keys_define:nn { documentmetadata / data }
+{
+	affiliation	.code:n = \documentmetadata_set_author_info 
+					{\tl_use:N \documentmetadata_current_author_tl} { affiliation } {#1},
+	email		.code:n = \documentmetadata_set_author_info 
+					{\tl_use:N \documentmetadata_current_author_tl} { email } {#1},
+	funding		.code:n = \documentmetadata_set_author_info 
+					{\tl_use:N \documentmetadata_current_author_tl} { funding } {#1}
+}
+% TODO: affiliation-secondary, email-secondary, abbreviated-name, note (typically set as footnote)
+% TODO: role = Corresponding author
+% TODO: allow to pass the address directly in the affiliation field instead of a key to a predefined institution
+% \end{macrocode}
+
+% \begin{macro}{\Institution}
+% 	Add an institution.
+%	The first argument is the key (which should be used in the \Author command),
+%	and the second argument specifies the address.
+%	\begin{macrocode}
+\NewDocumentCommand \Institution { m m }
+{
+	\prop_gput:Nnx \g_documentmetadata_institution_prop { #1 } { \tl_trim_spaces:n { #2 } }
+	\prop_log:N \g_documentmetadata_institution_prop
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\Author}
+% 	Add a new author.
+%	The author name is given as mandatory argument.
+%	Additional information can be specified in the optional argument as key-value pairs.
+%
+%	We first create a new row and set the name of the author.
+%	Then the key-value pair argument is parsed, which sets the additional information about the author.
+%	\begin{macrocode}
+\NewDocumentCommand \Author { o m m }
+{
+	\documentmetadata_new_author { #2 }
+	\documentmetadata_set_author_info { #2 } { name } { #3 }
+	
+	\tl_set:Nn \documentmetadata_current_author_tl { #2 }
+	\IfValueT {#1} {
+ 		\keys_set:nn { documentmetadata  / data } {#1}
+	}
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\Title}
+% 	Specifies the title of the document.
+%	The main title is given as mandatory argument.
+%	Additional information can be specified in the optional argument as key-value pairs.
+%	\begin{macrocode}
+\NewDocumentCommand \Title { o m }
+{
+	\tl_set:Nn \g_documentmetadata_title_tl { #2 }
+	% TODO: Parse optional argument: subtitle, short-title, note (typically set as footnote)
+ 	%\keys_set:nn { documentmetadata  / data } {#1}
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\Keywords}
+% 	Specifies the keywords of the document.
+%	\begin{macrocode}
+\NewDocumentCommand \Keywords { m }
+{
+	\tl_set:Nn \g_documentmetadata_keywords_tl { #1 }
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\Abstract}
+% 	Specifies the abstract that summarizes the document.
+%	\begin{macrocode}
+\NewDocumentCommand \Abstract { m }
+{
+	\tl_set:Nn \g_documentmetadata_abstract_tl { \tl_trim_spaces:n { #1 } }
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\MSC}
+% 	Specifies the classification according to 2010 Mathematics Subject Classification.
+%	\begin{macrocode}
+\NewDocumentCommand \MSC { m }
+{
+	\tl_set:Nn \g_documentmetadata_mscclassification_tl { \tl_trim_spaces:n { #1 } }
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\MakeTitle}
+% 	Creates the title.
+%	\begin{macrocode}
+\robustify{ \footnote }
+\robustify{ \texttt }
+\NewDocumentCommand \MakeTitle { }
+{
+	\begin{center}
+		{
+			\scshape
+			\Large
+			\tl_use:N \g_documentmetadata_title_tl
+		}
+		\vskip 2em
+		{
+			\normalfont
+			\renewcommand*{\thefootnote}{\alph{footnote}}
+			% Get list of author names and details
+			\seq_set_map:NNn \l_author_names_seq \g_documentmetadata_authors_seq {
+				\documentmetadata_get_author_info { ##1 } { name }
+				\footnote{
+					\documentmetadata_get_affiliation_for_author { ##1 }
+					.~
+					\documentmetadata_get_author_info { ##1 } { funding }
+					\texttt{~\documentmetadata_get_author_info { ##1 } { email } }
+				}
+			}
+			% Combine in the format: First, Second and Third
+			\seq_use:Nnnn \l_author_names_seq { ~and~ } { ,~ } { ~and~ }
+		}
+		\vskip 1.5em
+		{
+			\@date
+		}
+		\vskip 2em
+		\begin{minipage}{.85\linewidth}
+			\noindent
+			\normalfont
+			\small
+			\tl_use:N \g_documentmetadata_abstract_tl
+			\smallskip
+			\footnotesize
+
+			\newline
+			\noindent 
+			\textsc{Keywords:~} \tl_use:N \g_documentmetadata_keywords_tl
+
+			\tl_if_exist:NT \g_documentmetadata_mscclassification_tl
+			{
+				\newline
+				\noindent
+				\textsc{MSC~2010:~} \tl_use:N \g_documentmetadata_mscclassification_tl
+			}
+		\end{minipage}
+	\end{center}
+
+	\thispagestyle{\titlepagestyle}
+}
+% 	\end{macrocode}
+% \end{macro}
+
+% \begin{macro}{\documentmetadata_set_legacy}
+% 	Set the old commands like \title, \author, ... according to the values set via the new interface.
+%	\begin{macrocode}
+\cs_new_protected:Npn \documentmetadata_set_legacy
+{
+	\title{\tl_use:N \g_documentmetadata_title_tl}
+	\author{\documentmetadata_get_author_string}
+}
+\AtBeginDocument{\documentmetadata_set_legacy}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\documentmetadata_get_author_string}
+%	\begin{macrocode}
+\cs_new_protected:Npn \documentmetadata_get_author_string
+{
+	% Get list of author names
+	\seq_set_map:NNn \l_author_names_seq \g_documentmetadata_authors_seq {
+		\documentmetadata_get_author_info { ##1 } { name }
+	}
+	% Combine in the format: First, Second and Third
+	\seq_use:Nnnn \l_author_names_seq { ~and~ } { ,~ } { ~and~ }
+}
+% 	\end{macrocode}
+% \end{macro}
+% \begin{macro}{\documentmetadata_get_author_string}
+% 	
+%	\begin{macrocode}
+%\cs_generate_variant:Nn \prop_item:Nn { Nx }
+\tl_new:N \l_bob_templist_tl
+\tl_new:N \l_bob_tablebody_tl
+\cs_new_protected:Npn \documentmetadata_get_affiliation_for_author #1
+{
+	\tl_set:Nx \l_bob_templist_tl { \documentmetadata_get_author_info { #1 } { affiliation } }
+	%\tl_use:N \l_bob_templist_tl
+	%\tl_use:N \l_bob_tablebody_tl
+	%\prop_get:NnN \g_documentmetadata_institution_prop {\l_bob_templist_tl} \l_bob_tablebody_tl
+	\prop_get:NVNTF \g_documentmetadata_institution_prop \l_bob_templist_tl \l_bob_tablebody_tl { \tl_use:N \l_bob_tablebody_tl } {\l_bob_templist_tl}
+	%\prop_get:NnN \g_documentmetadata_institution_prop {mpi} \l_bob_tablebody_tl
+	%\tl_use:N \l_bob_tablebody_tl
+	%\prop_log:N \g_documentmetadata_institution_prop
+	%\prop_item:Nx \g_documentmetadata_institution_prop {
+	%	\documentmetadata_get_author_info { #1 } { affiliation }
+	%}
+	%\documentmetadata_get_author_info { #1 } { affiliation }
+}
+
+% 	\end{macrocode}
+% \end{macro}
+%
+%
+% \begin{macrocode}
+% 	</package>
+% \end{macrocode}
+% \end{implementation}
+%
+% \PrintIndex


### PR DESCRIPTION
This PR proposes to add a package to consistently specify metadata of the document (e.g. author, title, emails, etc). It is inspired by https://tex.stackexchange.com/a/137387/34554. I remember that I've seen some early experiments concerning metadata here, but couldn't find the issue/PR.

The usage of the code looks similar to the following:
```latex
  \Title{A fairy tale}

  \Institution{earth}{Under the Earth, Mountain}
  \Institution{tree}{Between Trees, Forest}

  \Author[
	affiliation = earth,
	email = The.Dormant.One@snail-mail.mnt,
	funding = {Partially supported by the World Tree Yggdrasill.}
	]{dvalinn}{Dvalinn, One of the four Stags}
  \Author[
	affiliation = tree,
	email = Wide.Ruler@bird-mail.frs,
	funding = {Supported by leather pieces of shoes of various people.}
	]{vidarr}{Vidarr, Son of Odin}

\Keywords{Norse, Mythology}

\begin{Abstract}
	Once upon a time...well, not quite.
\end{Abstract}
```

It contains also the command `\MakeTitle` which displays the information. This is more for demonstration purposes and in the long term should be moved to a different package (to clearly separate specifying metadata and showing metadata). 

It's a bit of an early version and one might add many more fields to authors or intuitions (also subtitle, short title, etc).
What do you think?