### PR TITLE
[WIP] Implement \tl_map_inline:npn & \tl_map_function_unbraced:Nn

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -550,6 +550,29 @@
 %   \texttt{n}-type arguments. See also \cs{tl_map_function:NN}.
 % \end{function}
 %
+% \begin{function}[updated = 2020-10-30, rEXP]
+%   {\tl_map_function_unbraced:NN, \tl_map_function_unbraced:cN}
+%   \begin{syntax}
+%     \cs{tl_map_function_unbraced:NN} \meta{tl~var} \meta{function}
+%   \end{syntax}
+%   Applies \meta{function} to every \meta{item} in the \meta{tl~var}.
+%   The \meta{function} receives one unbraced argument for each iteration.
+%   This may be a number of tokens if the \meta{item} was stored within
+%   braces. Hence the \meta{function} should anticipate receiving
+%   \texttt{n}-type arguments. See also \cs{tl_map_function_unbraced:nN}.
+% \end{function}
+%
+% \begin{function}[updated = 2020-10-30, rEXP]{\tl_map_function_unbraced:nN}
+%   \begin{syntax}
+%     \cs{tl_map_function_unbraced:nN} \Arg{token list} \meta{function}
+%   \end{syntax}
+%   Applies \meta{function} to every \meta{item} in the \meta{token list},
+%   The \meta{function} receives one unbraced argument for each iteration.
+%   This may be a number of tokens if the \meta{item} was stored within
+%   braces. Hence the \meta{function} should anticipate receiving
+%   \texttt{n}-type arguments. See also \cs{tl_map_function_unbraced:NN}.
+% \end{function}
+%
 % \begin{function}[updated = 2012-06-29]
 %   {\tl_map_inline:Nn, \tl_map_inline:cn}
 %   \begin{syntax}
@@ -2479,6 +2502,32 @@
     #1 {#2} \@@_map_function:Nn #1
   }
 \cs_generate_variant:Nn \tl_map_function:NN { c }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\tl_map_function_unbraced:nN}
+% \begin{macro}{\tl_map_function_unbraced:NN, \tl_map_function_unbraced:cN}
+% \begin{macro}{\@@_map_function_unbraced:Nn}
+%   Expandable loop macro for token lists. These have the advantage of not
+%   needing to test if the argument is empty, because if it is, the stop
+%   marker is read immediately and the loop terminated.
+%    \begin{macrocode}
+\cs_new:Npn \tl_map_function_unbraced:nN #1#2
+  {
+    \@@_map_function_unbraced:Nn #2 #1
+      \q_@@_recursion_tail
+    \prg_break_point:Nn \tl_map_break: { }
+  }
+\cs_new:Npn \tl_map_function_unbraced:NN
+  { \exp_args:No \tl_map_function_unbraced:nN }
+\cs_new:Npn \@@_map_function_unbraced:Nn #1#2
+  {
+    \@@_if_recursion_tail_break:nN {#2} \tl_map_break:
+    #1 #2 \@@_map_function_unbraced:Nn #1
+  }
+\cs_generate_variant:Nn \tl_map_function_unbraced:NN { c }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -573,6 +573,27 @@
 %   \texttt{n}-type arguments. See also \cs{tl_map_function_unbraced:NN}.
 % \end{function}
 %
+% \begin{function}[updated = 2020-10-30]
+%   {\tl_map_inline:Npn, \tl_map_inline:cpn}
+%   \begin{syntax}
+%     \cs{tl_map_inline:Npn} \meta{tl~var} \meta{parameters} \Arg{inline function}
+%   \end{syntax}
+%   Applies the \meta{inline function} to every \meta{item} stored within the
+%   \meta{tl~var}. The \meta{inline function} should consist of code which
+%   receives the \meta{item} unbraced as \meta{parameters} (|#1|, |#2|, \emph{etc.}).
+%   See also \cs{tl_map_function_unbraced:NN}.
+% \end{function}
+%
+% \begin{function}[updated = 2020-10-30]{\tl_map_inline:npn}
+%   \begin{syntax}
+%     \cs{tl_map_inline:npn} \Arg{token list} \meta{parameters} \Arg{inline function}
+%   \end{syntax}
+%   Applies the \meta{inline function} to every \meta{item} stored within the
+%   \meta{token list}. The \meta{inline function} should consist of code which
+%   receives the \meta{item} unbraced as \meta{parameters} (|#1|, |#2|, \emph{etc.}).
+%   See also \cs{tl_map_function_unbraced:nN}.
+% \end{function}
+%
 % \begin{function}[updated = 2012-06-29]
 %   {\tl_map_inline:Nn, \tl_map_inline:cn}
 %   \begin{syntax}
@@ -2530,6 +2551,33 @@
 \cs_generate_variant:Nn \tl_map_function_unbraced:NN { c }
 %    \end{macrocode}
 % \end{macro}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\tl_map_inline:npn, \@@_map_inline:nnn}
+% \begin{macro}{\tl_map_inline:Npn, \tl_map_inline:cpn}
+%   The inline functions are straight forward by now. We use a little
+%   trick with the counter \cs{g__kernel_prg_map_int} to make
+%   them nestable. We can also make use of \cs{@@_map_function:Nn}
+%   from before.
+%    \begin{macrocode}
+\cs_new_protected:Npn \tl_map_inline:npn #1#2#
+  { \@@_map_inline:nnn {#1} {#2} }
+\cs_new_protected:Npn \@@_map_inline:nnn #1#2#3 
+  {
+    \int_gincr:N \g__kernel_prg_map_int
+    \cs_gset_protected:cpn
+      { @@_map_ \int_use:N \g__kernel_prg_map_int :w } #2 {#3}
+    \exp_args:Nc \@@_map_function_unbraced:Nn
+      { @@_map_ \int_use:N \g__kernel_prg_map_int :w }
+      #1 \q_@@_recursion_tail
+    \prg_break_point:Nn \tl_map_break:
+      { \int_gdecr:N \g__kernel_prg_map_int }
+  }
+\cs_new_protected:Npn \tl_map_inline:Npn
+  { \exp_args:No \tl_map_inline:npn }
+\cs_generate_variant:Nn \tl_map_inline:Npn { c }
+%    \end{macrocode}
 % \end{macro}
 % \end{macro}
 %


### PR DESCRIPTION
# [WIP] Implement `\tl_map_function_unbraced:Nn`

With variants `\tl_map_function_unbraced:NN` and `\tl_map_function_unbraced:cN`.

Also implement `\tl_map_function_unbraced:Nn`.

These are basically the same as the `\tl_map_function:Nn` family, but without `#1` receiving `#2` braced. Careful use of this macro allows for cleanly mapping multi-argument functions.

**TODO:** The docs here are sucky, but I wrote this months ago and haven't been LaTeXing enough to feel out better wording that isn't incorrect. This is a useful macro, even if a bit awkward & subtle to describe.

---

# [WIP] Implement `\tl_map_inline:npn`

With internal `\@@_map_inline:nnn` & variants `\tl_map_inline:Npn` and `\tl_map_inline:cpn`.

It's like `\tl_map_inline:nn`, but you can supply a consistent number of arguments (of your choosing) in the token list, match your parameters, and map using multiple arguments instead of just one! It's really handy when factoring out slightly more complex templates.

Theoretically, `\tl_map_inline:nn` could be a simple wrapper of this, but do we want to rely on `\tl_map_function_unbraced:Nn` when we don't have to?

---

Finally got around to extracting this fiddle from a personal package. This PR probably has problems, especially on the documentation side, but at least it's out and other better at TeX than me can word stuff better? (The concepts themselves aren't that complex, just kinda foreign or uncommon IMO.)

Some example uses from that package:

```tex
% \begin{macro}{\keyval_parse_inline:Nnnn}
% \begin{macro}{\keyval_gparse_inline:Nnnn}
%    \begin{macrocode}
\cs_if_free:NT \keyval_parse_inline:Nnnn
  {
    \tl_map_inline:npn
      {
        {
          \keyval_parse_inline:Nnnn
          \tl_build_begin:N \tl_build_put_right:Nx \tl_build_end:N
        }
        {
          \keyval_gparse_inline:Nnnn
          \tl_build_gbegin:N \tl_build_gput_right:Nx \tl_build_gend:N
        }
      }
      #1#2#3#4
      {
        \cs_new_protected:Npn #1 ##1##2##3##4
          {
            #2 ##1
            \keyval_parse_inline:nnn
              { #3 ##1 {##2} }
              { #3 ##1 {##3} }
              {##4}
            #4 ##1
          }
      }
  }
%    \end{macrocode}
% \end{macro}
% \end{macro}
```

```tex
% \begin{macro}[pTF]{\ecv_string_if_exist:n}
% \begin{macro}[pTF]{\ecv_string_if_empty:n}
%    \begin{macrocode}
\tl_map_inline:nn { {exist} {empty} }
  {
    \tl_map_inline:npn
      { { {_p} {} } { {} {T} } { {} {F} } { {} {TF} } } ##1##2
      {
        \cs_new:cpx { ecv_string_if_ #1 ##1 : n ##2 } ####1
          {
            \exp_not:c { tl_if_ #1 ##1 : c ##2 }
              { l_@@_string_ ~ ####1 _tl }
          }
      }
  }
%    \end{macrocode}
% \end{macro}
% \end{macro}
```

This honestly just feels like a natural extension of the existing `\tl_map_inline:nn` API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/latex3/latex3/819)
<!-- Reviewable:end -->
