### PR TITLE
Register prefix (pgf)

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -143,6 +143,7 @@ pdfoverlay,pdfoverlay,David Purton,https://github.com/dcpurton/pdfoverlay,https:
 pdftex,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 peek,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 percent,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
+pgf,pgf,The PGF/TikZ Team,https://pgf-tikz.github.io,https://github.com/pgf-tikz/pgf,https://github.com/pgf-tikz/pgf/issues,2020-07-03,2020-07-03,
 pi,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 pkgploader,pkgploader,Michiel Helvensteijn,,,,2014-02-05,2014-02-05,
 polyglossia,polyglossia,Arthur Reutenauer,https://www.polyglossia.org/,https://github.com/reutenauer/polyglossia,https://github.com/reutenauer/polyglossia/issues,2019-09-03,,


### PR DESCRIPTION
I would like to register the `pgf` prefix for future usage and in anticipation of someone else attempting to register it.  It is not actively used yet, but eventually we hope to be able to migrate PDF resource management to `pdfresources` (at least for LaTeX) which will make this necessary.