### PR TITLE
Fix two typos in doc [ci skip]

### DIFF
--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -2240,7 +2240,7 @@
 %   that is not possible without the risk of mistakenly grabbing the
 %   entire brace group (potentially leading to a~\texttt{!~Runaway argument}
 %   error) or trying to grab a |}|$_2$, leading to a~\texttt{!~Argument
-%   of~\dots~has an extra~|}|}.
+%   of~\dots~has an extra~\}}.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_allowed_token_check:N #1
   {

--- a/l3packages/xtemplate/xtemplate.dtx
+++ b/l3packages/xtemplate/xtemplate.dtx
@@ -365,7 +365,7 @@
 %
 % \begin{function}{\EvaluateNow}
 %   \begin{syntax}
-%     \cs{EvaluteNow} \Arg{expression}
+%     \cs{EvaluateNow} \Arg{expression}
 %   \end{syntax}
 %   The standard method when creating an instance from a template is to
 %   evaluate the \meta{expression} when the instance is used. However, it may


### PR DESCRIPTION
 - In `xtemplate.dtx`, replace mis-spelled `\cs{EvaluteNow}` to `\cs{EvaluateNow}`.
 - In `xparse.dtx`, avoid short verb `|...|` in the argument of `\texttt`.

The second typo, introduced in https://github.com/latex3/latex3/commit/dd0062fa65d32f4974691f51d773c6949484b197, causes following error when running `lualatex xparse.dtx` to get the doc of `xparse` with documented implementation:
```
! LaTeX Error: \verb illegal in command argument.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...

l.2243 %   of~\dots~has an extra~|}
                                 |}.
```