### PR TITLE
Fix typo TeX(live|Live) => TeX Live

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -548,7 +548,7 @@
 %   The maximum number of characters in a line to be written
 %   by the \cs{iow_wrap:nnnN}
 %   function. This value depends on the \TeX{} system in use: the standard
-%   value is $78$, which is typically correct for unmodified \TeX{}live
+%   value is $78$, which is typically correct for unmodified \TeX{} Live
 %   and \hologo{MiKTeX} systems.
 % \end{variable}
 %
@@ -771,7 +771,7 @@
 %     \cs{file_get_mdfive_hash:nN} \Arg{file name} \meta{tl var}
 %   \end{syntax}
 %   Sets the \meta{tl var} to the result of applying
-%   \cs{file_mdfive_hash:n} to the \meta{file}. If the file is not found, 
+%   \cs{file_mdfive_hash:n} to the \meta{file}. If the file is not found,
 %   the \meta{tl var} will be set to \cs{q_no_value}.
 % \end{function}
 %
@@ -791,7 +791,7 @@
 %     \cs{file_get_size:nN} \Arg{file name} \meta{tl var}
 %   \end{syntax}
 %   Sets the \meta{tl var} to the result of applying
-%   \cs{file_size:n} to the \meta{file}. If the file is not found, 
+%   \cs{file_size:n} to the \meta{file}. If the file is not found,
 %   the \meta{tl var} will be set to \cs{q_no_value}.
 %   This is not available in older versions of \XeTeX{}.
 % \end{function}
@@ -817,7 +817,7 @@
 %     \cs{file_get_timestamp:nN} \Arg{file name} \meta{tl var}
 %   \end{syntax}
 %   Sets the \meta{tl var} to the result of applying
-%   \cs{file_timestamp:n} to the \meta{file}. If the file is not found, 
+%   \cs{file_timestamp:n} to the \meta{file}. If the file is not found,
 %   the \meta{tl var} will be set to \cs{q_no_value}.
 %   This is not available in older versions of \XeTeX{}.
 % \end{function}
@@ -1647,7 +1647,7 @@
 %   This is the \enquote{raw} number of characters in a line which
 %   can be written to the terminal.
 %   The standard value is the line length typically used by
-%   \TeX{}Live and \hologo{MiKTeX}.
+%   \TeX{} Live and \hologo{MiKTeX}.
 %    \begin{macrocode}
 \int_new:N  \l_iow_line_count_int
 \int_set:Nn \l_iow_line_count_int { 78 }
@@ -2488,10 +2488,10 @@
   }
 \cs_new:Npx \__kernel_file_name_expand_group:nw #1
   {
-    \c_left_brace_str 
+    \c_left_brace_str
     \exp_not:N \__kernel_file_name_expand_loop:w
      #1
-     \c_right_brace_str 
+     \c_right_brace_str
   }
 \exp_last_unbraced:NNo
   \cs_new:Npx \__kernel_file_name_expand_space:w \c_space_tl
@@ -2527,7 +2527,7 @@
 %   Spaces need to be trimmed from the start of the name and from the end of
 %   any extension. However, the name we are passed might not have an extension:
 %   that means we have to look for one. If there is no extension, we still use
-%   the standard trimming function but deliberately prevent any spaces being 
+%   the standard trimming function but deliberately prevent any spaces being
 %   removed at the end.
 %    \begin{macrocode}
 \cs_new:Npn \__kernel_file_name_trim_spaces:n #1
@@ -3040,7 +3040,7 @@
 \cs_new_protected:Npn \file_get_hex_dump:nnnN #1#2#3#4
   {
     \file_get_hex_dump:nnnNF {#1} {#2} {#3} #4
-      { \tl_set:Nn #4 { \q_no_value } } 
+      { \tl_set:Nn #4 { \q_no_value } }
   }
 \prg_new_protected_conditional:Npnn \file_get_hex_dump:nnnN #1#2#3#4
   { T , F , TF }

--- a/l3kernel/l3intarray.dtx
+++ b/l3kernel/l3intarray.dtx
@@ -157,7 +157,7 @@
 %
 % While \LuaTeX{}'s memory is extensible, other engines can
 % \enquote{only} deal with a bit less than $4\times 10^6$ entries in all
-% \tn{fontdimen} arrays combined (with default \TeX{}Live settings).
+% \tn{fontdimen} arrays combined (with default \TeX{} Live settings).
 %
 % \end{documentation}
 %


### PR DESCRIPTION
Hi, just a couple of typographical changes `TeX(live|Live)` => `TeX Live` (I was uncomfortable seeing it in lowercase and all together).
PD: By default my editor removes the spaces at the end of the line :)
Saludos