### PR TITLE
add fitr support to \@@_backend_destination:nn

### DIFF
--- a/l3backend/l3backend-pdf.dtx
+++ b/l3backend/l3backend-pdf.dtx
@@ -620,6 +620,7 @@
 %   Here, we need to turn the zoom into a scale. We also need to know where
 %   the current anchor point actually is: worked out in PostScript. For the
 %   rectangle version, we have a bit more PostScript: we need two points.
+%   fitr without rule spec doesn't work, so it falls back to /Fit here.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_backend_destination:nn #1#2
   {
@@ -637,6 +638,7 @@
               { fitbv } { /FitBV ~ pdf.dest.x }
               { fith }  { /FitH ~ pdf.dest.y }
               { fitv }  { /FitV ~ pdf.dest.x }
+              { fitr }  { /Fit }
             }
             {
               /XYZ ~ pdf.dest.point ~ \fp_eval:n { (#2) / 100 }
@@ -881,6 +883,7 @@
             { fitbv } { fitbv }
             { fith }  { fith }
             { fitv }  { fitv }
+            { fitr }  { fitr }
           }
           { xyz ~ zoom \fp_eval:n { #2 * 10 } }
         \scan_stop:
@@ -1476,6 +1479,7 @@
 %   Here, we need to turn the zoom into a scale. The method for \texttt{FitR}
 %   is from Alexander Grahn: the idea is to avoid needing to do any calculations
 %   in \TeX{} by using the backend data for \texttt{@xpos} and \texttt{@ypos}.
+%   fitr without rule spec doesn't work, so it falls back to /Fit here.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_backend_destination:nn #1#2
   {
@@ -1493,6 +1497,7 @@
               { fitbv } { /FitBV ~ @xpos }
               { fith }  { /FitH ~ @ypos }
               { fitv }  { /FitV ~ @xpos }
+              { fitr }  { /Fit }
             }
             { /XYZ ~ @xpos ~ @ypos ~ \fp_eval:n { (#2) / 100 } }
         ]


### PR DESCRIPTION
pdftex and luatex allows to use fitr without rule spec, they then fill the coordinates by using the surrounding box. 
This can be useful sometimes, so this adds it as option to \@@_backend_destination:nn.   For dvipdfmx and dvips /Fit is used as fallback.  