### PR TITLE
Faster expandable sort

### DIFF
--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -351,6 +351,23 @@
 %   described in Section~\ref{sec:l3sort:mech}.
 % \end{function}
 %
+% \begin{function}[added = 2021-01-23, EXP]{\clist_sort:NN, \clist_sort:nN}
+%   \begin{syntax}
+%     \cs{clist_sort:NN} \meta{clist var} \meta{conditional}
+%   \end{syntax}
+%   Sorts the items in the \meta{clist var}, using the \meta{conditional} to
+%   compare the items, and leaves the result in the input stream as a |clist|.
+%   The \meta{conditional} should have signature |:nnTF|, and return
+%   \texttt{true} if the two items being compared should be left in the same
+%   order, and \texttt{false} if the items should be swapped. The details of
+%   sorting comparison are described in Section~\ref{sec:l3sort:mech}.
+%   \begin{texnote}
+%     The result is returned within \cs{exp_not:n}, which means that the
+%     token list does not expand further when appearing in an
+%     \texttt{x}-type or \texttt{e}-type argument expansion.
+%   \end{texnote}
+% \end{function}
+%
 % \section{Comma list conditionals}
 %
 % \begin{function}[EXP,pTF]{\clist_if_empty:N, \clist_if_empty:c}
@@ -1517,7 +1534,10 @@
 % \end{macro}
 %
 % \begin{macro}
-%   {\clist_sort:Nn, \clist_sort:cn, \clist_gsort:Nn, \clist_gsort:cn}
+%   {
+%     \clist_sort:Nn, \clist_sort:cn, \clist_gsort:Nn, \clist_gsort:cn
+%     \clist_sort:nN, \clist_sort:NN
+%   }
 %   Implemented in \pkg{l3sort}.
 % \end{macro}
 %

--- a/l3kernel/l3sort.dtx
+++ b/l3kernel/l3sort.dtx
@@ -1321,6 +1321,335 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}[EXP]{\clist_sort:nN,\clist_sort:NN}
+%   Sorting a |clist| can be done in the same way we sort a |tl|, we just have
+%   to convert the |clist| into the same representation used by \cs{tl_sort:nN}
+%   internally during our first bottom up pass and convert back to a |clist|
+%   after we're done. The \cs{clist_sort:NN} variant can take a shortcut in
+%   the bottom up pass as a |clist| variable would already be sanitized. For the
+%   |n| variant we place \cs{prg_do_nothing:} infront of the list to avoid
+%   accidental brace stripping.
+%
+%   In the case that \cs{tex_expanded:D} isn't available we fall back by
+%   converting the |clist| into a token list and using the same sorting function
+%   inside an |f|-expansion. The result is then turned into a |clist|. For the
+%   conversion to a token list we use \cs{clist_map_function:NN} for the
+%   |N|-type and \cs{clist_map_function:nN} for the |n|-type variant.
+%    \begin{macrocode}
+\cs_if_exist:NTF \tex_expanded:D
+  {
+    \cs_new:Npn \clist_sort:nN #1#2
+      {
+        \__kernel_exp_not:w
+          \exp_after:wN \@@_merge_exp_after_bottom_up_clist:Nw \exp_after:wN #2
+          \tex_expanded:D
+            {
+              \@@_merge_exp_bottom_up_clist_n:Nw
+                #2 \prg_do_nothing: #1 , \s_@@_merge_exp_mark ,
+            }
+      }
+    \cs_new:Npn \clist_sort:NN #1#2
+      {
+        \__kernel_exp_not:w
+          \exp_after:wN \@@_merge_exp_after_bottom_up_clist:Nw \exp_after:wN #2
+          \tex_expanded:D
+            {
+              \exp_after:wN \@@_merge_exp_bottom_up_clist_N:Nw \exp_after:wN
+                #2 #1 , \s_@@_merge_exp_mark , \s_@@_merge_exp_stop ,
+            }
+      }
+  }
+  {
+    \cs_new:Npn \clist_sort:nN #1#2
+      {
+        \exp_not:f
+          {
+            \clist_map_function:nN {#1} \@@_quick_prepare_clist:nw
+            \@@_quick_prepare_clist_result:nN {} #2
+          }
+      }
+    \cs_new:Npn \clist_sort:NN #1#2
+      {
+        \exp_not:f
+          {
+            \clist_map_function:NN #1 \@@_quick_prepare_clist:nw
+            \@@_quick_prepare_clist_result:nN { } #2
+          }
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\@@_quick_prepare_clist:nw}
+%    \begin{macrocode}
+    \cs_new:Npn \@@_quick_prepare_clist:nw
+        #1#2 \@@_quick_prepare_clist_result:nN #3
+      {
+        #2 \@@_quick_prepare_clist_result:nN { #3 {#1} }
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\@@_quick_prepare_clist_result:nN}
+%    \begin{macrocode}
+    \cs_new:Npn \@@_quick_prepare_clist_result:nN #1#2
+      {
+        \tl_if_empty:nF {#1}
+          {
+            \exp_after:wN \@@_quick_to_clist:n \exp:w \exp_end_continue_f:w
+              \@@_quick_prepare:Nnnn #2 { } { }
+                #1
+                { \prg_break_point: \@@_quick_prepare_end:NNNnw }
+              \s_@@_stop
+              { \prg_break_point: \@@_quick_to_clist_end:w }
+            \@@_quick_to_clist_result:n { }
+          }
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\@@_quick_to_clist:n}
+%    \begin{macrocode}
+    \cs_new:Npn \@@_quick_to_clist:n #1
+      {
+        \prg_break: #1 \prg_break_point:
+        \__clist_if_wrap:nTF {#1}
+          \@@_quick_to_clist_out_wrap:nw
+          \@@_quick_to_clist_out:nw
+          {#1}
+        \@@_quick_to_clist:n
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\@@_quick_to_clist_out:nw, \@@_quick_to_clist_out_wrap:nw}
+%    \begin{macrocode}
+    \cs_new:Npn \@@_quick_to_clist_out:nw #1#2 \@@_quick_to_clist_result:n #3
+      { #2 \@@_quick_to_clist_result:n { #3 , #1 } }
+    \cs_new:Npn \@@_quick_to_clist_out_wrap:nw
+        #1#2 \@@_quick_to_clist_result:n #3
+      { #2 \@@_quick_to_clist_result:n { #3 , {#1} } }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\@@_quick_to_clist_end:w}
+%    \begin{macrocode}
+    \cs_new:Npn \@@_quick_to_clist_end:w #1 \@@_quick_to_clist_result:n #2
+      { \exp_after:wN \exp_stop_f: \use_none:n #2 }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]
+%   {
+%     \@@_merge_exp_after_bottom_up_clist:Nw,
+%     \@@_merge_exp_after_merge_clist:Nw,
+%     \@@_merge_exp_after_mark_clist:w
+%   }
+%   These macros are the same as in the |tl| sorting variant, except that they
+%   will use \cs{@@_merge_exp_to_clist:n} on the sorted list.
+%    \begin{macrocode}
+\cs_if_exist:NT \tex_expanded:D
+  {
+    \cs_new:Npn \@@_merge_exp_after_bottom_up_clist:Nw
+        #1#2 \s_@@_merge_exp_list #3
+      {
+        \@@_if_stop:w #3 \@@_merge_exp_after_stop:w \s_@@_merge_exp_stop
+        \@@_if_mark:w #3 \@@_merge_exp_after_mark_clist:w \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_after_merge_clist:Nw \exp_after:wN #1
+        \tex_expanded:D { \if_false: } \fi:
+          \@@_merge_exp_merge:Nw #1#2 \s_@@_merge_exp_list {#3}
+      }
+    \cs_new:Npn \@@_merge_exp_after_merge_clist:Nw
+        #1#2 \s_@@_merge_exp_list #3
+      {
+        \@@_if_mark:w #3 \@@_merge_exp_after_mark_clist:w \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_after_merge_clist:Nw \exp_after:wN #1
+        \tex_expanded:D { \if_false: } \fi:
+          \@@_merge_exp_merge:Nw #1#2 \s_@@_merge_exp_list {#3}
+      }
+    \cs_new:Npn \@@_merge_exp_after_mark_clist:w
+        \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_after_merge_clist:Nw \exp_after:wN #1
+        \tex_expanded:D #2 \fi:
+        \@@_merge_exp_merge:Nw #3#4 \s_@@_merge_exp_list
+        #5 \s_@@_merge_exp_list
+        \s_@@_merge_exp_stop \s_@@_merge_exp_list
+      { \tex_expanded:D { { \@@_merge_exp_to_clist:n #4 } } }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[rEXP]
+%   {
+%     \@@_merge_exp_bottom_up_clist_n:Nw,
+%     \@@_merge_exp_bottom_up_clist_n:n,
+%     \@@_merge_exp_bottom_up_clist_n_auxi:n,
+%     \@@_merge_exp_bottom_up_clist_n:wNw,
+%     \@@_merge_exp_bottom_up_clist_n:nNw,
+%     \@@_merge_exp_bottom_up_clist_n_auxii:n,
+%     \@@_merge_exp_bottom_up_clist_n_auxiii:n,
+%     \@@_merge_exp_bottom_up_clist_n:wnN,
+%     \@@_merge_exp_bottom_up_clist_n:w,
+%     \@@_merge_exp_bottom_up_clist_n_mark_i:w,
+%     \@@_merge_exp_bottom_up_clist_n_mark_ii:w
+%   }
+%   These macros do the bottom up pass for a |clist|. Elements are stripped at
+%   commas. For each element we have to test whether it's blank, in which case
+%   it is skipped. Next we need to trim spaces from both ends, after which we
+%   remove exactly one set of possible braces. All this takes several steps
+%   which is why we need a lot of auxiliaries.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n:Nw #1#2,
+      {
+        \@@_if_mark:w
+          #2 \@@_merge_exp_bottom_up_clist_n_mark_i:w \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_bottom_up_clist_n:n \exp_after:wN {#2}
+        #1 \prg_do_nothing:
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n:n #1
+      {
+        \tl_if_blank:nTF {#1}
+          { \@@_merge_exp_bottom_up_clist_n:Nw }
+          {
+            \tl_trim_spaces_apply:nN {#1} \@@_merge_exp_bottom_up_clist_n_auxi:n
+          }
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n_auxi:n #1
+      { \@@_merge_exp_bottom_up_clist_n:wNw #1 , }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n:wNw #1,
+      { \@@_merge_exp_bottom_up_clist_n:nNw {#1} }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n:nNw #1#2#3,
+      {
+        \@@_if_mark:w
+          #3 \@@_merge_exp_bottom_up_clist_n_mark_ii:w \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_bottom_up_clist_n_auxii:n \exp_after:wN
+          {#3} {#1} #2
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n_auxii:n #1
+      {
+        \tl_if_blank:nT {#1} \@@_merge_exp_bottom_up_clist_n:w
+        \tl_trim_spaces_apply:nN {#1} \@@_merge_exp_bottom_up_clist_n_auxiii:n
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n_auxiii:n #1
+      { \@@_merge_exp_bottom_up_clist_n:wnN #1 , }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n:wnN #1,#2#3
+      {
+        #3 {#2} {#1}
+          { \__kernel_exp_not:w { {#2} {#1} } }
+          { \__kernel_exp_not:w { {#1} {#2} } }
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \@@_merge_exp_bottom_up_clist_n:Nw #3 \prg_do_nothing:
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n:w
+        \tl_trim_spaces_apply:nN #1 \@@_merge_exp_bottom_up_clist_n_auxiii:n
+        #2#3
+      { \@@_merge_exp_bottom_up_clist_n:nNw {#2} #3 \prg_do_nothing: }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n_mark_i:w
+        \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_bottom_up_clist_n:n \exp_after:wN #1
+        \prg_do_nothing:
+        \s_@@_merge_exp_stop
+      {
+        \s_@@_merge_exp_mark \s_@@_merge_exp_list
+        \s_@@_merge_exp_stop \s_@@_merge_exp_list
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_n_mark_ii:w
+        \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_bottom_up_clist_n_auxii:n \exp_after:wN
+        #1#2#3
+        \s_@@_merge_exp_stop
+      {
+        { \__kernel_exp_not:w {#2} }
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \s_@@_merge_exp_mark \s_@@_merge_exp_list
+        \s_@@_merge_exp_stop \s_@@_merge_exp_list
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[rEXP]
+%   {
+%     \@@_merge_exp_bottom_up_clist_N:Nw,
+%     \@@_merge_exp_bottom_up_clist_N_stop:w,
+%     \@@_merge_exp_bottom_up_clist_N_mark:w
+%   }
+%   If the input is a |clist| variable the sanitizing is already done and we
+%   just need to grab two list elements and else do the same as for the |tl|
+%   bottom up variant.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_N:Nw #1#2,#3,
+      {
+        \@@_if_stop:w
+          #3 \@@_merge_exp_bottom_up_clist_N_stop:w \s_@@_merge_exp_stop
+        \@@_if_mark:w
+          #3 \@@_merge_exp_bottom_up_clist_N_mark:w \s_@@_merge_exp_mark
+        #1 {#2} {#3}
+          { \__kernel_exp_not:w { {#2} {#3} } }
+          { \__kernel_exp_not:w { {#3} {#2} } }
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \@@_merge_exp_bottom_up_clist_N:Nw #1
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_N_stop:w
+        \s_@@_merge_exp_stop
+        \@@_if_mark:w \s_@@_merge_exp_stop
+        \@@_merge_exp_bottom_up_clist_N_mark:w \s_@@_merge_exp_mark
+        #1
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \@@_merge_exp_bottom_up_clist_N:Nw #2
+      {
+        \s_@@_merge_exp_mark \s_@@_merge_exp_list
+        \s_@@_merge_exp_stop \s_@@_merge_exp_list
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_clist_N_mark:w
+        \s_@@_merge_exp_mark
+        #1#2#3
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \@@_merge_exp_bottom_up_clist_N:Nw #4
+      {
+        { \__kernel_exp_not:w {#2} }
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \s_@@_merge_exp_mark \s_@@_merge_exp_list
+        \s_@@_merge_exp_stop \s_@@_merge_exp_list
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[rEXP]
+%   {
+%     \@@_merge_exp_to_clist:n,
+%     \@@_merge_exp_to_clist_next:n,
+%     \@@_merge_exp_to_clist_done:w
+%   }
+%   The first recursion of this loop doesn't need to check whether the end is
+%   reached, as it is never used on an empty list. The next recursions all need
+%   to check whether the end is reached and put a comma before each output
+%   element. We use \cs{__clist_if_wrap:nTF} to decide whether an additional set
+%   of braces is necessary.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_merge_exp_to_clist:n #1
+      {
+        \__clist_if_wrap:nTF {#1}
+          { { \__kernel_exp_not:w {#1} } }
+          { \__kernel_exp_not:w {#1} }
+        \@@_merge_exp_to_clist_next:n
+      }
+    \cs_new:Npn \@@_merge_exp_to_clist_next:n #1
+      {
+        \@@_if_tail:w #1 \@@_merge_exp_to_clist_done:w \s_@@_merge_exp_tail
+        ,
+        \__clist_if_wrap:nTF {#1}
+          { { \__kernel_exp_not:w {#1} } }
+          { \__kernel_exp_not:w {#1} }
+        \@@_merge_exp_to_clist_next:n
+      }
+    \cs_new:Npn \@@_merge_exp_to_clist_done:w
+        \s_@@_merge_exp_tail
+        ,
+        \__clist_if_wrap:nTF #1
+        \@@_merge_exp_to_clist_next:n
+      {}
+  }
+%    \end{macrocode}
+% \end{macro}
 %
 % \subsection{Messages}
 %

--- a/l3kernel/l3sort.dtx
+++ b/l3kernel/l3sort.dtx
@@ -199,11 +199,26 @@
 % \end{variable}
 % \end{variable}
 %
-% \begin{variable}{\s_@@_mark,\s_@@_stop}
+% \begin{variable}
+%   {
+%     \s_@@_mark,
+%     \s_@@_stop,
+%     \s_@@_merge_exp_mark,
+%     \s_@@_merge_exp_stop,
+%     \s_@@_merge_exp_tail,
+%     \s_@@_merge_exp_list,
+%   }
 %   Internal scan marks.
 %    \begin{macrocode}
 \scan_new:N \s_@@_mark
 \scan_new:N \s_@@_stop
+\cs_if_exist:NT \tex_expanded:D
+  {
+    \scan_new:N \s_@@_merge_exp_mark
+    \scan_new:N \s_@@_merge_exp_stop
+    \scan_new:N \s_@@_merge_exp_tail
+    \scan_new:N \s_@@_merge_exp_list
+  }
 %    \end{macrocode}
 % \end{variable}
 %
@@ -820,14 +835,20 @@
 % sorting lists of more than a few thousand items would exhaust a
 % typical \TeX{}'s memory.
 %
-% \begin{macro}[EXP]{\tl_sort:nN}
+% If the primitive \cs{expanded} is available we can make use of it to propagate
+% expansion without the need to read the entire list at each step. In this case
+% we can use a merge sort implementation which is typically faster than the
+% quicksort implementation discussed above.
+%
+% \begin{macro}[EXP]{\tl_sort:nN,\tl_sort:NN}
 % \begin{macro}[EXP]
 %   {
 %     \@@_quick_prepare:Nnnn,
 %     \@@_quick_prepare_end:NNNnw,
 %     \@@_quick_cleanup:w
 %   }
-%   The code within the \cs{exp_not:f} sorts the list, leaving in most
+%   If \cs{expanded} is not available,
+%   the code within the \cs{exp_not:f} sorts the list, leaving in most
 %   cases a leading \cs{exp_not:f}, which stops the expansion, letting
 %   the result be return within \cs{exp_not:n}.  We filter out the case
 %   of a list with no item, which would otherwise cause problems.  Then
@@ -842,32 +863,61 @@
 %   after \cs{s_@@_mark}, namely removing the trailing \cs{s_@@_stop} and
 %   \cs{s_@@_stop} and leaving \cs{exp_stop_f:} to stop
 %   \texttt{f}-expansion.
+%
+%   In the case that \cs{expanded} is available the expansion is started by
+%   \cs{__kernel_exp_not:w} directly and we use \cs{tex_expanded:D} for the
+%   merge sort iterations. The first bottom up pass differs from the others as
+%   this pass introduces limiters marking the end of each sublist. 
 %    \begin{macrocode}
-\cs_new:Npn \tl_sort:nN #1#2
+\cs_if_exist:NTF \tex_expanded:D
   {
-    \exp_not:f
+    \cs_new:Npn \tl_sort:nN #1#2
       {
-        \tl_if_blank:nF {#1}
-          {
-            \@@_quick_prepare:Nnnn #2 { } { }
-              #1
-              { \prg_break_point: \@@_quick_prepare_end:NNNnw }
-            \s_@@_stop
-          }
+        \__kernel_exp_not:w
+          \exp_after:wN \@@_merge_exp_after_bottom_up_tl:Nw \exp_after:wN #2
+          \tex_expanded:D
+            {
+              \@@_merge_exp_bottom_up_tl:Nnn
+                #2 #1 \s_@@_merge_exp_mark \s_@@_merge_exp_stop
+            }
+      }
+    \cs_new:Npn \tl_sort:NN #1#2
+      {
+        \__kernel_exp_not:w
+          \exp_after:wN \@@_merge_exp_after_bottom_up_tl:Nw \exp_after:wN #2
+          \tex_expanded:D
+            {
+              \exp_after:wN \@@_merge_exp_bottom_up_tl:Nnn \exp_after:wN
+                #2 #1 \s_@@_merge_exp_mark \s_@@_merge_exp_stop
+            }
       }
   }
-\cs_new:Npn \@@_quick_prepare:Nnnn #1#2#3#4
   {
-    \prg_break: #4 \prg_break_point:
-    \@@_quick_prepare:Nnnn #1 { #2 #3 } { #1 {#4} }
-  }
-\cs_new:Npn \@@_quick_prepare_end:NNNnw #1#2#3#4#5 \s_@@_stop
-  {
-    \@@_quick_split:NnNn #4 \@@_quick_end:nnTFNn { }
-    \s_@@_mark { \@@_quick_cleanup:w \exp_stop_f: }
-    \s_@@_mark \s_@@_stop
-  }
-\cs_new:Npn \@@_quick_cleanup:w #1 \s_@@_mark \s_@@_stop {#1}
+    \cs_new:Npn \tl_sort:nN #1#2
+      {
+        \exp_not:f
+          {
+            \tl_if_blank:nF {#1}
+              {
+                \@@_quick_prepare:Nnnn #2 { } { }
+                  #1
+                  { \prg_break_point: \@@_quick_prepare_end:NNNnw }
+                \s_@@_stop
+              }
+          }
+      }
+    \cs_new:Npn \@@_quick_prepare:Nnnn #1#2#3#4
+      {
+        \prg_break: #4 \prg_break_point:
+        \@@_quick_prepare:Nnnn #1 { #2 #3 } { #1 {#4} }
+      }
+    \cs_new:Npn \@@_quick_prepare_end:NNNnw #1#2#3#4#5 \s_@@_stop
+      {
+        \@@_quick_split:NnNn #4 \@@_quick_end:nnTFNn { }
+        \s_@@_mark { \@@_quick_cleanup:w \exp_stop_f: }
+        \s_@@_mark \s_@@_stop
+      }
+    \cs_new:Npn \@@_quick_cleanup:w #1 \s_@@_mark \s_@@_stop {#1}
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -901,41 +951,41 @@
 %   argument is always the user's \meta{conditional} rather than an
 %   ending function.
 %    \begin{macrocode}
-\cs_new:Npn \@@_quick_split:NnNn #1#2#3#4
-  {
-    #3 {#2} {#4} \@@_quick_only_ii:NnnnnNn
-      \@@_quick_only_i:NnnnnNn
-      \@@_quick_single_end:nnnwnw
-      { #3 {#4} } { } { } {#2}
-  }
-\cs_new:Npn \@@_quick_only_i:NnnnnNn #1#2#3#4#5#6#7
-  {
-    #6 {#5} {#7} \@@_quick_split_ii:NnnnnNn
-      \@@_quick_only_i:NnnnnNn
-      \@@_quick_only_i_end:nnnwnw
-      { #6 {#7} } { #3 #2 } { } {#5}
-  }
-\cs_new:Npn \@@_quick_only_ii:NnnnnNn #1#2#3#4#5#6#7
-  {
-    #6 {#5} {#7} \@@_quick_only_ii:NnnnnNn
-      \@@_quick_split_i:NnnnnNn
-      \@@_quick_only_ii_end:nnnwnw
-      { #6 {#7} } { } { #4 #2 } {#5}
-  }
-\cs_new:Npn \@@_quick_split_i:NnnnnNn #1#2#3#4#5#6#7
-  {
-    #6 {#5} {#7} \@@_quick_split_ii:NnnnnNn
-      \@@_quick_split_i:NnnnnNn
-      \@@_quick_split_end:nnnwnw
-      { #6 {#7} } { #3 #2 } {#4} {#5}
-  }
-\cs_new:Npn \@@_quick_split_ii:NnnnnNn #1#2#3#4#5#6#7
-  {
-    #6 {#5} {#7} \@@_quick_split_ii:NnnnnNn
-      \@@_quick_split_i:NnnnnNn
-      \@@_quick_split_end:nnnwnw
-      { #6 {#7} } {#3} { #4 #2 } {#5}
-  }
+    \cs_new:Npn \@@_quick_split:NnNn #1#2#3#4
+      {
+        #3 {#2} {#4} \@@_quick_only_ii:NnnnnNn
+          \@@_quick_only_i:NnnnnNn
+          \@@_quick_single_end:nnnwnw
+          { #3 {#4} } { } { } {#2}
+      }
+    \cs_new:Npn \@@_quick_only_i:NnnnnNn #1#2#3#4#5#6#7
+      {
+        #6 {#5} {#7} \@@_quick_split_ii:NnnnnNn
+          \@@_quick_only_i:NnnnnNn
+          \@@_quick_only_i_end:nnnwnw
+          { #6 {#7} } { #3 #2 } { } {#5}
+      }
+    \cs_new:Npn \@@_quick_only_ii:NnnnnNn #1#2#3#4#5#6#7
+      {
+        #6 {#5} {#7} \@@_quick_only_ii:NnnnnNn
+          \@@_quick_split_i:NnnnnNn
+          \@@_quick_only_ii_end:nnnwnw
+          { #6 {#7} } { } { #4 #2 } {#5}
+      }
+    \cs_new:Npn \@@_quick_split_i:NnnnnNn #1#2#3#4#5#6#7
+      {
+        #6 {#5} {#7} \@@_quick_split_ii:NnnnnNn
+          \@@_quick_split_i:NnnnnNn
+          \@@_quick_split_end:nnnwnw
+          { #6 {#7} } { #3 #2 } {#4} {#5}
+      }
+    \cs_new:Npn \@@_quick_split_ii:NnnnnNn #1#2#3#4#5#6#7
+      {
+        #6 {#5} {#7} \@@_quick_split_ii:NnnnnNn
+          \@@_quick_split_i:NnnnnNn
+          \@@_quick_split_end:nnnwnw
+          { #6 {#7} } {#3} { #4 #2 } {#5}
+      }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -968,34 +1018,309 @@
 %   the pivot are sorted, then items less than the pivot, and the
 %   continuations are done in such a way to place the pivot in between.
 %    \begin{macrocode}
-\cs_new:Npn \@@_quick_end:nnTFNn #1#2#3#4#5#6 {#5}
-\cs_new:Npn \@@_quick_single_end:nnnwnw #1#2#3#4 \s_@@_mark #5#6 \s_@@_stop
-  { #5 {#3} #6 \s_@@_stop }
-\cs_new:Npn \@@_quick_only_i_end:nnnwnw #1#2#3#4 \s_@@_mark #5#6 \s_@@_stop
-  {
-    \@@_quick_split:NnNn #1
-      \@@_quick_end:nnTFNn { } \s_@@_mark {#5}
-    {#3}
-    #6 \s_@@_stop
-  }
-\cs_new:Npn \@@_quick_only_ii_end:nnnwnw #1#2#3#4 \s_@@_mark #5#6 \s_@@_stop
-  {
-    \@@_quick_split:NnNn #2
-      \@@_quick_end:nnTFNn { } \s_@@_mark { #5 {#3} }
-    #6 \s_@@_stop
-  }
-\cs_new:Npn \@@_quick_split_end:nnnwnw #1#2#3#4 \s_@@_mark #5#6 \s_@@_stop
-  {
-    \@@_quick_split:NnNn #2 \@@_quick_end:nnTFNn { } \s_@@_mark
+    \cs_new:Npn \@@_quick_end:nnTFNn #1#2#3#4#5#6 {#5}
+    \cs_new:Npn \@@_quick_single_end:nnnwnw #1#2#3#4 \s_@@_mark #5#6 \s_@@_stop
+      { #5 {#3} #6 \s_@@_stop }
+    \cs_new:Npn \@@_quick_only_i_end:nnnwnw #1#2#3#4 \s_@@_mark #5#6 \s_@@_stop
       {
         \@@_quick_split:NnNn #1
           \@@_quick_end:nnTFNn { } \s_@@_mark {#5}
         {#3}
+        #6 \s_@@_stop
       }
-    #6 \s_@@_stop
+    \cs_new:Npn \@@_quick_only_ii_end:nnnwnw #1#2#3#4 \s_@@_mark #5#6 \s_@@_stop
+      {
+        \@@_quick_split:NnNn #2
+          \@@_quick_end:nnTFNn { } \s_@@_mark { #5 {#3} }
+        #6 \s_@@_stop
+      }
+    \cs_new:Npn \@@_quick_split_end:nnnwnw #1#2#3#4 \s_@@_mark #5#6 \s_@@_stop
+      {
+        \@@_quick_split:NnNn #2 \@@_quick_end:nnTFNn { } \s_@@_mark
+          {
+            \@@_quick_split:NnNn #1
+              \@@_quick_end:nnTFNn { } \s_@@_mark {#5}
+            {#3}
+          }
+        #6 \s_@@_stop
+      }
   }
 %    \end{macrocode}
 % \end{macro}
+%
+%    \begin{macrocode}
+\cs_if_exist:NT \tex_expanded:D
+  {
+%    \end{macrocode}
+%
+% \begin{macro}[EXP]
+%   {\@@_if_stop:w, \@@_if_mark:w, \@@_if_tail:w}
+%   Since the three scan marks are forbidden to appear in the lists we can setup
+%   quick tests by just gobbling everything up until that marker.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_if_stop:w #1 \s_@@_merge_exp_stop {}
+    \cs_new:Npn \@@_if_mark:w #1 \s_@@_merge_exp_mark {}
+    \cs_new:Npn \@@_if_tail:w #1 \s_@@_merge_exp_tail {}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[rEXP]
+%   {
+%     \@@_merge_exp_bottom_up_tl:Nnn,
+%     \@@_merge_exp_bottom_up_tl_mark:w
+%     \@@_merge_exp_bottom_up_tl_stop:w
+%   }
+%   The first bottom up pass grabs two items and sorts them. Markers are placed
+%   to indicate the end of each sublist. Since we grab two items in each
+%   recursion step we have to check both of these values for the end of list
+%   markers. If the input token list has an odd number of elements, |#3| will be
+%   \cs{s_@@_merge_exp_mark} in the last recursion. In this case |#2| will be
+%   the last element and form a sublist with just one element. If the input
+%   token list has an even number of elements, |#3| will be
+%   \cs{s_@@_merge_exp_stop} in the last recursion and we just leave the markers
+%   for the end of sublists.
+%
+%   After the first bottom up pass every sublist will be sorted and followed by
+%   \cs{s_@@_merge_exp_tail}. The sublists are separated by
+%   \cs{s_@@_merge_exp_list}, and the end of sublists is indicated by a sublist
+%   containing only \cs{s_@@_merge_exp_mark} and another one containing
+%   \cs{s_@@_merge_exp_stop}.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_merge_exp_bottom_up_tl:Nnn #1#2#3
+      {
+        \@@_if_stop:w #3 \@@_merge_exp_bottom_up_tl_stop:w \s_@@_merge_exp_stop
+        \@@_if_mark:w #3 \@@_merge_exp_bottom_up_tl_mark:w \s_@@_merge_exp_mark
+        #1 {#2} {#3}
+          { \__kernel_exp_not:w { {#2} {#3} } }
+          { \__kernel_exp_not:w { {#3} {#2} } }
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \@@_merge_exp_bottom_up_tl:Nnn #1
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_tl_stop:w
+        \s_@@_merge_exp_stop
+        \@@_if_mark:w \s_@@_merge_exp_stop \@@_merge_exp_bottom_up_tl_mark:w
+        \s_@@_merge_exp_mark
+        #1
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \@@_merge_exp_bottom_up_tl:Nnn #2
+      {
+        \s_@@_merge_exp_mark \s_@@_merge_exp_list
+        \s_@@_merge_exp_stop \s_@@_merge_exp_list
+      }
+    \cs_new:Npn \@@_merge_exp_bottom_up_tl_mark:w
+        \s_@@_merge_exp_mark
+        #1#2#3
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \@@_merge_exp_bottom_up_tl:Nnn #4
+        \s_@@_merge_exp_stop
+      {
+        { \__kernel_exp_not:w {#2} }
+        \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        \s_@@_merge_exp_mark \s_@@_merge_exp_list
+        \s_@@_merge_exp_stop \s_@@_merge_exp_list
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]
+%   {
+%     \@@_merge_exp_after_bottom_up_tl:Nw,
+%     \@@_merge_exp_after_merge_tl:Nw,
+%     \@@_merge_exp_after_stop:w,
+%     \@@_merge_exp_after_mark_tl:w
+%   }
+%   After the first bottom up pass there can be two special cases for which we
+%   have to test. If the input list was empty the argument |#3| of
+%   \cs{@@_merge_exp_after_bottom_up_tl:Nw} will only contain
+%   \cs{s_@@_merge_exp_stop} in which case the remainder of the sorting macro is
+%   gobbled and an empty group (|{}|) will be left in the input stream for
+%   \cs{__kernel_exp_not:w}. The next special case which is tested in both
+%   \cs{@@_merge_exp_after_bottom_up_tl:Nw} and
+%   \cs{@@_merge_exp_after_merge_tl:Nw} is if we're done and only a single
+%   sublist is remaining, in which case |#3| will be \cs{s_@@_merge_exp_mark}.
+%   When this is encountered the now sorted list is grabbed with the user
+%   provided sorting function infront of it (to prevent any accidental brace
+%   stripping). The remainder of the current recursion is removed and the sorted
+%   list is left in the input stream for \cs{__kernel_exp_not:w} using
+%   \cs{use_none:n} to remove the leading sorting function.
+%
+%   If we're not yet done we call the next merging recursion inside
+%   \cs{tex_expanded:D}.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_merge_exp_after_bottom_up_tl:Nw
+        #1#2 \s_@@_merge_exp_list #3
+      {
+        \@@_if_stop:w #3 \@@_merge_exp_after_stop:w \s_@@_merge_exp_stop
+        \@@_if_mark:w #3 \@@_merge_exp_after_mark_tl:w \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_after_merge_tl:Nw \exp_after:wN #1
+        \tex_expanded:D { \if_false: } \fi:
+          \@@_merge_exp_merge:Nw #1#2 \s_@@_merge_exp_list {#3}
+      }
+    \cs_new:Npn \@@_merge_exp_after_merge_tl:Nw
+        #1#2 \s_@@_merge_exp_list #3
+      {
+        \@@_if_mark:w #3 \@@_merge_exp_after_mark_tl:w \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_after_merge_tl:Nw \exp_after:wN #1
+        \tex_expanded:D { \if_false: } \fi:
+          \@@_merge_exp_merge:Nw #1#2 \s_@@_merge_exp_list {#3}
+      }
+    \cs_new:Npn \@@_merge_exp_after_stop:w
+        \s_@@_merge_exp_stop
+        \@@_if_mark:w \s_@@_merge_exp_stop #1
+        \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_after_merge_tl:Nw \exp_after:wN #2
+        \tex_expanded:D #3 \fi:
+        \@@_merge_exp_merge:Nw #4 \s_@@_merge_exp_mark \s_@@_merge_exp_list #5
+        \s_@@_merge_exp_list
+      {{}}
+    \cs_new:Npn \@@_merge_exp_after_mark_tl:w
+        \s_@@_merge_exp_mark
+        \exp_after:wN \@@_merge_exp_after_merge_tl:Nw \exp_after:wN #1
+        \tex_expanded:D #2 \fi:
+        \@@_merge_exp_merge:Nw #3 \s_@@_merge_exp_tail \s_@@_merge_exp_list
+        #4 \s_@@_merge_exp_list
+        \s_@@_merge_exp_stop \s_@@_merge_exp_list
+      { \exp_after:wN { \use_none:n #3 } }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[rEXP]{\@@_merge_exp_merge:Nw}
+%   Two sublists are merged by taking the first elements from both sublist and
+%   comparing them. \cs{@@_merge_exp_merge:Nw} is only called on two sublists
+%   which are known to be non-empty, so the first step doesn't have to check for
+%   any markers. The first elements of each sublist are compared with the
+%   provided function, \cs{@@_merge_exp_merge_i:Nnnn} and
+%   \cs{@@_merge_exp_merge_ii:Nw} do the branching and grab the next element
+%   from the list. No accidental brace-stripping can happen for |#3| because of
+%   the trailing \cs{s_@@_merge_exp_tail}. The user test in |#1| and the list
+%   elements which were just compared are placed a second time after the test so
+%   that the next steps can use them as arguments.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_merge_exp_merge:Nw #1#2#3 \s_@@_merge_exp_list #4
+      {
+        #1 {#2} {#4}
+          \@@_merge_exp_merge_i:Nnnn
+          \@@_merge_exp_merge_ii:Nw
+        #1 {#2} {#4}
+        #3 \s_@@_merge_exp_list
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[rEXP]
+%   {
+%     \@@_merge_exp_merge_i:Nnnn,
+%     \@@_merge_exp_merge_i_tail:w,
+%     \@@_merge_exp_merge_ii:Nw,
+%     \@@_merge_exp_merge_ii_tail:w
+%   }
+%   \cs{@@_merge_exp_merge_i:Nnnn} is called when the element of the first
+%   sublist should be placed next. After that is done we have to check whether
+%   the first sublist is completely processed in which case
+%   \cs{@@_merge_exp_merge_i_tail:w} is called. Else we just do the next
+%   comparison.
+%
+%   \cs{@@_merge_exp_merge_i_tail:w} places the remainder of the second sublist
+%   after the now completely sorted merged list. Then the next two sublists
+%   should be merged by \cs{@@_merge_exp_merge_next:Nw}.
+%
+%   \cs{@@_merge_exp_merge_ii:Nw} and \cs{@@_merge_exp_merge_ii_tail:w} work
+%   pretty similar. The big difference is that \cs{@@_merge_exp_merge_ii:Nw}
+%   needs to grab the entire first sublist to get the next element from the
+%   second.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_merge_exp_merge_i:Nnnn #1#2#3#4
+      {
+        { \__kernel_exp_not:w {#2} }
+        \@@_if_tail:w #4 \@@_merge_exp_merge_i_tail:w \s_@@_merge_exp_tail
+        #1 {#4} {#3}
+          \@@_merge_exp_merge_i:Nnnn
+          \@@_merge_exp_merge_ii:Nw
+        #1 {#4} {#3}
+      }
+    \cs_new:Npn \@@_merge_exp_merge_i_tail:w
+        \s_@@_merge_exp_tail
+        #1#2#3 \@@_merge_exp_merge_i:Nnnn \@@_merge_exp_merge_ii:Nw
+        #4
+        \s_@@_merge_exp_list
+        #5 \s_@@_merge_exp_list
+      {
+        \__kernel_exp_not:w { {#3} #5 } \s_@@_merge_exp_list
+        \@@_merge_exp_merge_next:Nw #1
+      }
+    \cs_new:Npn \@@_merge_exp_merge_ii:Nw #1#2#3#4 \s_@@_merge_exp_list #5
+      {
+        { \__kernel_exp_not:w {#3} }
+        \@@_if_tail:w #5 \@@_merge_exp_merge_ii_tail:w \s_@@_merge_exp_tail
+        #1 {#2} {#5}
+          \@@_merge_exp_merge_i:Nnnn
+          \@@_merge_exp_merge_ii:Nw
+        #1 {#2} {#5}
+        #4 \s_@@_merge_exp_list
+      }
+    \cs_new:Npn \@@_merge_exp_merge_ii_tail:w
+        \s_@@_merge_exp_tail
+        #1#2#3 \@@_merge_exp_merge_i:Nnnn \@@_merge_exp_merge_ii:Nw
+        #4#5#6
+        #7 \s_@@_merge_exp_list
+        \s_@@_merge_exp_list
+      {
+        \__kernel_exp_not:w { {#2} #7 } \s_@@_merge_exp_list
+        \@@_merge_exp_merge_next:Nw #1
+      }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[rEXP]
+%   {
+%     \@@_merge_exp_merge_next:Nw,
+%     \@@_merge_exp_merge_next_stop:w,
+%     \@@_merge_exp_merge_next_mark:w,
+%   }
+%   \cs{@@_merge_exp_merge_next:Nw} is pretty much the same as
+%   \cs{@@_merge_exp_merge:Nw} but it has to check whether we're done with the
+%   current merging iteration. There are two cases, either the number of
+%   sublists was even, in which case |#4| will be \cs{s_@@_merge_exp_stop} and
+%   we're completely done, so we're ending the \cs{tex_expanded:D} expansion
+%   by leaving a closing brace and place the markers we just gobbled back at the
+%   end of the sublists. If the number of sublists was odd |#4| will be
+%   \cs{s_@@_merge_exp_mark} and |{#2}#3| will be the last sublist. The macro
+%   \cs{@@_merge_exp_merge_next_mark:w} will put this last sublist back and end
+%   the \cs{tex_expanded:D} expansion.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_merge_exp_merge_next:Nw #1#2#3 \s_@@_merge_exp_list #4
+      {
+        \@@_if_stop:w #4 \@@_merge_exp_merge_next_stop:w \s_@@_merge_exp_stop
+        \@@_if_mark:w #4 \@@_merge_exp_merge_next_mark:w \s_@@_merge_exp_mark
+        #1 {#2} {#4}
+          \@@_merge_exp_merge_i:Nnnn
+          \@@_merge_exp_merge_ii:Nw
+        #1 {#2} {#4}
+        #3 \s_@@_merge_exp_list
+      }
+    \cs_new:Npn \@@_merge_exp_merge_next_stop:w
+        \s_@@_merge_exp_stop
+        \@@_if_mark:w \s_@@_merge_exp_stop \@@_merge_exp_merge_next_mark:w
+        \s_@@_merge_exp_mark
+        #1 \@@_merge_exp_merge_i:Nnnn \@@_merge_exp_merge_ii:Nw
+        #2 \s_@@_merge_exp_list
+      {
+        \if_false: { \fi: }
+        \s_@@_merge_exp_mark \s_@@_merge_exp_list \s_@@_merge_exp_stop
+      }
+    \cs_new:Npn \@@_merge_exp_merge_next_mark:w
+        \s_@@_merge_exp_mark
+        #1#2#3 \@@_merge_exp_merge_i:Nnnn \@@_merge_exp_merge_ii:Nw
+        #4#5#6
+        #7 \s_@@_merge_exp_list
+      {
+        \if_false: { \fi: }
+        {#2} #7 \s_@@_merge_exp_list \s_@@_merge_exp_mark
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 %
 % \subsection{Messages}
 %

--- a/l3kernel/l3sort.dtx
+++ b/l3kernel/l3sort.dtx
@@ -840,7 +840,7 @@
 % we can use a merge sort implementation which is typically faster than the
 % quicksort implementation discussed above.
 %
-% \begin{macro}[EXP]{\tl_sort:nN,\tl_sort:NN}
+% \begin{macro}[EXP]{\tl_sort:nN,\tl_sort:oN,\tl_sort:NN}
 % \begin{macro}[EXP]
 %   {
 %     \@@_quick_prepare:Nnnn,
@@ -881,7 +881,7 @@
                 #2 #1 \s_@@_merge_exp_mark \s_@@_merge_exp_stop
             }
       }
-    \cs_new:Npn \tl_sort:NN #1#2
+    \cs_new:Npn \tl_sort:oN #1#2
       {
         \__kernel_exp_not:w
           \exp_after:wN \@@_merge_exp_after_bottom_up_tl:Nw \exp_after:wN #2
@@ -891,6 +891,7 @@
                 #2 #1 \s_@@_merge_exp_mark \s_@@_merge_exp_stop
             }
       }
+    \cs_new_eq:NN \tl_sort:NN \tl_sort:oN
   }
   {
     \cs_new:Npn \tl_sort:nN #1#2
@@ -906,6 +907,8 @@
               }
           }
       }
+    \cs_generate_variant:Nn \tl_sort:nN { oN }
+    \cs_new_eq:NN \tl_sort:NN \tl_sort:oN
     \cs_new:Npn \@@_quick_prepare:Nnnn #1#2#3#4
       {
         \prg_break: #4 \prg_break_point:

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -873,7 +873,7 @@
 %   described in Section~\ref{sec:l3sort:mech}.
 % \end{function}
 %
-% \begin{function}[added = 2017-02-06, EXP]{\tl_sort:nN}
+% \begin{function}[added = 2017-02-06, EXP]{\tl_sort:nN, \tl_sort:oN}
 %   \begin{syntax}
 %     \cs{tl_sort:nN} \Arg{token list} \meta{conditional}
 %   \end{syntax}
@@ -884,6 +884,19 @@
 %   left in the same order, and \texttt{false} if the items should be
 %   swapped. The details of sorting comparison are
 %   described in Section~\ref{sec:l3sort:mech}.
+%   \begin{texnote}
+%     The result is returned within \cs{exp_not:n}, which means that the
+%     token list does not expand further when appearing in an
+%     \texttt{x}-type or \texttt{e}-type argument expansion.
+%   \end{texnote}
+% \end{function}
+%
+% \begin{function}[added = 2021-01-23, EXP]{\tl_sort:NN}
+%   \begin{syntax}
+%     \cs{tl_sort:NN} \meta{tl var} \meta{conditional}
+%   \end{syntax}
+%   Like \cs{tl_sort:nN} but this sorts a \meta{tl var}, leaving the result in
+%   the input stream.
 %   \begin{texnote}
 %     The result is returned within \cs{exp_not:n}, which means that the
 %     token list does not expand further when appearing in an
@@ -2801,7 +2814,10 @@
 % \end{macro}
 %
 % \begin{macro}
-%   {\tl_sort:Nn, \tl_sort:cn, \tl_gsort:Nn, \tl_gsort:cn, \tl_sort:nN}
+%   {
+%     \tl_sort:Nn, \tl_sort:cn, \tl_gsort:Nn, \tl_gsort:cn,
+%     \tl_sort:nN, \tl_sort:oN, \tl_sort:NN
+%   }
 %   Implemented in \pkg{l3sort}.
 % \end{macro}
 %

--- a/l3kernel/testfiles/m3quark001.tlg
+++ b/l3kernel/testfiles/m3quark001.tlg
@@ -131,6 +131,10 @@ already been used for a scan mark.
 \s__fp_tuple 
 \s__sort_mark 
 \s__sort_stop 
+\s__sort_merge_exp_mark 
+\s__sort_merge_exp_stop 
+\s__sort_merge_exp_tail 
+\s__sort_merge_exp_list 
 \s__str 
 \s__tl 
 \s__color_stop 

--- a/l3kernel/testfiles/m3sort002.lvt
+++ b/l3kernel/testfiles/m3sort002.lvt
@@ -29,6 +29,16 @@
     \NEWLINE
     \tl_sort:nN { {a\par b} } \ERROR
     \NEWLINE
+    \tl_sort:nN { 81 } \test_compare:nnTF
+    \NEWLINE
+    \tl_sort:nN { 815 } \test_compare:nnTF
+    \NEWLINE
+    \tl_sort:nN { {\if_true: 8\fi:}15 } \test_compare:nnTF
+    \NEWLINE
+    \tl_sort:nN { {\if_true: 8\else: 6\fi:}15 } \test_compare:nnTF
+    \NEWLINE
+    \tl_sort:nN { {\if_false: 8\else: 6\fi:}15 } \test_compare:nnTF
+    \NEWLINE
     \tl_sort:nN { 8{+2}3461{-0}2{00}3748 } \test_compare:nnTF
     \NEWLINE
     \exp_args:Nf \tl_sort:nN
@@ -50,7 +60,42 @@
 \TIMO
 
 \TESTEXP { More~expandable~sorting }
-  { \exp_args:No \tl_sort:nN \l_tmpa_tl \test_compare:nnTF }
+  {
+    \exp_args:No \tl_sort:nN \l_tmpa_tl \test_compare:nnTF
+  }
 
+\OMIT
+\prg_set_conditional:Npnn \test_compare:nn #1#2 { TF }
+  {
+    \if_int_compare:w 
+        \__str_if_eq:nn { \tl_to_str:n {#1} } { \tl_to_str:n {#2} }
+        > 0 \exp_stop_f:
+      \prg_return_false:
+    \else:
+      \prg_return_true:
+    \fi:
+  }
+\TIMO
+
+\TESTEXP { Sorting~unbalanced~conditionals }
+  {
+    \tl_sort:nN { \if_true: \if_false: \else: \fi: } \test_compare:nnTF
+  }
+
+\OMIT
+\box_new:N \l_test_box
+\TIMO
+
+\TEST { halign~robust }
+  {
+    \vbox_set:Nn \l_test_box
+      {
+        \tex_halign:D { \TYPE{0} # \TYPE{1} & # \ERROR \tex_cr:D
+          \exp_after:wN \use_none:nnnn
+          \exp:w \exp_end_continue_f:w
+          \tl_sort:nN { & & \tex_cr:D \tex_cr:D } \test_compare:nnTF
+          \tex_cr:D }
+      }
+  }
 
 \END

--- a/l3kernel/testfiles/m3sort002.tlg
+++ b/l3kernel/testfiles/m3sort002.tlg
@@ -6,6 +6,11 @@ TEST 1: Sort expandably
 ============================================================
 ||
 {a\par b}
+{1}{8}
+{1}{5}{8}
+{1}{5}{\if_true: 8\fi: }
+{1}{5}{\if_true: 8\else: 6\fi: }
+{1}{5}{\if_false: 8\else: 6\fi: }
 {-0}{00}{1}{+2}{2}{3}{3}{4}{4}{6}{7}{8}{8}
 {-0}{00}{-0}{00}{-0}{00}{-0}{00}{-0}{00}{-0}{00}{-0}{00}{-0}{00}{-0}{00}{-0}{00}{1}{1}{1}{1}{1}{1}{1}{1}{1}{1}{+2}{2}{+2}{2}{+2}{2}{+2}{2}{+2}{2}{+2}{2}{+2}{2}{+2}{2}{+2}{2}{+2}{2}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{3}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{4}{6}{6}{6}{6}{6}{6}{6}{6}{6}{6}{7}{7}{7}{7}{7}{7}{7}{7}{7}{7}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}{8}
 ============================================================
@@ -13,4 +18,15 @@ TEST 1: Sort expandably
 TEST 2: More expandable sorting
 ============================================================
 {cc}{cccii}{cccl}{cccliii}{ccclix}{ccclvi}{ccclxii}{ccclxv}{ccclxviii}{ccclxxi}{ccclxxiv}{ccclxxvii}{ccclxxx}{ccclxxxiii}{ccclxxxix}{ccclxxxvi}{cccv}{cccviii}{cccxcii}{cccxcv}{cccxcviii}{cccxi}{cccxiv}{cccxli}{cccxliv}{cccxlvii}{cccxvii}{cccxx}{cccxxiii}{cccxxix}{cccxxvi}{cccxxxii}{cccxxxv}{cccxxxviii}{cciii}{ccix}{ccli}{ccliv}{cclvii}{cclx}{cclxiii}{cclxix}{cclxvi}{cclxxii}{cclxxv}{cclxxviii}{cclxxxi}{cclxxxiv}{cclxxxvii}{ccvi}{ccxc}{ccxciii}{ccxcix}{ccxcvi}{ccxii}{ccxlii}{ccxlv}{ccxlviii}{ccxv}{ccxviii}{ccxxi}{ccxxiv}{ccxxvii}{ccxxx}{ccxxxiii}{ccxxxix}{ccxxxvi}{cdi}{cdiv}{cdvii}{cdx}{cdxiii}{cdxix}{cdxvi}{cdxxii}{cdxxv}{cdxxviii}{cdxxxi}{ci}{civ}{clii}{clv}{clviii}{clxi}{clxiv}{clxvii}{clxx}{clxxiii}{clxxix}{clxxvi}{clxxxii}{clxxxv}{clxxxviii}{cvii}{cx}{cxci}{cxciv}{cxcvii}{cxiii}{cxix}{cxl}{cxliii}{cxlix}{cxlvi}{cxvi}{cxxii}{cxxv}{cxxviii}{cxxxi}{cxxxiv}{cxxxvii}{l}{liii}{lix}{lvi}{lxii}{lxv}{lxviii}{lxxi}{lxxiv}{lxxvii}{lxxx}{lxxxiii}{lxxxix}{lxxxvi}{v}{viii}{xcii}{xcv}{xcviii}{xi}{xiv}{xli}{xliv}{xlvii}{xvii}{xx}{xxiii}{xxix}{xxvi}{xxxii}{xxxv}{xxxviii}
+============================================================
+============================================================
+TEST 3: Sorting unbalanced conditionals
+============================================================
+{\else: }{\fi: }{\if_false: }{\if_true: }
+============================================================
+============================================================
+TEST 4: halign robust
+============================================================
+0
+1
 ============================================================


### PR DESCRIPTION
This PR adds a code variant for `\tl_sort:nN` making use of `\expanded` when it's available, as a result speeding up the code considerably (almost 30 times faster for 10000 items, 1.6 times fast for 1 element).

It also adds an expandable variant to sort `clist`s, which is a bit slower because it has to sanitize a `clist` and convert the sorting result from a sorted token list to a `clist` again. The variant without `\expanded` is pretty simple, the variant with `\expanded` is much more complicated, incorporating the input sanitisation. The code could be reduced by using `\clist_map_function:nN`similar to how it is done for the variant without `\expanded`.