### PR TITLE
Version check

### DIFF
--- a/contrib/testfiles/ctex002.luatex.tlg
+++ b/contrib/testfiles/ctex002.luatex.tlg
@@ -1,5 +1,6 @@
 This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
+(load cache: extra_lmromanslant10-regular.luc)
 LaTeX Font Info:    Font shape `LTJY3/FandolSong-Regular(0)/m/sl' in size <10.53937> not available
 (Font)              Font shape `LTJY3/FandolSong-Regular(0)/m/it' tried instead on input line ....
 luaotfload | aux : font no 39 (nil) does not define feature vert for script latn with language dflt
@@ -36,18 +37,16 @@ Completed box being shipped out [1]
 ....\glue 0.0 plus 0.60931
 ....\hbox(9.27464+1.26472)x10.53937, direction TLT
 .....\LTJY3/FandolSong-Regular(0)/m/n/10.53937 好
-....\penalty 10000
 ....\glue 0.0 plus 0.60931
 ....\hbox(9.27464+1.26472)x5.26968, direction TLT
 .....\LTJY3/FandolSong-Regular(0)/m/n/10.53937 ，
 ....\glue 5.26968 minus 5.26968
 ....\hbox(9.27464+1.26472)x10.53937, direction TLT
 .....\LTJY3/FandolSong-Regular(0)/m/n/10.53937 世
-....\penalty 500
 ....\glue 0.0 plus 0.60931
 ....\hbox(9.27464+1.26472)x10.53937, direction TLT
 .....\LTJY3/FandolSong-Regular(0)/m/n/10.53937 界
-....\penalty 10000
+....\penalty 500
 ....\glue 0.0 plus 0.60931
 ....\hbox(9.27464+1.26472)x5.26968, direction TLT
 .....\LTJY3/FandolSong-Regular(0)/m/n/10.53937 ！

--- a/l3backend/l3backend-basics.dtx
+++ b/l3backend/l3backend-basics.dtx
@@ -69,26 +69,25 @@
 % place in the files.
 %    \begin{macrocode}
 %<*package>
-\def\ExplBackendFileDate{2020-06-29}
 \ProvidesExplFile
 %<*dvipdfmx>
-  {l3backend-dvipdfmx.def}{\ExplBackendFileDate}{}
+  {l3backend-dvipdfmx.def}{2020-06-29}{}
   {L3 backend support: dvipdfmx}
 %</dvipdfmx>
 %<*dvips>
-  {l3backend-dvips.def}{\ExplBackendFileDate}{}
+  {l3backend-dvips.def}{2020-06-29}{}
   {L3 backend support: dvips}
 %</dvips>
 %<*dvisvgm>
-  {l3backend-dvisvgm.def}{\ExplBackendFileDate}{}
+  {l3backend-dvisvgm.def}{2020-06-29}{}
   {L3 backend support: dvisvgm}
 %</dvisvgm>
 %<*pdfmode>
-  {l3backend-pdfmode.def}{\ExplBackendFileDate}{}
+  {l3backend-pdfmode.def}{2020-06-29}{}
   {L3 backend support: PDF mode}
 %</pdfmode>
 %<*xdvipdfmx>
-  {l3backend-xdvipdfmx.def}{\ExplBackendFileDate}{}
+  {l3backend-xdvipdfmx.def}{2020-06-29}{}
   {L3 backend support: xdvipdfmx}
 %</xdvipdfmx>
 %    \end{macrocode}
@@ -100,9 +99,9 @@
 %   With time, this test should vanish and only the dependency check
 %   should remain.
 %    \begin{macrocode}
-\cs_if_exist:NTF \__kernel_dependency_version_check:Nn
+\cs_if_exist:NTF \__kernel_dependency_version_check:nn
   {
-    \__kernel_dependency_version_check:Nn \ExplBackendFileDate
+    \__kernel_dependency_version_check:nn {2020-06-29}
 %<dvipdfmx>      {l3backend-dvipdfmx.def}
 %<dvips>      {l3backend-dvips.def}
 %<dvisvgm>      {l3backend-dvisvgm.def}

--- a/l3backend/l3backend-basics.dtx
+++ b/l3backend/l3backend-basics.dtx
@@ -69,27 +69,55 @@
 % place in the files.
 %    \begin{macrocode}
 %<*package>
+\def\ExplBackendFileDate{2020-06-29}
 \ProvidesExplFile
 %<*dvipdfmx>
-  {l3backend-dvipdfmx.def}{2020-06-29}{}
+  {l3backend-dvipdfmx.def}{\ExplBackendFileDate}{}
   {L3 backend support: dvipdfmx}
 %</dvipdfmx>
 %<*dvips>
-  {l3backend-dvips.def}{2020-06-29}{}
+  {l3backend-dvips.def}{\ExplBackendFileDate}{}
   {L3 backend support: dvips}
 %</dvips>
 %<*dvisvgm>
-  {l3backend-dvisvgm.def}{2020-06-29}{}
+  {l3backend-dvisvgm.def}{\ExplBackendFileDate}{}
   {L3 backend support: dvisvgm}
 %</dvisvgm>
 %<*pdfmode>
-  {l3backend-pdfmode.def}{2020-06-29}{}
+  {l3backend-pdfmode.def}{\ExplBackendFileDate}{}
   {L3 backend support: PDF mode}
 %</pdfmode>
 %<*xdvipdfmx>
-  {l3backend-xdvipdfmx.def}{2020-06-29}{}
+  {l3backend-xdvipdfmx.def}{\ExplBackendFileDate}{}
   {L3 backend support: xdvipdfmx}
 %</xdvipdfmx>
+%    \end{macrocode}
+%
+%   Check if the loaded kernel is at least enough to load this file.
+%   The kernel date has to be at least equal to \cs{ExplBackendFileDate}
+%   or later.  If \cs{__kernel_dependency_version_check:Nn} doesn't
+%   exist we're loading in an older kernel, so it's an error anyway.
+%   With time, this test should vanish and only the dependency check
+%   should remain.
+%    \begin{macrocode}
+\cs_if_exist:NTF \__kernel_dependency_version_check:Nn
+  {
+    \__kernel_dependency_version_check:Nn \ExplBackendFileDate
+%<dvipdfmx>      {l3backend-dvipdfmx.def}
+%<dvips>      {l3backend-dvips.def}
+%<dvisvgm>      {l3backend-dvisvgm.def}
+%<pdfmode>      {l3backend-pdfmode.def}
+%<xdvipdfmx>      {l3backend-xdvipdfmx.def}
+  }
+  {
+    \cs_if_exist_use:cF { @latex@error } { \errmessage }
+      {
+        Mismatched~LaTeX~support~files~detected. \MessageBreak
+        Loading~aborted!
+      }
+      { \use:c { @ehd } }
+    \tex_endinput:D
+  }
 %</package>
 %    \end{macrocode}
 %

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1065,8 +1065,10 @@
 %   \url{https://github.com/latex3/latex3/issues/781}).
 %    \begin{macrocode}
 %<*2ekernel>
-\global\expandafter\let\csname\detokenize
-  {c__kernel_expl_date_tl}\endcsname\ExplFileDate
+\unless\ifcsname\detokenize{c__kernel_expl_date_tl}\endcsname
+  \global\expandafter\let\csname\detokenize
+    {c__kernel_expl_date_tl}\endcsname\ExplFileDate
+\fi
 %</2ekernel>
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1244,86 +1244,47 @@
 %<@@=expl>
 %    \end{macrocode}
 %
-% Several times users reported this error when loading \pkg{expl3}:
-% \begin{verbatim}
-% ! Undefined control sequence.
-% l.67   \bool
-%             _new:N \g__expl_reload_bool
-% \end{verbatim}
-% raised in the reload block below.  This happens because the reload
-% check below assumes that if the boolean \cs{g_@@_reload_bool} doesn't
-% exist, this file is being loaded for the first time, and \pkg{expl3}
-% syntax is on.  This is a bit of a stretch for assumptions, but it's
-% valid as long as everything's in sync.  However the problem reported
-% happened because of a stray format file in the user tree which didn't
-% have the reload code defined here (commit \texttt{1d16336}), so the
-% \cs{g_@@_reload_bool} doesn't exist, but \pkg{expl3} syntax is off,
-% thus the error.
+% At this point, if we have \cs{c__kernel_expl_date_tl} defined, just
+% call the \cs{__kernel_dependency_version_check:Nn} auxiliary to check
+% if it matches \cs{ExplLoaderFileDate}.  Here the test is performed
+% only if \cs{c__kernel_expl_date_tl} exists because this file can be
+% loaded in a \LaTeXe{} format without \pkg{expl3} preloaded, where that
+% token list doesn't exist.
 %
-% At this point, if we have \cs{c__kernel_expl_date_tl} defined, the
-% situation is straightforward:  if it matches \cs{ExplLoaderFileDate},
-% then everything's as expected, so no need to worry.  If it doesn't,
-% then the current version of \pkg{expl3} differs from the one in the
-% format, so raise a fatal error:  the bahaviour is too unpredictable to
-% continue safely.  Also, if the error is to be raised, then we're
-% reloading, which means that \pkg{expl3} syntax is off, so we turn it
-% on for the message.
+% This is all done in the \texttt{package} \pkg{docstrip} guard because
+% it doesn't apply to \pkg{expl3.ltx}.
 %    \begin{macrocode}
+%<*package>
 \ifcsname\detokenize{c__kernel_expl_date_tl}\endcsname
-  \expandafter\ifx\csname\detokenize
-      {c__kernel_expl_date_tl}\endcsname\ExplLoaderFileDate
-  \else
-    \ExplSyntaxOn
-    \__kernel_msg_set:nnn { kernel } { mismatched-expl3 }
-      {
-        Mismatched~expl3~detected!~Loading~expl3~will~abort.
-        \\ \\
-        The~version~of~expl3~preloaded~in~LaTeX~is~
-        \c__kernel_expl_date_tl,~but~the~version~of~expl3~you~are~
-        trying~to~load~is~dated~\ExplLoaderFileDate.~This~is~most~
-        likely~due~to~a~stray~format~file~in~the~user~tree.~Please~
-        make~sure~that~your~LaTeX~format~is~updated.
-      }
-    \exp_after:wN \ExplSyntaxOff \use:n
-      {
-        \__kernel_msg_critical:nn { kernel } { mismatched-expl3 }
-        \use:c { fi: } \use:c { fi: }
-      }
-  \fi
-%    \end{macrocode}
-% If \cs{c__kernel_expl_date_tl} does \emph{not} exist, then we're on
-% uncharted lands (that is, any time prior to the version that
-% introduced this token list :-).  Two cases might be here, depending
-% whether \pkg{expl3} is loaded into the kernel or not. If we're loading
-% \pkg{expl3} \enquote{normally} as a package, \pkg{expl3} syntax is on.
-% Otherwise it's already loaded in the kernel and we're reloading
-% \file{expl3.sty} so (\file{expl3-code.tex} doesn't load again and)
-% \pkg{expl3} syntax is off.
-%    \begin{macrocode}
+  \expandafter\@firstofone
 \else
+%    \end{macrocode}
+% If \cs{c__kernel_expl_date_tl} does \emph{not} exist we may be loading
+% in a format without \pkg{expl3} preloaded or in the earlier (although
+% still compatible) version in which the error mentioned above showed
+% up.  If loading as a package, \file{expl3-code.tex} got read and here
+% the \pkg{expl3} syntax is on.  Otherwise it was already loaded in a
+% sligtly older kernel, so we fire the incompatibility error message and
+% abort loading.
+%    \begin{macrocode}
   \ifodd\csname\detokenize{l__kernel_expl_bool}\endcsname
 %    \end{macrocode}
-%   Package mode; all should be fine, since \file{expl3.sty} and
-%   \file{expl3-code.tex} are both loaded in one go, so versions should
-%   match (if they don't, it's detected above).
-%   Also, we've just tested that \pkg{expl3} syntax is on, so the reload
-%   test below will return false and \cs{bool_new:N} will run correctly.
+%   In package mode all files are loaded in one go, so versions will
+%   match, so nothing has to be done.
 %    \begin{macrocode}
+    \expandafter\expandafter
+    \expandafter\@gobble
   \else
 %    \end{macrocode}
-%   In this branch we're reloading, but there are still two cases to
-%   consider (sigh\ldots); whether the version preloaded in the format
-%   is recent enough to have \cs{g_@@_reload_bool} (2020-06-18 and
-%   later) or not.  If the boolean is there, we have to do nothing
-%   because right ahead we deal with this case.
-%   If it is not, we just have to create it:
+%   And reloading in an incompatible version is an error:
 %    \begin{macrocode}
-    \ExplSyntaxOn
-    \bool_if_exist:NF \g_@@_reload_bool
-      { \bool_new:N \g_@@_reload_bool }
-    \ExplSyntaxOff
+    \expandafter\expandafter
+    \expandafter\@firstofone
   \fi
 \fi
+  {\csname\detokenize{__kernel_dependency_version_check:Nn}\endcsname
+     \ExplLoaderFileDate{expl3.sty}}%
+%</package>
 %    \end{macrocode}
 %
 % Here we can also detect whether we're reloading.  This code goes into

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1272,8 +1272,11 @@
   \ifodd\csname\detokenize{l__kernel_expl_bool}\endcsname
 %    \end{macrocode}
 %   In package mode all files are loaded in one go, so versions will
-%   match, so nothing has to be done.
+%   match.  We just have to set \cs{c__kernel_expl_date_tl} so that
+%   further dependencies don't break:
 %    \begin{macrocode}
+    \global\expandafter\let\csname\detokenize
+      {c__kernel_expl_date_tl}\endcsname\ExplLoaderFileDate
     \expandafter\expandafter
     \expandafter\@gobble
   \else

--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -206,7 +206,7 @@
 %
 % \begin{function}[added = 2019-05-08]{\ior_shell_open:Nn}
 %   \begin{syntax}
-%     \cs{ior_shell_open:nN} \meta{stream} \Arg{shell~command}
+%     \cs{ior_shell_open:Nn} \meta{stream} \Arg{shell~command}
 %   \end{syntax}
 %   Opens the \emph{pseudo}-file created by the output of the
 %   \meta{shell command} for reading using \meta{stream} as the

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -3612,6 +3612,8 @@
 % \subsection{Checking the version of kernel dependencies}
 %
 % \begin{macro}{\__kernel_dependency_version_check:Nn}
+% \begin{macro}{\__kernel_dependency_version_check:nn}
+% \begin{macro}{\@@_kernel_dependency_compare:nnn,\@@_parse_version:w}
 %   This function is responsible for checking if dependencies of the
 %   \LaTeX3 kernel match the version preloaded in the \LaTeXe{} kernel.
 %   If versions don't match, the function attempts to tell why by
@@ -3624,8 +3626,8 @@
 %   the required date, it's an error and the loading should abort.
 %    \begin{macrocode}
 \cs_new_protected:Npn \__kernel_dependency_version_check:Nn #1
-  { \exp_args:NV \@@_kernel_dependency_compare:nn #1 }
-\cs_new_protected:Npn \@@_kernel_dependency_compare:nn #1
+  { \exp_args:NV \__kernel_dependency_version_check:nn #1 }
+\cs_new_protected:Npn \__kernel_dependency_version_check:nn #1
   {
     \cs_if_exist:NTF \c__kernel_expl_date_tl
       {
@@ -3727,6 +3729,8 @@
     \tex_endinput:D
   }
 %    \end{macrocode}
+% \end{macro}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 %

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -3668,9 +3668,9 @@
           \tl_if_exist:NT \c__kernel_expl_date_tl
             {
               \\ \\
-              The~L3~programming~layer~inside~the~LaTeX~format \\
-              are~dated~\c__kernel_expl_date_tl,~but~in~your~TeX~
-              tree~the~files \\ are~dated~#1.
+              The~L3~programming~layer~in~the~LaTeX~format \\
+              is~dated~\c__kernel_expl_date_tl,~but~in~your~TeX~
+              tree~the~files \\ are~from~#1.
             }
           \use_none:n
         }

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -2921,12 +2921,10 @@
 % \end{macro}
 % \end{macro}
 % \begin{variable}{\g_@@_internal_ior}
-%   A reserved stream to test for file existence, if required.
+%   A reserved stream to test for file existence (if required), and for
+%   opening a shell.
 %    \begin{macrocode}
-\bool_lazy_or:nnF
-  { \cs_if_exist_p:N \tex_filesize:D }
-  { \sys_if_engine_luatex_p: }
-  { \ior_new:N \g_@@_internal_ior }
+\ior_new:N \g_@@_internal_ior
 %    \end{macrocode}
 % \end{variable}
 %
@@ -3607,6 +3605,110 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_id_info_auxiii:w #1 - #2 - #3 - #4 \s_@@_stop
   { \tl_set:Nn \ExplFileDate { #1/#2/#3 } }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% \subsection{Checking the version of kernel dependencies}
+%
+% \begin{macro}{\__kernel_dependency_version_check:Nn}
+%   This function is responsible for checking if dependencies of the
+%   \LaTeX3 kernel match the version preloaded in the \LaTeXe{} kernel.
+%   If versions don't match, the function attempts to tell why by
+%   searching for a possible stray format file.
+%
+%   The function starts by checking if it needs to do anything at all.
+%   Usually it doesn't, so just quit silently.
+%    \begin{macrocode}
+\cs_new_protected:Npn \__kernel_dependency_version_check:Nn #1 #2
+  {
+    \tl_if_eq:NNF #1 \c__kernel_expl_date_tl
+      { \@@_mismatched_dependency_error:Nn #1 {#2} }
+  }
+%    \end{macrocode}
+%
+% \begin{macro}{\@@_mismatched_dependency_error:Nn}
+%   If the versions differ, then we try to give the user some guidance.
+%   This function starts by taking the engine name \cs{c_sys_engine_str}
+%   and replacing |tex| by |latex|, then building a command of the form:
+%   \begin{texttt}
+%   kpsewhich --all --engine=\meta{engine} \meta{format}[-dev].fmt
+%   \end{texttt}
+%   to query the format files available.  A shell is opened and each
+%   line is read into a sequence.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_mismatched_dependency_error:Nn #1 #2
+  {
+    \exp_args:NNx \ior_shell_open:Nn \g_@@_internal_ior
+      {
+        kpsewhich ~ --all ~
+          --engine = \c_sys_engine_exec_str
+          \c_space_tl \c_sys_engine_format_str
+            \tl_if_empty:NF \development@branch@name { -dev } .fmt
+      }
+    \seq_clear:N \l_@@_tmp_seq
+    \ior_map_inline:Nn \g_@@_internal_ior
+      { \seq_put_right:Nn \l_@@_tmp_seq {##1} }
+    \ior_close:N \g_@@_internal_ior
+%    \end{macrocode}
+%   Now define a some shorthands so that we can use \cs{@latex@error}
+%   (almost) easily:
+%    \begin{macrocode}
+    \group_begin:
+      \cs_set:Npn \\ { \MessageBreak }
+      \cs_set_eq:NN \  \c_space_tl
+      \@latex@error
+        {
+          Mismatched~LaTeX~support~files~detected. \\
+          Loading~'#2'~aborted!
+%    \end{macrocode}
+%   \cs{c__kernel_expl_date_tl} may not exist, due to an older format,
+%   so only print the dates when the sentinel token list exists:
+%    \begin{macrocode}
+          \tl_if_exist:NT \c__kernel_expl_date_tl
+            {
+              \\ \\
+              The~L3~programming~layer~inside~the~LaTeX~format \\
+              are~dated~\c__kernel_expl_date_tl,~but~in~your~TeX~
+              tree~the~files \\ are~dated~#1.
+            }
+          \use_none:n
+        }
+        {
+%    \end{macrocode}
+%   The sequence containing the format files should have exactly one
+%   item: the format file currently being run.  If that's the case, the
+%   cause of the error is not that, so print a generic help with some
+%   possible causes.  If more than one format file was found, then print
+%   the list to the user, with appropriate indications of what's in the
+%   system and what's in the user tree.
+%    \begin{macrocode}
+          \int_compare:nNnTF { \seq_count:N \l_@@_tmp_seq } > 1
+            {
+              The~cause~seems~to~be~an~old~format~file~in~the~user~tree. \\
+              LaTeX~found~these~files:
+              \seq_map_tokens:Nn \l_@@_tmp_seq { \\~-~\use:n } \\
+              Try~deleting~the~file~in~the~user~tree~then~run~LaTeX~again.
+            }
+            {
+              The~most~likely~causes~are:
+              \\~-~A~recent~format~generation~failed;
+              \\~-~A~stray~format~file~in~the~user~tree~which~needs~
+                   to~be~removed~or~rebuilt;
+              \\~-~You~are~running~a~manually~installed~version~of~#2 \\
+              \ \ \ which~is~incompatible~with~the~version~in~LaTeX. \\
+            }
+          \\
+          LaTeX~will~abort~loading~the~incompatible~support~files~
+          but~this~may~lead~to \\ later~errors.~Please~ensure~that~
+          your~LaTeX~format~is~correctly~regenerated.
+        }
+    \group_end:
+%    \end{macrocode}
+%   And finish by ending the current file.
+%    \begin{macrocode}
+    \tex_endinput:D
+  }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -3537,7 +3537,7 @@
 %</package>
 %    \end{macrocode}
 %
-% \subsection{GetIfInfo}
+% \subsection{GetIdInfo}
 %
 % \begin{macro}{\GetIdInfo}
 % \begin{macro}{\@@_id_info_auxi:w, \@@_id_info_auxii:w, \@@_id_info_auxiii:w}

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -3617,17 +3617,34 @@
 %   If versions don't match, the function attempts to tell why by
 %   searching for a possible stray format file.
 %
-%   The function starts by checking if it needs to do anything at all.
-%   Usually it doesn't, so just quit silently.
+%   The function starts by checking that the kernel date is defined, and
+%   if not zero is used to force the error route.  The kernel date is
+%   then compared with the argument requested date (ususally the
+%   packaging date of the dependency).  If the kernel date is less than
+%   the required date, it's an error and the loading should abort.
 %    \begin{macrocode}
-\cs_new_protected:Npn \__kernel_dependency_version_check:Nn #1 #2
+\cs_new_protected:Npn \__kernel_dependency_version_check:Nn #1
+  { \exp_args:NV \@@_kernel_dependency_compare:nn #1 }
+\cs_new_protected:Npn \@@_kernel_dependency_compare:nn #1
   {
-    \tl_if_eq:NNF #1 \c__kernel_expl_date_tl
-      { \@@_mismatched_dependency_error:Nn #1 {#2} }
+    \cs_if_exist:NTF \c__kernel_expl_date_tl
+      {
+        \exp_args:NV \@@_kernel_dependency_compare:nnn
+          \c__kernel_expl_date_tl {#1}
+       }
+       { \@@_kernel_dependency_compare:nnn { 0000-00-00 } {#1} }
   }
+\cs_new_protected:Npn \@@_kernel_dependency_compare:nnn #1 #2 #3
+  {
+    \int_compare:nNnT
+        { \@@_parse_version:w #1 \s_@@_stop } <
+        { \@@_parse_version:w #2 \s_@@_stop }
+      { \@@_mismatched_dependency_error:nn {#2} {#3} }
+  }
+\cs_new:Npn \@@_parse_version:w #1 - #2 - #3 \s_@@_stop {#1#2#3}
 %    \end{macrocode}
 %
-% \begin{macro}{\@@_mismatched_dependency_error:Nn}
+% \begin{macro}{\@@_mismatched_dependency_error:nn}
 %   If the versions differ, then we try to give the user some guidance.
 %   This function starts by taking the engine name \cs{c_sys_engine_str}
 %   and replacing |tex| by |latex|, then building a command of the form:
@@ -3637,7 +3654,7 @@
 %   to query the format files available.  A shell is opened and each
 %   line is read into a sequence.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_mismatched_dependency_error:Nn #1 #2
+\cs_new_protected:Npn \@@_mismatched_dependency_error:nn #1 #2
   {
     \exp_args:NNx \ior_shell_open:Nn \g_@@_internal_ior
       {
@@ -3670,7 +3687,7 @@
               \\ \\
               The~L3~programming~layer~in~the~LaTeX~format \\
               is~dated~\c__kernel_expl_date_tl,~but~in~your~TeX~
-              tree~the~files \\ are~from~#1.
+              tree~the~files~require \\ at~least~#1.
             }
           \use_none:n
         }

--- a/l3kernel/l3kernel-functions.dtx
+++ b/l3kernel/l3kernel-functions.dtx
@@ -101,6 +101,15 @@
 %   the \meta{follow-on}.
 % \end{function}
 %
+% \begin{function}{\__kernel_dependency_version_check:Nn}
+%   \begin{syntax}
+%     \cs{__kernel_dependency_version_check:Nn} \Arg{\cs{release}} \Arg{file}
+%   \end{syntax}
+%   Checks if the \meta{file}, dated \meta{release} has the same release date as
+%   the \pkg{l3kernel} preloaded in \LaTeXe{}.  If the dates don't match, the
+%   loading of \meta{file} is aborted and an error is raised.
+% \end{function}
+%
 % \begin{function}{\__kernel_deprecation_code:nn}
 %   \begin{syntax}
 %     \cs{__kernel_deprecation_code:nn} \Arg{error code} \Arg{working code}
@@ -123,6 +132,11 @@
 %   A boolean which records the current code syntax status: \texttt{true} if
 %   currently inside a code environment. This variable should only be
 %   set by \cs{ExplSyntaxOn}/\cs{ExplSyntaxOff}.
+% \end{variable}
+%
+% \begin{variable}{\c__kernel_expl_date_tl}
+%   A token list containing the release date of the \pkg{l3kernel} preloaded
+%   in \LaTeXe{} used to check if dependencies match.
 % \end{variable}
 %
 % \begin{function}{\__kernel_file_missing:n}

--- a/l3kernel/l3kernel-functions.dtx
+++ b/l3kernel/l3kernel-functions.dtx
@@ -101,12 +101,16 @@
 %   the \meta{follow-on}.
 % \end{function}
 %
-% \begin{function}{\__kernel_dependency_version_check:Nn}
+% \begin{function}{
+%     \__kernel_dependency_version_check:Nn,
+%     \__kernel_dependency_version_check:nn,
+%   }
 %   \begin{syntax}
-%     \cs{__kernel_dependency_version_check:Nn} \Arg{\cs{release}} \Arg{file}
+%     \cs{__kernel_dependency_version_check:Nn} \Arg{\cs{date}} \Arg{file}
+%     \cs{__kernel_dependency_version_check:nn} \Arg{date} \Arg{file}
 %   \end{syntax}
-%   Checks if the \meta{file}, dated \meta{release} has the same release date as
-%   the \pkg{l3kernel} preloaded in \LaTeXe{}.  If the dates don't match, the
+%   Checks if the loaded version of the \pkg{expl3} kernel is at least \meta{date},
+%   required by \meta{file}.  If the kernel date is older than \meta{date}, the
 %   loading of \meta{file} is aborted and an error is raised.
 % \end{function}
 %

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -252,7 +252,7 @@
 %   Execute \meta{tokens} through shell escape at shipout.
 % \end{function}
 %
-% \subsection{Loading configuration data}
+% \section{Loading configuration data}
 %
 % \begin{function}[added = 2019-09-12]{\sys_load_backend:n}
 %   \begin{syntax}
@@ -277,7 +277,7 @@
 %   back deprecations, respectively.
 % \end{function}
 %
-% \subsection{Final settins}
+% \subsection{Final settings}
 %
 % \begin{function}[added = 2019-10-06]{\sys_finalise:}
 %   \begin{syntax}

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -105,6 +105,18 @@
 %   |luatex|, |pdftex|, |ptex|, |uptex| or |xetex|.
 % \end{variable}
 %
+% \begin{variable}[added = 2020-07-31]{\c_sys_engine_exec_str}
+%   The name of the standard executable for the current TeX engine given
+%   as a lower case string: one of
+%   |luahbtex|, |pdftex|, |eptex|, |euptex| or |xetex|.
+% \end{variable}
+%
+% \begin{variable}[added = 2020-07-31]{\c_sys_engine_format_str}
+%   The name of the preloaded format for the current TeX run given
+%   as a lower case string: one of
+%   |lualatex|, |pdflatex| (or |latex|), |platex|, |uplatex| or |xelatex|.
+% \end{variable}
+%
 % \section{Output format}
 %
 % \begin{function}[added = 2015-09-19, EXP, pTF]
@@ -360,6 +372,50 @@
 %    \end{macrocode}
 % \end{variable}
 % \end{macro}
+%
+% \begin{variable}{\c_sys_engine_exec_str,\c_sys_engine_format_str}
+%   Take the functions defined above, and set up the engine and format
+%   names.  \cs{c_sys_engine_exec_str} differs from \cs{c_sys_engine_str}
+%   as it is the \emph{actual} engine name, not a \enquote{filtered}
+%   version.  It differs for |ptex| and |uptex|, which have a leading
+%   |e|, and for |luatex|, because \LaTeX{} uses the \Lua HB\TeX{}
+%   engine.
+%
+%   \cs{c_sys_engine_format_str} is quite similar to
+%   \cs{c_sys_engine_str}, except that it differentiates |pdflatex| from
+%   |latex| (which is \pdfTeX{} in DVI mode).  This differentiation,
+%   however, is reliable only if the user doesn't change
+%   \cs{tex_pdfoutput:D} before loading this code.
+%    \begin{macrocode}
+\str_const:Nx \c_sys_engine_exec_str
+  {
+    \sys_if_engine_pdftex:T { pdf }
+    \sys_if_engine_xetex:T  { xe  }
+    \sys_if_engine_ptex:T   { ep  }
+    \sys_if_engine_uptex:T  { eup }
+    \sys_if_engine_luatex:T
+      {
+        lua \lua_now:e
+          {
+            if (pcall(require, 'luaharfbuzz')) then ~
+              tex.print("hb") ~
+            end
+          }
+      }
+    tex
+  }
+\str_const:Nx \c_sys_engine_format_str
+  {
+    \sys_if_engine_pdftex:T
+      { \int_compare:nNnT { \tex_pdfoutput:D } = { 1 } { pdf } }
+    \sys_if_engine_xetex:T  { xe  }
+    \sys_if_engine_ptex:T   { p   }
+    \sys_if_engine_uptex:T  { up  }
+    \sys_if_engine_luatex:T { lua }
+    latex
+  }
+%    \end{macrocode}
+% \end{variable}
 %
 % \subsubsection{Randomness}
 %

--- a/l3kernel/testfiles/m3expl009.lvt
+++ b/l3kernel/testfiles/m3expl009.lvt
@@ -31,7 +31,7 @@
 % If the version of expl3 preloaded in the kernel differs
 % from the one in expl3.sty we have a critical error:
 \RELOAD
-  { \tl_set:Nn \c__kernel_expl_date_tl { WRONG-DATE } }
+  { \tl_set:Nn \c__kernel_expl_date_tl { 0000-00-00 } }
 
 % If they are equal, though, nothing bad happens. This should
 % be the most common scenario.

--- a/l3kernel/testfiles/m3expl009.lvt
+++ b/l3kernel/testfiles/m3expl009.lvt
@@ -28,50 +28,23 @@
   }
 \ExplSyntaxOff
 
-% The conditionals in parentheses refer to the outcome of the
-% \ifcsname and \ifx/\ifodd tests on lines 1272 onwards of
-% expl3.dtx in the commit that introduced this file.
-% Tested adding \typeouts to each branch, but they can't
-% really stay in the code :-)
-
-
 % If the version of expl3 preloaded in the kernel differs
 % from the one in expl3.sty we have a critical error:
 \RELOAD
   { \tl_set:Nn \c__kernel_expl_date_tl { WRONG-DATE } }
-% (TRUE, FALSE)
-
 
 % If they are equal, though, nothing bad happens. This should
 % be the most common scenario.
 \RELOAD
   { }
-% (TRUE, TRUE)
 
-
-% If, however, this token list is not defined:
-\ExplSyntaxOn
-\cs_gset_eq:NN \c__kernel_expl_date_tl \tex_undefined:D
-\ExplSyntaxOff
-% then we're on a version of expl3 prior to the one that
-% introduced this commit, so we can't check for the version
-% and have to guess (kind of) if we're in package mode or
-% just reloading expl3.sty with the kernel code in the
-% format.  This emulates a somewhat recent version
-% (2020-06-18 or later):
+% If this token list is not defined then we're on an earlier
+% version of expl3 anyway, so it's another critical error,
+% but no date is showed:
 \RELOAD
-  { }
-% (FALSE, FALSE)
+  { \cs_set_eq:NN \c__kernel_expl_date_tl \tex_undefined:D }
 
-
-% And this one emulates an older version, but still
-% post-expl3-in-format:
-\RELOAD
-  { \cs_set_eq:NN \g__expl_reload_bool \tex_undefined:D }
-% (FALSE, FALSE, plus defining the reload boolean)
-
-
-% Package mode (FALSE, TRUE) can't be easily emulated in
+% Package mode can't be easily emulated in
 % this test file (and it's a bit pointless), but it works
 % when loading this version of expl3 in a 2018 TL LaTeX.
 % Yours truly,

--- a/l3kernel/testfiles/m3expl009.tlg
+++ b/l3kernel/testfiles/m3expl009.tlg
@@ -6,9 +6,9 @@ Author: Phelype Oleinik
 Package: expl3 ....-..-.. L3 programming layer (loader) 
 ! LaTeX Error: Mismatched LaTeX support files detected.
                Loading 'expl3.sty' aborted!
-               The L3 programming layer inside the LaTeX format
-               are dated WRONG-DATE, but in your TeX tree the files
-               are dated ....-..-...
+               The L3 programming layer in the LaTeX format
+               is dated WRONG-DATE, but in your TeX tree the files
+               are from ....-..-...
 See the LaTeX manual or LaTeX Companion for explanation.
 Type  H <return>  for immediate help.
  ...                                              

--- a/l3kernel/testfiles/m3expl009.tlg
+++ b/l3kernel/testfiles/m3expl009.tlg
@@ -7,7 +7,7 @@ Package: expl3 ....-..-.. L3 programming layer (loader)
 ! LaTeX Error: Mismatched LaTeX support files detected.
                Loading 'expl3.sty' aborted!
                The L3 programming layer in the LaTeX format
-               is dated WRONG-DATE, but in your TeX tree the files
+               is dated ....-..-.., but in your TeX tree the files
                are from ....-..-...
 See the LaTeX manual or LaTeX Companion for explanation.
 Type  H <return>  for immediate help.

--- a/l3kernel/testfiles/m3expl009.tlg
+++ b/l3kernel/testfiles/m3expl009.tlg
@@ -4,24 +4,39 @@ Author: Phelype Oleinik
 \cnta=\count...
 (expl3.sty
 Package: expl3 ....-..-.. L3 programming layer (loader) 
-! Critical LaTeX3 Error: Mismatched expl3 detected! Loading expl3 will abort.
-(LaTeX3)                 
-(LaTeX3)                 The version of expl3 preloaded in LaTeX is
-(LaTeX3)                 WRONG-DATE, but the version of expl3 you are trying
-(LaTeX3)                 to load is dated ....-..-... This is most likely
-(LaTeX3)                 due to a stray format file in the user tree. Please
-(LaTeX3)                 make sure that your LaTeX format is updated.
-Type <return> to continue.
+! LaTeX Error: Mismatched LaTeX support files detected.
+               Loading 'expl3.sty' aborted!
+               The L3 programming layer inside the LaTeX format
+               are dated WRONG-DATE, but in your TeX tree the files
+               are dated ....-..-...
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help.
  ...                                              
-l. ...      }
-LaTeX does not know anything more about this error, sorry.
-Try typing <return> to proceed.
-If that doesn't work, type X <return> to quit.
-Reading the current file 'expl3' will stop.
+l. ...     \ExplLoaderFileDate{expl3.sty}}
+                                         %
+The most likely causes are:
+ - A recent format generation failed;
+ - A stray format file in the user tree which needs to be removed or rebuilt;
+ - You are running a manually installed version of expl3.sty
+   which is incompatible with the version in LaTeX.
+LaTeX will abort loading the incompatible support files but this may lead to
+later errors. Please ensure that your LaTeX format is correctly regenerated.
 ) (expl3.sty
 Package: expl3 ....-..-.. L3 programming layer (loader) 
 ) (expl3.sty
 Package: expl3 ....-..-.. L3 programming layer (loader) 
-) (expl3.sty
-Package: expl3 ....-..-.. L3 programming layer (loader) 
+! LaTeX Error: Mismatched LaTeX support files detected.
+               Loading 'expl3.sty' aborted!
+See the LaTeX manual or LaTeX Companion for explanation.
+Type  H <return>  for immediate help.
+ ...                                              
+l. ...     \ExplLoaderFileDate{expl3.sty}}
+                                         %
+The most likely causes are:
+ - A recent format generation failed;
+ - A stray format file in the user tree which needs to be removed or rebuilt;
+ - You are running a manually installed version of expl3.sty
+   which is incompatible with the version in LaTeX.
+LaTeX will abort loading the incompatible support files but this may lead to
+later errors. Please ensure that your LaTeX format is correctly regenerated.
 )

--- a/l3kernel/testfiles/m3expl009.tlg
+++ b/l3kernel/testfiles/m3expl009.tlg
@@ -7,8 +7,8 @@ Package: expl3 ....-..-.. L3 programming layer (loader)
 ! LaTeX Error: Mismatched LaTeX support files detected.
                Loading 'expl3.sty' aborted!
                The L3 programming layer in the LaTeX format
-               is dated ....-..-.., but in your TeX tree the files
-               are from ....-..-...
+               is dated ....-..-.., but in your TeX tree the files require
+               at least ....-..-...
 See the LaTeX manual or LaTeX Companion for explanation.
 Type  H <return>  for immediate help.
  ...                                              


### PR DESCRIPTION
The proposal here adds a command `\__kernel_dependency_version_check:Nn` that checks if the loaded `expl3` kernel supports the dependency being loaded (dependency being `expl3.sty` itself, `l3backend`, or other files not part of the 'core' `expl3`).

`\__kernel_dependency_version_check:Nn \MinKernelDate { current-file }` checks if the version date of the `expl3` kernel currently loaded is at least `\MinKernelDate`, and if it's not an error is raised and `\endinput` is used.

This might be a redundant test in some cases, but in others it will save us from trying to figure out the cause of some apparently unrelated error, like in https://github.com/latex3/latex3/issues/781, or previous problems we had with a version mismatch between `l3backend` and `l3kernel`.