### PR TITLE
Changes to expl3 to allow loading earlier in LaTeX2e

### DIFF
--- a/contrib/testfiles/ctex002.luatex.tlg
+++ b/contrib/testfiles/ctex002.luatex.tlg
@@ -2,8 +2,8 @@ This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
 LaTeX Font Info:    Font shape `LTJY3/FandolSong-Regular(0)/m/sl' in size <10.53937> not available
 (Font)              Font shape `LTJY3/FandolSong-Regular(0)/m/it' tried instead on input line ....
-luaotfload | aux : font no 41 (nil) does not define feature vert for script latn with language dflt
-luaotfload | aux : font no 41 (nil) does not define feature vrt2 for script latn with language dflt
+luaotfload | aux : font no 39 (nil) does not define feature vert for script latn with language dflt
+luaotfload | aux : font no 39 (nil) does not define feature vrt2 for script latn with language dflt
 Completed box being shipped out [1]
 \vbox(633.0+0.0)x407.0, direction TLT
 .\whatsit4=[]

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1215,22 +1215,33 @@
 \fi
 %    \end{macrocode}
 %
-% If \pkg{expl3} was pre-loaded, we now have to deal with the fact that
-% the syntax will not be activated for the package mode version:
-% simply turn it on. We use \tn{@pushfilenameaux} as a marker: it's defined
-% a little later.
-%    \begin{macrocode}
-\ifdefined\@pushfilenameaux
-  \ExplSyntaxOn
-\fi
-%    \end{macrocode}
-%
 %    \begin{macrocode}
 %<@@=expl>
 %    \end{macrocode}
 %
+% Here we can also detect whether we're reloading.  This code goes into
+% \texttt{expl3.ltx} and \texttt{expl3.sty}, the former loaded into the
+% \LaTeXe{} format.  When this code is loaded for the first time, the
+% \cs{g_@@_reload_bool} boolean doesn't exist (\cs{else} branch of the
+% \cs{ifcsname} below), so we create it.  If the \cs{ifcsname} is true,
+% then we do \cs{ExplSyntaxOn} (because when reloading,
+% \texttt{expl3-code.tex} isn't read again), and set
+% \cs{g_@@_reload_bool} to true.
+%    \begin{macrocode}
+\ifcsname\detokenize{g_@@_reload_bool}\endcsname
+  \ExplSyntaxOn
+  \bool_gset_true:N \g_@@_reload_bool
+\else
+  \bool_new:N \g_@@_reload_bool
+\fi
+%    \end{macrocode}
+%
 % \begin{variable}{\c_@@_def_ext_tl}
-%   Needed by \LaTeXe{}, and avoiding a re-load issue.
+%   Needed by \LaTeXe{}, and avoiding a re-load issue.  Variables are
+%   best checked explicitly, rather than with \cs{g_@@_reload_bool}
+%   because some appear only in one of the code files, so
+%   \cs{g_@@_reload_bool} doesn't necessarily mean that the variable
+%   is already declared.
 %    \begin{macrocode}
 \cs_if_exist:NF \c_@@_def_ext_tl
   { \tl_const:Nn \c_@@_def_ext_tl { def } }
@@ -1332,11 +1343,9 @@
 %</!2ekernel>
 %    \end{macrocode}
 %
-% A test for pre-loading: does \tn{@pushfilenameaux} already exist.
-% The alrady-loaded mechanism will handle everything now.
 %    \begin{macrocode}
 %<*!2ekernel>
-\cs_if_exist:NT \@pushfilenameaux
+\bool_if:NT \g_@@_reload_bool
   {
     \cs_gset_eq:NN \__kernel_sys_configuration_load:n
       \__kernel_sys_configuration_load_std:n

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1404,6 +1404,7 @@
   {
     \cs_gset_eq:NN \__kernel_sys_configuration_load:n
       \__kernel_sys_configuration_load_std:n
+    \ExplSyntaxOff
     \endinput
   }
 %</!2ekernel>

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1323,19 +1323,74 @@
   }
 %    \end{macrocode}
 %
-%  A backend has to be in place by the start of the document: this has to be
-%  before global options are checked for use. The odd group stuff avoids
-%  needing to actually patch \tn{document}.
+% \begin{macro}{\@expl@sys@load@backend@@@@}
+%   A backend has to be in place by the start of the document: this has
+%   to be before global options are checked for use.
+%
+%   The \cs[no-index]{@expl@...@@@@} macros defined in this package are
+%   interfaces for \LaTeXe{}.  There are currently (this will change
+%   with the next release of \LaTeXe{}) two possible cases, at this
+%   point of the code:  either \cs{@expl@sys@load@backend@@@@} (and the
+%   others) already exist because they were defined in
+%   \texttt{ltexpl.ltx} (in \texttt{2ekernel} mode) or in
+%   \texttt{expl3.ltx} (in \texttt{package} mode).
+%
+%   In \texttt{2ekernel} mode, if they exist we are using a future
+%   (2020-10-01) release of \LaTeXe{} and we don't need (and can't)
+%   patch \LaTeXe's internals because these commands are already there.
+%   Though if they don't exist in \texttt{2ekernel} mode, we're using
+%   an older version of the kernel, so we \emph{must} patch.
+%
+%   In \texttt{package} mode, if these commands exist, then we are using
+%   a version of \LaTeXe{} with \textsf{expl3} preloaded (any version)
+%   and in any case patching is already done or the macros are in the
+%   format itself, so nothing to do.
+%   But if in \texttt{package} mode these macros don't exist, we have an
+%   even older version of \LaTeXe{} which doesn't even have
+%   \textsf{expl3} preloaded, so patching is necessary.
+%
+%   All this means that in both \texttt{2ekernel} and \texttt{package}
+%   mode we have to check whether \cs{@expl@sys@load@backend@@@@}
+%   exists, and patch some \LaTeXe{} internals if it doesn't.
+%
+%   In newer \LaTeXe{}, these macros have an empty definition in
+%   \texttt{ltexpl.dtx} in case something wrong happens while loading
+%   this file (\texttt{expl3.ltx}), so they can safely be used in the
+%   \LaTeXe{} kernel.
+%
+%   \cs{@expl@sys@load@backend@@@@} is inserted right at the beginning
+%   of \cs{document}, but after closing the group started by \cs{begin}.
+%   When using \cs{tl_put_left:Nn} to patch the backend loading in
+%   \cs{document}, we need to make sure that it happens at group level
+%   zero, thus the strange |\endgroup...\begingroup| thing.
+%
+%   This chunk of code should only be executed when loading
+%   \texttt{expl3.sty} in a \LaTeXe{} without \pkg{expl3} preloaded, so
+%   we check if \cs{@expl@sys@load@backend@@@@} exists.
 %    \begin{macrocode}
-%<*2ekernel>
-\tl_put_left:Nn \document
+\cs_if_exist:NF \@expl@sys@load@backend@@@@
   {
-    \endgroup
+    \tl_put_left:Nn \document
+      {
+        \endgroup
+        \@expl@sys@load@backend@@@@
+        \begingroup
+      }
+  }
+%    \end{macrocode}
+%
+%   Now we define it anyhow.
+%    \begin{macrocode}
+\cs_gset_protected:Npn \@expl@sys@load@backend@@@@
+  {
     \str_if_exist:NF \c_sys_backend_str
       { \sys_load_backend:n { } }
-    \begingroup
   }
-%</2ekernel>
+%    \end{macrocode}
+% \end{macro}
+%
+%  Process package options.
+%    \begin{macrocode}
 %<*!2ekernel>
 \keys_set:nV { sys } \l_@@_options_clist
 \str_if_exist:NF \c_sys_backend_str
@@ -1380,13 +1435,24 @@
 %
 % \begin{macro}{\@pushfilename, \@popfilename}
 % \begin{macro}{\@@_status_pop:w}
+% \begin{macro}{\@expl@push@filename@@@@}
+% \begin{macro}{\@expl@push@filename@aux@@@@}
+% \begin{macro}{\@expl@pop@filename@@@@}
 %   The idea here is to use \LaTeXe{}'s \tn{@pushfilename} and
 %   \tn{@popfilename} to track the current syntax status. This can be
 %   achieved by saving the current status flag at each push to a stack,
 %   then recovering it at the pop stage and checking if the code
 %   environment should still be active.
+%
+%   Here the code follows the same patching logic than above for
+%   \cs{@expl@sys@load@backend@@@@}.
 %    \begin{macrocode}
-\tl_put_left:Nn \@pushfilename
+\cs_if_exist:NF \@expl@push@filename@@@@
+  {
+    \tl_put_left:Nn  \@pushfilename { \@expl@push@filename@@@@ }
+    \tl_put_right:Nn \@pushfilename { \@expl@push@filename@aux@@@@ }
+  }
+\cs_gset_protected:Npn \@expl@push@filename@@@@
   {
     \exp_args:Nx \__kernel_file_input_push:n
       {
@@ -1401,17 +1467,24 @@
       }
     \ExplSyntaxOff
   }
-\tl_put_right:Nn \@pushfilename { \@pushfilenameaux }
 %    \end{macrocode}
 %   This bit of trickery is needed to grab the name of the file being loaded
 %   so we can record it.
 %    \begin{macrocode}
-\cs_set_protected:Npn \@pushfilenameaux #1#2#3
+\cs_gset_protected:Npn \@expl@push@filename@aux@@@@ #1#2#3
   {
     \str_gset:Nn \g_file_curr_name_str {#3}
     #1 #2 {#3}
   }
-\tl_put_right:Nn \@popfilename
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+\cs_if_exist:NF \@expl@pop@filename@@@@
+  {
+    \tl_put_right:Nn \@popfilename
+      { \@expl@pop@filename@@@@ }
+  }
+\cs_gset_protected:Npn \@expl@pop@filename@@@@
   {
     \__kernel_file_input_pop:
     \tl_if_empty:NTF \l_@@_status_stack_tl
@@ -1431,6 +1504,9 @@
       { \ExplSyntaxOff }
   }
 %    \end{macrocode}
+% \end{macro}
+% \end{macro}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 %

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1457,7 +1457,7 @@
   {
     \exp_args:Nx \__kernel_file_input_push:n
       {
-        \tl_to_str:N \@currname
+        \tl_to_str:N \@currname .
         \tl_to_str:N \@currext
       }
     \tl_put_left:Nx \l_@@_status_stack_tl

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1243,7 +1243,7 @@
 %   \cs{g_@@_reload_bool} doesn't necessarily mean that the variable
 %   is already declared.
 %    \begin{macrocode}
-\cs_if_exist:NF \c_@@_def_ext_tl
+\tl_if_exist:NF \c_@@_def_ext_tl
   { \tl_const:Nn \c_@@_def_ext_tl { def } }
 %    \end{macrocode}
 % \end{variable}
@@ -1283,7 +1283,7 @@
 % \begin{variable}{\l_@@_options_clist}
 %    \begin{macrocode}
 %<*!2ekernel>
-\cs_if_exist:NF \l_@@_options_clist
+\clist_if_exist:NF \l_@@_options_clist
   { \clist_new:N \l_@@_options_clist }
 \DeclareOption*
   { \clist_put_right:NV \l_@@_options_clist \CurrentOption }

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1156,23 +1156,40 @@
 %
 % \begin{macro}{\ProvidesExplPackage, \ProvidesExplClass, \ProvidesExplFile}
 %   For other packages and classes building on this one it is convenient
-%   not to need \cs{ExplSyntaxOn} each time.
+%   not to need \cs{ExplSyntaxOn} each time.  All macros use the same
+%   internal one with the proper \LaTeXe{} command.
 %    \begin{macrocode}
-\protected\def\ProvidesExplPackage#1#2#3#4%
+\protected\def\ProvidesExplPackage
+  {\@expl@provides@file@@Nnnnnn\ProvidesPackage{Package}}
+\protected\def\ProvidesExplClass
+  {\@expl@provides@file@@Nnnnnn\ProvidesClass{Document Class}}
+\protected\def\ProvidesExplFile
+  {\@expl@provides@file@@Nnnnnn\ProvidesFile{File}}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@expl@provides@file@@Nnnnnn, \@expl@provides@generic@@wnnw}
+%   We need to check the existence of the
+%   \cs[no-index]{Provides\meta{thing}}, since we need to load this very
+%   early in the \LaTeXe{} kernel.
+%    \begin{macrocode}
+\protected\long\def\@expl@provides@file@@Nnnnnn#1#2#3#4#5#6%
   {%
-    \ProvidesPackage{#1}[#2 \ifx\relax#3\relax\else v#3\space\fi #4]%
+    \ifnum0%
+        \ifdefined#11\fi
+        \ifx\relax#1\else1\fi
+        =11
+      \expandafter#1%
+    \else
+      \@expl@provides@generic@@wnnw{#2}%
+    \fi
+      {#3}[{#4 \ifx\relax#5\relax\else v#5\space\fi #6}]%
     \ExplSyntaxOn
-  }%
-\protected\def\ProvidesExplClass#1#2#3#4%
+  }
+\protected\long\def\@expl@provides@generic@@wnnw#1\fi#2[#3]%
   {%
-    \ProvidesClass{#1}[#2 \ifx\relax#3\relax\else v#3\space\fi #4]%
-    \ExplSyntaxOn
-  }%
-\protected\def\ProvidesExplFile#1#2#3#4%
-  {%
-    \ProvidesFile{#1}[#2 \ifx\relax#3\relax\else v#3\space\fi #4]%
-    \ExplSyntaxOn
-  }%
+    \immediate\write-1{#1: #2 #3}%
+  }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1405,7 +1405,7 @@
     \cs_gset_eq:NN \__kernel_sys_configuration_load:n
       \__kernel_sys_configuration_load_std:n
     \ExplSyntaxOff
-    \endinput
+    \file_input_stop:
   }
 %</!2ekernel>
 %    \end{macrocode}

--- a/l3kernel/testfiles/m3expl007.lvt
+++ b/l3kernel/testfiles/m3expl007.lvt
@@ -1,5 +1,5 @@
 %
-% Copyright (C) 2015,2018 The LaTeX3 Project
+% Copyright (C) 2020 The LaTeX3 Project
 %
 \documentclass{minimal}
 \input{regression-test}

--- a/l3kernel/testfiles/m3expl008.luatex.tlg
+++ b/l3kernel/testfiles/m3expl008.luatex.tlg
@@ -1,0 +1,24 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Phelype Oleinik
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@bac
+kend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@bac
+kend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument
+(expl3.ltx)
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@bac
+kend@@ \begingroup \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument
+(expl3.ltx)
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@bac
+kend@@ \begingroup \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument

--- a/l3kernel/testfiles/m3expl008.lvt
+++ b/l3kernel/testfiles/m3expl008.lvt
@@ -1,0 +1,72 @@
+%
+% Copyright (C) 2020 The LaTeX3 Project
+%
+
+% \RequirePackage[enable-debug,check-declarations]{expl3}
+\ExplSyntaxOn
+\sys_load_debug:
+\debug_on:n { log-functions }
+\ExplSyntaxOff
+\input{regression-test}
+
+\START
+\AUTHOR{Phelype Oleinik}
+
+% Beware of the code.
+
+% Trying to emulate and test the four possible cases detailed in the
+% description of \@expl@sys@load@backend@@@@ in expl.dtx.
+
+\makeatletter
+\def\UndefineExplHooks{%
+  \let\@expl@sys@load@backend@@\UNDEFINED
+  \def\@expl@push@filename@@{%
+   \def\@expl@push@filename@@{%
+    \let\@expl@push@filename@@\UNDEFINED}}%
+  \def\@expl@push@filename@aux@@{%
+   \def\@expl@push@filename@aux@@{%
+    \let\@expl@push@filename@aux@@\UNDEFINED}}%
+  \def\@expl@pop@filename@@{%
+   \def\@expl@pop@filename@@{%
+    \let\@expl@pop@filename@@\UNDEFINED}}%
+  }
+\def\DefineExplHooks{%
+  \def\@expl@sys@load@backend@@{}%
+  \def\@expl@push@filename@@{}%
+  \def\@expl@push@filename@aux@@{}%
+  \def\@expl@pop@filename@@{}%
+  }
+\def\ShowDocument{%
+  \expandafter\showdocaux\document}
+\def\showdocaux#1\ifx#2\ignorespaces{%
+  \showtokens{#1}}
+
+\ShowDocument
+
+% First case, package mode and LaTeX2e without expl3:
+\UndefineExplHooks
+\OMIT % avoid engine-specific logging
+\RequirePackage{expl3}
+\TIMO
+
+\ShowDocument
+
+% Second case, package mode and LaTeX2e with expl3 preloaded:
+\DefineExplHooks
+\RequirePackage{expl3}
+
+\ShowDocument
+
+% Third case, 2ekernel mode and LaTeX2e without expl3:
+\UndefineExplHooks
+\input{expl3.ltx}
+
+\ShowDocument
+
+% Fourth case, 2ekernel mode and LaTeX2e with expl3 preloaded:
+\DefineExplHooks
+\input{expl3.ltx}
+
+\ShowDocument
+
+\END

--- a/l3kernel/testfiles/m3expl008.tlg
+++ b/l3kernel/testfiles/m3expl008.tlg
@@ -1,0 +1,20 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Phelype Oleinik
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument
+(expl3.ltx)
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument
+(expl3.ltx)
+> \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup \@expl@sys@load@backend@@ \begingroup \endgroup .
+\showdocaux ... #2\ignorespaces ->\showtokens {#1}
+l. ...\ShowDocument


### PR DESCRIPTION
This PR contains some internal changes to `expl3.dtx` to allow `expl3` to be loaded earlier in the LaTeX2e kernel.  The complement branch for this one is at [ `latex2e/earlier-expl3`](https://github.com/latex3/latex2e/tree/earlier-expl3).  The changes in this pull request are, however, independent of the ones in the aforementioned branch, so this can be safely updated before LaTeX2e.