### PR TITLE
[.travis.yml] Set `os`, `dist` and remove `on_start` and `skip_cleanup`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+os: linux
+dist: xenial
+
 install:
  - source ./support/texlive.sh
 
@@ -25,7 +28,6 @@ notifications:
       - latex3-commits@tug.org
     on_success: change
     on_failure: always
-    on_start:   never
 
 deploy:
   - provider: releases
@@ -34,7 +36,6 @@ deploy:
     file_glob: true
     file:
       - ./*.zip
-    skip_cleanup: true
     on:
       tags: true
     prerelease: false


### PR DESCRIPTION
Used official linter from travis 1.10.0 (https://github.com/travis-ci/travis.rb#lint) to find the last two issues, `skip_cleanup: true` is now default as per https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release#cleaning-up-the-git-working-directory. `on_start` isn't present for email https://docs.travis-ci.com/user/notifications/#configuring-email-notifications. Explicitly setting the `os` and `dist` settings, as that's general good practice.