### PR TITLE
correct array writing in dvips mode, index missing

### DIFF
--- a/l3backend/l3backend-pdf.dtx
+++ b/l3backend/l3backend-pdf.dtx
@@ -167,7 +167,7 @@
 \cs_new_protected:Npn \@@_backend_object_write_array:nn #1#2
   {
     \@@_backend_pdfmark:x
-      { #1 [ ~ \exp_not:n {#2} ~ ] ~ /PUTINTERVAL }
+      { #1 ~0~ [ ~ \exp_not:n {#2} ~ ] ~ /PUTINTERVAL }
   }
 \cs_new_protected:Npn \@@_backend_object_write_dict:nn #1#2
   {
@@ -182,7 +182,7 @@
 \cs_new_protected:Npn \@@_backend_object_write_fstream:nnn #1#2#3
   {
     \__kernel_backend_postscript:n
-      { 
+      {
         SDict ~ begin ~
         mark ~ #1 ~ << #2 >> /PUT ~ pdfmark ~
         mark ~ #1 ~ ( #3 )~ ( r )~ file ~ /PUT ~ pdfmark ~


### PR DESCRIPTION
Example document why this is needed:


~~~~
\RequirePackage{l3pdf}
\ExplSyntaxOn
\pdf_uncompress:
\ExplSyntaxOff
\documentclass{article}
\begin{document}
\ExplSyntaxOn
\pdf_object_new:nn{ar1}{dict}
\pdf_object_new:nn{ar2}{dict}
\pdf_object_write:nn {ar1}{/A/B}
\pdf_object_write:nn {ar2}{/B/C}
\pdf_object_new:nn{blub}{array}
\pdf_object_write:nx {blub}{\pdf_object_ref:n {ar1} \pdf_object_ref:n {ar2}}
\ExplSyntaxOff
abc
\end{document}
~~~~

without the fix this creates (see the various null entries):

~~~~
4 0 obj
<</A/B>>endobj
5 0 obj
<</B/C>>endobj
6 0 obj
[null
null
null
null
 5 0 R ]endobj
~~~~

with the fix the expected:

~~~~
4 0 obj
<</A/B>>endobj
5 0 obj
<</B/C>>endobj
6 0 obj
[ 4 0 R 
 5 0 R ]endobj
~~~~