### PR TITLE
Register prefix (platex)

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -147,6 +147,7 @@ percent,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,ht
 pgf,pgf,The PGF/TikZ Team,https://pgf-tikz.github.io,https://github.com/pgf-tikz/pgf,https://github.com/pgf-tikz/pgf/issues,2020-07-03,2020-07-03,
 pi,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 pkgploader,pkgploader,Michiel Helvensteijn,,,,2014-02-05,2014-02-05,
+platex,platex,Japanese TeX Development Communit,https://github.com/texjporg/platex,https://github.com/texjporg/platex.git,https://github.com/texjporg/platex/issues,2020/9/30,2020/9/30,
 polyglossia,polyglossia,Arthur Reutenauer,https://www.polyglossia.org/,https://github.com/reutenauer/polyglossia,https://github.com/reutenauer/polyglossia/issues,2019-09-03,,
 prg,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 primargs,morewrites,Bruno Le Floch,https://github.com/blefloch/latex-morewrites,https://github.com/blefloch/latex-morewrites.git,https://github.com/blefloch/latex-morewrites/issues,2013-03-16,2015-09-22,


### PR DESCRIPTION
Starting from platex 2020-09-30, we decided to use "platex".