### PR TITLE
linklast for xdvipdfmx: correct int name, increase, avoid obj name clash

### DIFF
--- a/l3backend/l3backend-pdf.dtx
+++ b/l3backend/l3backend-pdf.dtx
@@ -1423,13 +1423,17 @@
   { \@@_backend_link_begin:n {#1#2} }
 \cs_new_protected:Npx \@@_backend_link_begin:n #1
   {
-    \@@_backend:n
+    \int_compare:nNnF \c__kernel_sys_dvipdfmx_version_int < { 20201111 }
+      {
+        \exp_not:N \int_gincr:N \exp_not:N  \g_@@_backend_link_int
+      }
+    \@@_backend:x
       {
          bann ~
          \int_compare:nNnF \c__kernel_sys_dvipdfmx_version_int < { 20201111 }
            {
-             @pdf.obj
-             \exp_not:N \int_use:N \exp_not:N  \g_@@_backend_object_int
+             @pdf.lnk
+             \exp_not:N \int_use:N \exp_not:N  \g_@@_backend_link_int
              \c_space_tl
            }
          <<
@@ -1453,7 +1457,7 @@
   {
     \int_compare:nNnF \c__kernel_sys_dvipdfmx_version_int < { 20201111 }
       {
-        @pdf.obj
+        @pdf.lnk
           \exp_not:N \int_use:N \exp_not:N \g_@@_backend_link_int
       }
   }


### PR DESCRIPTION
This corrects the link last code for newer xdvipdfmx. Beside others one has to use    \@@_backend:x
  to expand the int, but I'm not sure if this means that one should surround the `#1` with an \exp_not-