### PR TITLE
Split kernel messages by module

### DIFF
--- a/l3experimental/l3benchmark/l3benchmark.dtx
+++ b/l3experimental/l3benchmark/l3benchmark.dtx
@@ -199,18 +199,18 @@
 %   commands to produce errors.
 %    \begin{macrocode}
   {
-    \__kernel_msg_new:nnnn { kernel } { no-elapsed-time }
+    \__kernel_msg_new:nnnn { benchmark } { no-elapsed-time }
       { No~clock~detected~for~#1. }
       { The~current~engine~provides~no~way~to~access~the~system~time. }
     \cs_new_protected:Npn \sys_gzero_timer:
       {
-        \__kernel_msg_error:nnn { kernel } { no-elapsed-time }
+        \__kernel_msg_error:nnn { benchmark } { no-elapsed-time }
           { \sys_gzero_timer: }
       }
     \cs_new:Npn \sys_timer:
       {
         \int_value:w
-        \__kernel_msg_expandable_error:nnn { kernel } { no-elapsed-time }
+        \__kernel_msg_expandable_error:nnn { benchmark } { no-elapsed-time }
           { \sys_timer: }
         \c_zero_int
       }

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1943,7 +1943,7 @@
       { \@@_generate_conditional:nnNNNnnn {#1} {#2} #3 #4 #5 }
       { \tl_count:n {#2} }
       {
-        \__kernel_msg_error:nnxx { cs } { bad-number-of-arguments }
+        \__kernel_msg_error:nnxx { kernel } { bad-number-of-arguments }
           { \token_to_str:c { #1 : #2 } }
           { \tl_count:n {#2} }
         \use_none:nn

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1510,7 +1510,7 @@
 %   This is here as this particular integer is needed both in package
 %   mode and to bootstrap \pkg{l3alloc}, and is documented in \pkg{l3int}.
 %   \LuaTeX{} and those which contain parts of the Omega extensions have
-%   more registers available than \eTeX{}. 
+%   more registers available than \eTeX{}.
 %    \begin{macrocode}
 \tex_ifdefined:D \tex_luatexversion:D
   \tex_chardef:D \c_max_register_int = 65 535 ~
@@ -1765,12 +1765,12 @@
 %    \begin{macrocode}
 \cs_set_protected:Npn \debug_on:n #1
   {
-    \__kernel_msg_error:nnx { kernel } { enable-debug }
+    \__kernel_msg_error:nnx { debug } { enable-debug }
       { \tl_to_str:n { \debug_on:n {#1} } }
   }
 \cs_set_protected:Npn \debug_off:n #1
   {
-    \__kernel_msg_error:nnx { kernel } { enable-debug }
+    \__kernel_msg_error:nnx { debug } { enable-debug }
        { \tl_to_str:n { \debug_off:n {#1} } }
   }
 %    \end{macrocode}
@@ -1943,7 +1943,7 @@
       { \@@_generate_conditional:nnNNNnnn {#1} {#2} #3 #4 #5 }
       { \tl_count:n {#2} }
       {
-        \__kernel_msg_error:nnxx { kernel } { bad-number-of-arguments }
+        \__kernel_msg_error:nnxx { cs } { bad-number-of-arguments }
           { \token_to_str:c { #1 : #2 } }
           { \tl_count:n {#2} }
         \use_none:nn
@@ -2183,7 +2183,7 @@
         \tl_if_empty:nF {#6}
           {
             \__kernel_msg_error:nnxx
-              { kernel } { conditional-form-unknown }
+              { prg } { conditional-form-unknown }
               {#6} { \token_to_str:c { #1 : #2 } }
           }
         \use_none:nnnnnn

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -2183,7 +2183,7 @@
         \tl_if_empty:nF {#6}
           {
             \__kernel_msg_error:nnxx
-              { prg } { conditional-form-unknown }
+              { kernel } { conditional-form-unknown }
               {#6} { \token_to_str:c { #1 : #2 } }
           }
         \use_none:nnnnnn

--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -1235,18 +1235,18 @@
   {
     \sys_if_shell:TF
       { \exp_args:No \@@_shell_open:nN { \tl_to_str:n {#2} } #1 }
-      { \__kernel_msg_error:nn { kernel } { pipe-failed } }
+      { \__kernel_msg_error:nn { ior } { pipe-failed } }
   }
 \cs_new_protected:Npn \@@_shell_open:nN #1#2
   {
     \tl_if_in:nnTF {#1} { " }
       {
         \__kernel_msg_error:nnx
-          { kernel } { quote-in-shell } {#1}
+          { ior } { quote-in-shell } {#1}
       }
       { \__kernel_ior_open:Nn #2 { |#1 } }
   }
-\__kernel_msg_new:nnnn { kernel } { pipe-failed }
+\__kernel_msg_new:nnnn { ior } { pipe-failed }
   { Cannot~run~piped~system~commands. }
   {
     LaTeX~tried~to~call~a~system~process~but~this~was~not~possible.\\

--- a/l3kernel/l3cctab.dtx
+++ b/l3kernel/l3cctab.dtx
@@ -533,7 +533,7 @@
           { \@@_nesting_number:N \l_@@_internal_a_tl }
         \@@_select:N \l_@@_internal_a_tl
       }
-      { \__kernel_msg_error:nn { kernel } { cctab-extra-end } }
+      { \__kernel_msg_error:nn { cctab } { extra-end } }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -613,7 +613,7 @@
       }
       { \cs_if_exist_p:c { @@_group_ #1 _chk: } }
       {
-        \__kernel_msg_error:nnx { kernel } { cctab-group-mismatch }
+        \__kernel_msg_error:nnx { cctab } { group-mismatch }
           {
             \int_sign:n
               { \tex_currentgrouplevel:D - \l_@@_internal_b_tl }
@@ -652,10 +652,10 @@
 %    \begin{macrocode}
 \cs_if_exist:NT \hook_gput_code:nnn
   {
-    \hook_gput_code:nnn { enddocument/end } { kernel }
+    \hook_gput_code:nnn { enddocument/end } { cctab }
       {
         \seq_if_empty:NF \g_@@_stack_seq
-          { \__kernel_msg_error:nn { kernel } { cctab-missing-end } }
+          { \__kernel_msg_error:nn { cctab } { missing-end } }
       }
   }
 %    \end{macrocode}
@@ -689,7 +689,7 @@
         \@@_chk_if_valid_aux:NTF #1
           { \prg_return_true: }
           {
-            \__kernel_msg_error:nnx { kernel } { invalid-cctab }
+            \__kernel_msg_error:nnx { cctab } { invalid-cctab }
               { \token_to_str:N #1 }
             \prg_return_false:
           }
@@ -830,32 +830,32 @@
 % \subsection{Messages}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { cctab-stack-full }
+\__kernel_msg_new:nnnn { cctab } { stack-full }
   { The~category~code~table~stack~is~exhausted. }
   {
     LaTeX~has~been~asked~to~switch~to~a~new~category~code~table,~
     but~there~is~no~more~space~to~do~this!
   }
-\__kernel_msg_new:nnnn { kernel } { cctab-extra-end }
+\__kernel_msg_new:nnnn { cctab } { extra-end }
   { Extra~\iow_char:N\\cctab_end:~ignored~\msg_line_context:. }
   {
     LaTeX~came~across~a~\iow_char:N\\cctab_end:~without~a~matching~
     \iow_char:N\\cctab_begin:N.~This~command~will~be~ignored.
   }
-\__kernel_msg_new:nnnn { kernel } { cctab-missing-end }
+\__kernel_msg_new:nnnn { cctab } { missing-end }
   { Missing~\iow_char:N\\cctab_end:~before~end~of~TeX~run. }
   {
     LaTeX~came~across~more~\iow_char:N\\cctab_begin:N~than~
     \iow_char:N\\cctab_end:.
   }
-\__kernel_msg_new:nnnn { kernel } { invalid-cctab }
+\__kernel_msg_new:nnnn { cctab } { invalid-cctab }
   { Invalid~\iow_char:N\\catcode~table. }
   {
     You~can~only~switch~to~a~\iow_char:N\\catcode~table~that~is~
     initialized~using~\iow_char:N\\cctab_new:N~or~
     \iow_char:N\\cctab_const:Nn.
   }
-\__kernel_msg_new:nnnn { kernel } { cctab-group-mismatch }
+\__kernel_msg_new:nnnn { cctab } { group-mismatch }
   {
     \iow_char:N\\cctab_end:~occurred~in~a~
     \int_case:nn {#1}

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -2012,15 +2012,15 @@
 %   Apply the general \cs{__kernel_chk_defined:NT} and
 %   \cs{msg_show:nnnnnn}.
 %    \begin{macrocode}
-\cs_new_protected:Npn \clist_show:N { \@@_show:NN \msg_show:nnxxxx }
+\cs_new_protected:Npn \clist_show:N { \@@_show:NN \__kernel_msg_show:nnxxxx }
 \cs_generate_variant:Nn \clist_show:N { c }
-\cs_new_protected:Npn \clist_log:N { \@@_show:NN \msg_log:nnxxxx }
+\cs_new_protected:Npn \clist_log:N { \@@_show:NN \__kernel_msg_log:nnxxxx }
 \cs_generate_variant:Nn \clist_log:N { c }
 \cs_new_protected:Npn \@@_show:NN #1#2
   {
     \__kernel_chk_defined:NT #2
       {
-        #1 { LaTeX / clist } { show }
+        #1 { clist } { show }
           { \token_to_str:N #2 }
           { \clist_map_function:NN #2 \msg_show_item:n }
           { } { }
@@ -2033,11 +2033,11 @@
 %   A variant of the above: no existence check, empty first argument for
 %   the message.
 %    \begin{macrocode}
-\cs_new_protected:Npn \clist_show:n { \@@_show:Nn \msg_show:nnxxxx }
-\cs_new_protected:Npn \clist_log:n { \@@_show:Nn \msg_log:nnxxxx }
+\cs_new_protected:Npn \clist_show:n { \@@_show:Nn \__kernel_msg_show:nnxxxx }
+\cs_new_protected:Npn \clist_log:n { \@@_show:Nn \__kernel_msg_log:nnxxxx }
 \cs_new_protected:Npn \@@_show:Nn #1#2
   {
-    #1 { LaTeX / clist } { show }
+    #1 { clist } { show }
       { } { \clist_map_function:nN {#2} \msg_show_item:n } { } { }
   }
 %    \end{macrocode}

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -2020,7 +2020,7 @@
   {
     \__kernel_chk_defined:NT #2
       {
-        #1 { LaTeX/kernel } { show-clist }
+        #1 { LaTeX / clist } { show }
           { \token_to_str:N #2 }
           { \clist_map_function:NN #2 \msg_show_item:n }
           { } { }
@@ -2037,7 +2037,7 @@
 \cs_new_protected:Npn \clist_log:n { \@@_show:Nn \msg_log:nnxxxx }
 \cs_new_protected:Npn \@@_show:Nn #1#2
   {
-    #1 { LaTeX/kernel } { show-clist }
+    #1 { LaTeX / clist } { show }
       { } { \clist_map_function:nN {#2} \msg_show_item:n } { } { }
   }
 %    \end{macrocode}

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -566,7 +566,7 @@
     \coffin_if_exist:NTF #1
       { #2 }
       {
-        \__kernel_msg_error:nnx { coffin } { unknown-coffin }
+        \__kernel_msg_error:nnx { coffin } { unknown }
           { \token_to_str:N #1 }
       }
   }
@@ -913,7 +913,7 @@
     \prop_get:cnNF
       { coffin ~ \@@_to_value:N #1 ~ poles } {#2} #3
       {
-        \__kernel_msg_error:nnxx { coffin } { unknown-coffin-pole }
+        \__kernel_msg_error:nnxx { coffin } { unknown-pole }
           { \exp_not:n {#2} } { \token_to_str:N #1 }
         \tl_set:Nn #3 { { 0pt } { 0pt } { 0pt } { 0pt } }
       }
@@ -2463,7 +2463,7 @@
   {
     \@@_if_exist:NT #2
       {
-        #1 { coffin } { show-coffin }
+        #1 { coffin } { show }
           { \token_to_str:N #2 }
           {
             \iow_newline: >~ ht ~=~ \dim_eval:n { \coffin_ht:N #2 }
@@ -2491,16 +2491,16 @@
     but~they~do~not~have~a~unique~meeting~point:~
     the~value~(0pt,~0pt)~will~be~used.
   }
-\__kernel_msg_new:nnnn { coffin } { unknown-coffin }
+\__kernel_msg_new:nnnn { coffin } { unknown }
   { Unknown~coffin~'#1'. }
   { The~coffin~'#1'~was~never~defined. }
-\__kernel_msg_new:nnnn { coffin } { unknown-coffin-pole }
+\__kernel_msg_new:nnnn { coffin } { unknown-pole }
   { Pole~'#1'~unknown~for~coffin~'#2'. }
   {
     LaTeX~was~asked~to~find~a~typesetting~pole~for~a~coffin,~
     but~either~the~coffin~does~not~exist~or~the~pole~name~is~wrong.
   }
-\__kernel_msg_new:nnn { coffin } { show-coffin }
+\__kernel_msg_new:nnn { coffin } { show }
   {
     Size~of~coffin~#1 : #2 \\
     Poles~of~coffin~#1 : #3 .

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -2454,16 +2454,16 @@
 %   structure then the code complains.
 %    \begin{macrocode}
 \cs_new_protected:Npn \coffin_show_structure:N
-  { \@@_show_structure:NN \msg_show:nnxxxx }
+  { \@@_show_structure:NN \__kernel_msg_show:nnxxxx }
 \cs_generate_variant:Nn \coffin_show_structure:N { c }
 \cs_new_protected:Npn \coffin_log_structure:N
-  { \@@_show_structure:NN \msg_log:nnxxxx }
+  { \@@_show_structure:NN \__kernel_msg_log:nnxxxx }
 \cs_generate_variant:Nn \coffin_log_structure:N { c }
 \cs_new_protected:Npn \@@_show_structure:NN #1#2
   {
     \@@_if_exist:NT #2
       {
-        #1 { LaTeX / coffins } { show-coffin }
+        #1 { coffins } { show-coffin }
           { \token_to_str:N #2 }
           {
             \iow_newline: >~ ht ~=~ \dim_eval:n { \coffin_ht:N #2 }

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -566,7 +566,7 @@
     \coffin_if_exist:NTF #1
       { #2 }
       {
-        \__kernel_msg_error:nnx { coffins } { unknown-coffin }
+        \__kernel_msg_error:nnx { coffin } { unknown-coffin }
           { \token_to_str:N #1 }
       }
   }
@@ -913,7 +913,7 @@
     \prop_get:cnNF
       { coffin ~ \@@_to_value:N #1 ~ poles } {#2} #3
       {
-        \__kernel_msg_error:nnxx { coffins } { unknown-coffin-pole }
+        \__kernel_msg_error:nnxx { coffin } { unknown-coffin-pole }
           { \exp_not:n {#2} } { \token_to_str:N #1 }
         \tl_set:Nn #3 { { 0pt } { 0pt } { 0pt } { 0pt } }
       }
@@ -1147,7 +1147,7 @@
         \l_@@_pole_a_tl \l_@@_pole_b_tl
     \bool_if:NT \l_@@_error_bool
       {
-        \__kernel_msg_error:nn { coffins } { no-pole-intersection }
+        \__kernel_msg_error:nn { coffin } { no-pole-intersection }
         \dim_zero:N \l_@@_x_dim
         \dim_zero:N \l_@@_y_dim
       }
@@ -2463,7 +2463,7 @@
   {
     \@@_if_exist:NT #2
       {
-        #1 { coffins } { show-coffin }
+        #1 { coffin } { show-coffin }
           { \token_to_str:N #2 }
           {
             \iow_newline: >~ ht ~=~ \dim_eval:n { \coffin_ht:N #2 }
@@ -2484,23 +2484,23 @@
 % \subsection{Messages}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { coffins } { no-pole-intersection }
+\__kernel_msg_new:nnnn { coffin } { no-pole-intersection }
   { No~intersection~between~coffin~poles. }
   {
     LaTeX~was~asked~to~find~the~intersection~between~two~poles,~
     but~they~do~not~have~a~unique~meeting~point:~
     the~value~(0pt,~0pt)~will~be~used.
   }
-\__kernel_msg_new:nnnn { coffins } { unknown-coffin }
+\__kernel_msg_new:nnnn { coffin } { unknown-coffin }
   { Unknown~coffin~'#1'. }
   { The~coffin~'#1'~was~never~defined. }
-\__kernel_msg_new:nnnn { coffins } { unknown-coffin-pole }
+\__kernel_msg_new:nnnn { coffin } { unknown-coffin-pole }
   { Pole~'#1'~unknown~for~coffin~'#2'. }
   {
     LaTeX~was~asked~to~find~a~typesetting~pole~for~a~coffin,~
     but~either~the~coffin~does~not~exist~or~the~pole~name~is~wrong.
   }
-\__kernel_msg_new:nnn { coffins } { show-coffin }
+\__kernel_msg_new:nnn { coffin } { show-coffin }
   {
     Size~of~coffin~#1 : #2 \\
     Poles~of~coffin~#1 : #3 .

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -566,7 +566,7 @@
     \coffin_if_exist:NTF #1
       { #2 }
       {
-        \__kernel_msg_error:nnx { kernel } { unknown-coffin }
+        \__kernel_msg_error:nnx { coffins } { unknown-coffin }
           { \token_to_str:N #1 }
       }
   }
@@ -913,7 +913,7 @@
     \prop_get:cnNF
       { coffin ~ \@@_to_value:N #1 ~ poles } {#2} #3
       {
-        \__kernel_msg_error:nnxx { kernel } { unknown-coffin-pole }
+        \__kernel_msg_error:nnxx { coffins } { unknown-coffin-pole }
           { \exp_not:n {#2} } { \token_to_str:N #1 }
         \tl_set:Nn #3 { { 0pt } { 0pt } { 0pt } { 0pt } }
       }
@@ -1147,7 +1147,7 @@
         \l_@@_pole_a_tl \l_@@_pole_b_tl
     \bool_if:NT \l_@@_error_bool
       {
-        \__kernel_msg_error:nn { kernel } { no-pole-intersection }
+        \__kernel_msg_error:nn { coffins } { no-pole-intersection }
         \dim_zero:N \l_@@_x_dim
         \dim_zero:N \l_@@_y_dim
       }
@@ -1677,7 +1677,7 @@
   }
 \cs_generate_variant:Nn \coffin_gresize:Nnn { c }
 \cs_new_protected:Npn \@@_resize:NnnNN #1#2#3#4#5
-  {  
+  {
     \fp_set:Nn \l_@@_scale_x_fp
       { \dim_to_fp:n {#2} / \dim_to_fp:n { \coffin_wd:N #1 } }
     \fp_set:Nn \l_@@_scale_y_fp
@@ -1720,7 +1720,7 @@
     #4 { coffin ~ \@@_to_value:N #1 ~ corners }
       \l_@@_corners_prop
     #4 { coffin ~ \@@_to_value:N #1 ~ poles }
-      \l_@@_poles_prop  
+      \l_@@_poles_prop
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1950,7 +1950,7 @@
     \@@_reset_structure:N \l_@@_aligned_coffin
     \prop_set_eq:cc
       {
-        coffin ~ \@@_to_value:N \l_@@_aligned_coffin 
+        coffin ~ \@@_to_value:N \l_@@_aligned_coffin
         \c_space_tl corners
       }
       { coffin ~ \@@_to_value:N #1 ~ corners }
@@ -2463,7 +2463,7 @@
   {
     \@@_if_exist:NT #2
       {
-        #1 { LaTeX / kernel } { show-coffin }
+        #1 { LaTeX / coffins } { show-coffin }
           { \token_to_str:N #2 }
           {
             \iow_newline: >~ ht ~=~ \dim_eval:n { \coffin_ht:N #2 }
@@ -2484,23 +2484,23 @@
 % \subsection{Messages}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { no-pole-intersection }
+\__kernel_msg_new:nnnn { coffins } { no-pole-intersection }
   { No~intersection~between~coffin~poles. }
   {
     LaTeX~was~asked~to~find~the~intersection~between~two~poles,~
     but~they~do~not~have~a~unique~meeting~point:~
     the~value~(0pt,~0pt)~will~be~used.
   }
-\__kernel_msg_new:nnnn { kernel } { unknown-coffin }
+\__kernel_msg_new:nnnn { coffins } { unknown-coffin }
   { Unknown~coffin~'#1'. }
   { The~coffin~'#1'~was~never~defined. }
-\__kernel_msg_new:nnnn { kernel } { unknown-coffin-pole }
+\__kernel_msg_new:nnnn { coffins } { unknown-coffin-pole }
   { Pole~'#1'~unknown~for~coffin~'#2'. }
   {
     LaTeX~was~asked~to~find~a~typesetting~pole~for~a~coffin,~
     but~either~the~coffin~does~not~exist~or~the~pole~name~is~wrong.
   }
-\__kernel_msg_new:nnn { kernel } { show-coffin }
+\__kernel_msg_new:nnn { coffins } { show-coffin }
   {
     Size~of~coffin~#1 : #2 \\
     Poles~of~coffin~#1 : #3 .

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -2499,7 +2499,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \color_show:n #1
   {
-    \msg_show:nnxxxx { LaTeX / color } { show }
+    \__kernel_msg_show:nnxxxx { color } { show }
       {#1}
       {
         \@@_if_defined:nT {#1}

--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -169,7 +169,7 @@
     \exp_args:No \clist_map_inline:nn { \tl_to_str:n {#1} }
        {
         \cs_if_exist_use:cF { @@_ ##1 _on: }
-          { \__kernel_msg_error:nnn { kernel } { debug } {##1} }
+          { \__kernel_msg_error:nnn { debug } { debug } {##1} }
        }
   }
 \cs_set_protected:Npn \debug_off:n #1
@@ -177,7 +177,7 @@
     \exp_args:No \clist_map_inline:nn { \tl_to_str:n {#1} }
       {
         \cs_if_exist_use:cF { @@_ ##1 _off: }
-          { \__kernel_msg_error:nnn { kernel } { debug } {##1} }
+          { \__kernel_msg_error:nnn { debug } { debug } {##1} }
       }
   }
 \cs_new_protected:Npn \@@_all_on:
@@ -269,7 +269,7 @@
         \@@_suspended:T \use_none:nnn
         \cs_if_exist:NF ##1
           {
-            \__kernel_msg_error:nnx { kernel } { non-declared-variable }
+            \__kernel_msg_error:nnx { debug } { non-declared-variable }
               { \token_to_str:N ##1 }
           }
       }
@@ -362,7 +362,7 @@
       \if:w #1 \scan_stop:
         \cs_gset_nopar:Npn #1 {#2}
       \else:
-        \__kernel_msg_error:nnxxx { kernel } { local-global }
+        \__kernel_msg_error:nnxxx { debug } { local-global }
           {#1} {#2} { \iow_char:N \\ #3 }
       \fi:
     \fi:
@@ -437,7 +437,7 @@
       }
       {
         \__kernel_msg_expandable_error:nnnn
-          { kernel } { expr } {#4} {#1}
+          { debug } { expr } {#4} {#1}
       }
     #1
   }
@@ -562,11 +562,11 @@
     \if:w n #1 \prg_return_true: \else:
       \if:w N #1 \prg_return_false: \else:
         \__kernel_msg_expandable_error:nnn
-          { kernel } { bad-arg-type } {#1}
+          { debug } { bad-arg-type } {#1}
       \fi:
     \fi:
   }
-\__kernel_msg_new:nnn { kernel } { bad-arg-type }
+\__kernel_msg_new:nnn { debug } { bad-arg-type }
   { Wrong~argument~type~#1. }
 %    \end{macrocode}
 %   The macro below is a modifiec copy of
@@ -1431,7 +1431,7 @@
 %
 % Messages.
 % \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { debug }
+\__kernel_msg_new:nnnn { debug } { debug }
   { The~debugging~option~'#1'~does~not~exist~\msg_line_context:. }
   {
     The~functions~'\iow_char:N\\debug_on:n'~and~
@@ -1439,8 +1439,8 @@
     'all',~'check-declarations',~'check-expressions',~
     'deprecation',~'log-functions',~not~'#1'.
   }
-\__kernel_msg_new:nnn { kernel } { expr } { '#2'~in~#1 }
-\__kernel_msg_new:nnnn { kernel } { local-global }
+\__kernel_msg_new:nnn { debug } { expr } { '#2'~in~#1 }
+\__kernel_msg_new:nnnn { debug } { local-global }
   { Inconsistent~local/global~assignment }
   {
     \c_@@_coding_error_text_tl
@@ -1457,7 +1457,7 @@
     \ %
     variable~'#3'.
   }
-\__kernel_msg_new:nnnn { kernel } { non-declared-variable }
+\__kernel_msg_new:nnnn { debug } { non-declared-variable }
   { The~variable~#1~has~not~been~declared~\msg_line_context:. }
   {
     \c_@@_coding_error_text_tl

--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -286,7 +286,7 @@
         \__kernel_if_debug:TF
           {
             \exp_not:N \__kernel_msg_warning:nnxxx
-              { kernel } { deprecated-command }
+              { deprecation } { deprecated-command }
               {#1}
               { \token_to_str:N #3 }
               { \tl_to_str:n {#2} }
@@ -332,7 +332,7 @@
           \cs_if_eq:NNTF #3 \cs_gset_protected:Npn
             { \exp_not:N \__kernel_msg_error:nnnnnn }
             { \exp_not:N \__kernel_msg_expandable_error:nnnnnn }
-            { kernel } { deprecated-command }
+            { deprecation } { deprecated-command }
             {#1}
             { \token_to_str:N #4 }
             { \tl_to_str:n {#2} }
@@ -353,10 +353,10 @@
     \tex_protected:D \tex_outer:D \tex_edef:D #1
       {
         \exp_not:N \__kernel_msg_expandable_error:nnnnn
-          { kernel } { deprecated-command }
+          { deprecation } { deprecated-command }
           { \tl_to_str:n {#3} } { \token_to_str:N #1 } { \tl_to_str:n {#2} }
         \exp_not:N \__kernel_msg_error:nnxxx
-          { kernel } { deprecated-command }
+          { deprecation } { deprecated-command }
           { \tl_to_str:n {#3} } { \token_to_str:N #1 } { \tl_to_str:n {#2} }
       }
   }
@@ -364,7 +364,7 @@
 % \end{macro}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { kernel } { deprecated-command }
+\__kernel_msg_new:nnn { deprecation } { deprecated-command }
   {
     \tl_if_blank:nF {#3} { Use~ \tl_trim_spaces:n {#3} ~not~ }
     #2~deprecated~on~#1.

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -3372,7 +3372,7 @@
       }
     \seq_concat:NNN \l_@@_tmp_seq \l_@@_tmp_seq \g_@@_record_seq
     \seq_remove_duplicates:N \l_@@_tmp_seq
-    #1 { LaTeX/kernel } { file-list }
+    #1 { LaTeX / kernel } { file-list }
       { \seq_map_function:NN \l_@@_tmp_seq \@@_list_aux:n }
         { } { } { }
   }

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -1128,11 +1128,11 @@
 %   \texttt{show-streams} takes care of translating |ior|/|iow| to
 %   English.
 %    \begin{macrocode}
-\cs_new_protected:Npn \ior_show_list: { \@@_list:N \msg_show:nnxxxx }
-\cs_new_protected:Npn \ior_log_list: { \@@_list:N \msg_log:nnxxxx }
+\cs_new_protected:Npn \ior_show_list: { \@@_list:N \__kernel_msg_show:nnxxxx }
+\cs_new_protected:Npn \ior_log_list: { \@@_list:N \__kernel_msg_log:nnxxxx }
 \cs_new_protected:Npn \@@_list:N #1
   {
-    #1 { LaTeX / kernel } { show-streams }
+    #1 { kernel } { show-streams }
       { ior }
       {
         \prop_map_function:NN \g_@@_streams_prop
@@ -1524,11 +1524,11 @@
 % \begin{macro}{\@@_list:N}
 %   Done as for input, but with a copy of the auxiliary so the name is correct.
 %    \begin{macrocode}
-\cs_new_protected:Npn \iow_show_list: { \@@_list:N \msg_show:nnxxxx }
-\cs_new_protected:Npn \iow_log_list: { \@@_list:N \msg_log:nnxxxx }
+\cs_new_protected:Npn \iow_show_list: { \@@_list:N \__kernel_msg_show:nnxxxx }
+\cs_new_protected:Npn \iow_log_list: { \@@_list:N \__kernel_msg_log:nnxxxx }
 \cs_new_protected:Npn \@@_list:N #1
   {
-    #1 { LaTeX / kernel } { show-streams }
+    #1 { kernel } { show-streams }
       { iow }
       {
         \prop_map_function:NN \g_@@_streams_prop
@@ -3360,8 +3360,8 @@
 %   \cs{AtBeginDocument} into \cs{g_@@_record_seq}), turning it to a
 %   string (this does not affect the commas of this comma list).
 %    \begin{macrocode}
-\cs_new_protected:Npn \file_show_list: { \@@_list:N \msg_show:nnxxxx }
-\cs_new_protected:Npn \file_log_list: { \@@_list:N \msg_log:nnxxxx }
+\cs_new_protected:Npn \file_show_list: { \@@_list:N \__kernel_msg_show:nnxxxx }
+\cs_new_protected:Npn \file_log_list: { \@@_list:N \__kernel_msg_log:nnxxxx }
 \cs_new_protected:Npn \@@_list:N #1
   {
     \seq_clear:N \l_@@_tmp_seq
@@ -3372,7 +3372,7 @@
       }
     \seq_concat:NNN \l_@@_tmp_seq \l_@@_tmp_seq \g_@@_record_seq
     \seq_remove_duplicates:N \l_@@_tmp_seq
-    #1 { LaTeX / kernel } { file-list }
+    #1 { kernel } { file-list }
       { \seq_map_function:NN \l_@@_tmp_seq \@@_list_aux:n }
         { } { } { }
   }

--- a/l3kernel/l3fp-aux.dtx
+++ b/l3kernel/l3fp-aux.dtx
@@ -226,7 +226,7 @@
 %   stream and its contents reach \TeX{}'s stomach.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_misused:n #1
-  { \__kernel_msg_error:nnx { kernel } { misused-fp } { \fp_to_tl:n {#1} } }
+  { \__kernel_msg_error:nnx { fp } { misused-fp } { \fp_to_tl:n {#1} } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -1267,7 +1267,7 @@
 %
 % Using a floating point directly is an error.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { misused-fp }
+\__kernel_msg_new:nnnn { fp } { misused-fp }
   { A~floating~point~with~value~'#1'~was~misused. }
   {
     To~obtain~the~value~of~a~floating~point~variable,~use~

--- a/l3kernel/l3fp-aux.dtx
+++ b/l3kernel/l3fp-aux.dtx
@@ -226,7 +226,7 @@
 %   stream and its contents reach \TeX{}'s stomach.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_misused:n #1
-  { \__kernel_msg_error:nnx { fp } { misused-fp } { \fp_to_tl:n {#1} } }
+  { \__kernel_msg_error:nnx { fp } { misused } { \fp_to_tl:n {#1} } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -1267,7 +1267,7 @@
 %
 % Using a floating point directly is an error.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { fp } { misused-fp }
+\__kernel_msg_new:nnnn { fp } { misused }
   { A~floating~point~with~value~'#1'~was~misused. }
   {
     To~obtain~the~value~of~a~floating~point~variable,~use~

--- a/l3kernel/l3fp-convert.dtx
+++ b/l3kernel/l3fp-convert.dtx
@@ -150,7 +150,7 @@
   }
 \cs_new:Npn \@@_to_scientific_recover:w #1 #2 ;
   {
-    \@@_error:nffn { fp-unknown-type } { \tl_to_str:n { #2 ; } } { } { }
+    \@@_error:nffn { unknown-type } { \tl_to_str:n { #2 ; } } { } { }
     nan
   }
 \cs_new:Npn \@@_tuple_to_scientific:w
@@ -244,7 +244,7 @@
   }
 \cs_new:Npn \@@_to_decimal_recover:w #1 #2 ;
   {
-    \@@_error:nffn { fp-unknown-type } { \tl_to_str:n { #2 ; } } { } { }
+    \@@_error:nffn { unknown-type } { \tl_to_str:n { #2 ; } } { } { }
     nan
   }
 \cs_new:Npn \@@_tuple_to_decimal:w
@@ -357,7 +357,7 @@
   { \@@_change_func_type:NNN #1 \@@_to_tl:w \@@_to_tl_recover:w #1 }
 \cs_new:Npn \@@_to_tl_recover:w #1 #2 ;
   {
-    \@@_error:nffn { fp-unknown-type } { \tl_to_str:n { #2 ; } } { } { }
+    \@@_error:nffn { unknown-type } { \tl_to_str:n { #2 ; } } { } { }
     nan
   }
 \cs_new:Npn \@@_tuple_to_tl:w

--- a/l3kernel/l3fp-logic.dtx
+++ b/l3kernel/l3fp-logic.dtx
@@ -423,7 +423,7 @@
     \prg_break_point:
     \use:n
       {
-        \@@_error:nfff { fp-step-tuple } { \fp_to_tl:n { #1#2 ; } }
+        \@@_error:nfff { step-tuple } { \fp_to_tl:n { #1#2 ; } }
           { \fp_to_tl:n { #3#4 ; } } { \fp_to_tl:n { #5#6 ; } }
       }
   }
@@ -442,7 +442,7 @@
               { zero-step } {#6}
           }
           {
-            \@@_error:nnfn { fp-bad-step } { }
+            \@@_error:nnfn { bad-step } { }
               { \fp_to_tl:n { \s_@@ \@@_chk:w #2#3#4 ; } } {#6}
           }
         \use_none:nnnnn
@@ -453,7 +453,7 @@
   {
     \fp_compare:nNnTF {#2} = {#3}
       {
-        \@@_error:nffn { fp-tiny-step }
+        \@@_error:nffn { tiny-step }
           { \fp_to_tl:n {#3} } { \fp_to_tl:n {#4} } {#6}
       }
       {
@@ -506,11 +506,11 @@
 % \end{macro}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { kernel } { fp-step-tuple }
+\__kernel_msg_new:nnn { fp } { step-tuple }
   { Tuple~argument~in~fp_step_...~{#1}{#2}{#3}. }
-\__kernel_msg_new:nnn { kernel } { fp-bad-step }
+\__kernel_msg_new:nnn { fp } { bad-step }
   { Invalid~step~size~#2~in~step~function~#3. }
-\__kernel_msg_new:nnn { kernel } { fp-tiny-step }
+\__kernel_msg_new:nnn { fp } { tiny-step }
   { Tiny~step~size~(#1+#2=#1)~in~step~function~#3. }
 %    \end{macrocode}
 %
@@ -698,7 +698,7 @@
         \@@_parse_expand:w
     \else:
       \__kernel_msg_expandable_error:nnnn
-        { kernel } { fp-missing } { : } { ~for~?: }
+        { fp } { missing } { : } { ~for~?: }
       \exp_after:wN \@@_parse_continue:NwN
       \exp_after:wN #1
       \exp:w \exp_end_continue_f:w

--- a/l3kernel/l3fp-parse.dtx
+++ b/l3kernel/l3fp-parse.dtx
@@ -789,7 +789,7 @@
           }
       }
       {
-        \__kernel_msg_expandable_error:nn { kernel } { fp-early-end }
+        \__kernel_msg_expandable_error:nn { fp } { early-end }
         \exp_after:wN \c_nan_fp \exp:w \exp_end_continue_f:w
       }
     #1
@@ -811,8 +811,8 @@
               {
                 \cs_if_eq:NNTF ##2 #1 { \use_i:nn } { \use:n }
                 {
-                  \__kernel_msg_expandable_error:nnn { kernel }
-                    { fp-robust-cmd }
+                  \__kernel_msg_expandable_error:nnn { fp }
+                    { robust-cmd }
                 }
               }
               {
@@ -928,7 +928,7 @@
     \str_if_eq:nnTF {#1} {#2}
       {
         \__kernel_msg_expandable_error:nnn
-          { kernel } { fp-infty-pi } {#1}
+          { fp } { infty-pi } {#1}
         \c_nan_fp
       }
       { #4 \@@_parse_expand:w }
@@ -1026,7 +1026,7 @@
           { @@_parse_caseless_ \str_foldcase:n {#2} :N }
           {
             \__kernel_msg_expandable_error:nnn
-              { kernel } { unknown-fp-word } {#2}
+              { fp } { unknown-fp-word } {#2}
             \exp_after:wN \c_nan_fp \exp:w \exp_end_continue_f:w
             \@@_parse_infix:NN
           }
@@ -1081,13 +1081,13 @@
     \cs_if_exist:cTF { @@_parse_infix_ \token_to_str:N #1 :N }
       {
         \__kernel_msg_expandable_error:nnn
-          { kernel } { fp-missing-number } {#1}
+          { fp } { missing-number } {#1}
         \exp_after:wN \c_nan_fp \exp:w \exp_end_continue_f:w
         \@@_parse_infix:NN #3 #1
       }
       {
         \__kernel_msg_expandable_error:nnn
-          { kernel } { fp-unknown-symbol } {#1}
+          { fp } { unknown-symbol } {#1}
         \@@_parse_one:Nw #3
       }
   }
@@ -1760,7 +1760,7 @@
             = 0 \exp_stop_f:
           0
           \__kernel_msg_expandable_error:nnn
-            { kernel } { fp-after-e } { floating~point~ }
+            { fp } { after-e } { floating~point~ }
           \prg_return_true:
         \else:
           0
@@ -1776,14 +1776,14 @@
         \else:
           0
           \__kernel_msg_expandable_error:nnn
-            { kernel } { fp-after-e } { dimension~#1 }
+            { fp } { after-e } { dimension~#1 }
         \fi:
         \prg_return_false:
       \fi:
     \else:
       0
       \__kernel_msg_expandable_error:nnn
-        { kernel } { fp-missing } { exponent }
+        { fp } { missing } { exponent }
       \prg_return_true:
     \fi:
   }
@@ -1852,7 +1852,7 @@
 \cs_new:Npn \@@_parse_apply_unary_chk:nNNNNw #1#2#3#4#5#6 @
   {
     #2
-    \@@_error:nffn { fp-#1-arg } { \@@_func_to_name:N #4 } { } { }
+    \@@_error:nffn { #1-arg } { \@@_func_to_name:N #4 } { } { }
     \exp_after:wN #4 \exp_after:wN #5 \c_nan_fp @
   }
 \cs_new:Npn \@@_parse_apply_unary_type:NNN #1#2#3
@@ -1955,7 +1955,7 @@
       }
       {
         \exp_not:N \__kernel_msg_expandable_error:nnn
-          { kernel } { fp-missing } { ) }
+          { fp } { missing } { ) }
         \exp_not:N \tl_if_empty:nT {#2} \exp_not:N \c_@@_empty_tuple_fp
         #2 @
         \exp_not:N \use_none:n #3
@@ -1978,7 +1978,7 @@
         \exp_after:wN \c_@@_empty_tuple_fp \exp:w
       \else:
         \__kernel_msg_expandable_error:nnn
-          { kernel } { fp-missing-number } { ) }
+          { fp } { missing-number } { ) }
         \exp_after:wN \c_nan_fp \exp:w
       \fi:
       \exp_end_continue_f:w
@@ -2294,7 +2294,7 @@
   {
     \if_meaning:w \scan_stop: #1
       \__kernel_msg_expandable_error:nnn
-        { kernel } { fp-missing } { * }
+        { fp } { missing } { * }
       \exp_after:wN \@@_parse_infix_mul:N
       \exp_after:wN #2
       \exp_after:wN #3
@@ -2380,7 +2380,7 @@
           \exp_after:wN \use_none:n
           \exp_after:wN #1
         \else:
-          \__kernel_msg_expandable_error:nnn { kernel } { fp-extra } { ) }
+          \__kernel_msg_expandable_error:nnn { fp } { extra } { ) }
           \exp_after:wN \@@_parse_infix:NN
           \exp_after:wN ##1
           \exp:w \exp_after:wN \@@_parse_expand:w
@@ -2584,7 +2584,7 @@
   \@@_ternary_auxii:NwwN \c_@@_prec_colon_int
   {
     \__kernel_msg_expandable_error:nnnn
-      { kernel } { fp-missing } { ? } { ~for~?: }
+      { fp } { missing } { ? } { ~for~?: }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -2625,7 +2625,7 @@
 \cs_new:Npn \@@_parse_excl_error:
   {
     \__kernel_msg_expandable_error:nnnn
-      { kernel } { fp-missing } { = } { ~after~!. }
+      { fp } { missing } { = } { ~after~!. }
   }
 \cs_new:Npn \@@_parse_compare:NNNNNNN #1
   {
@@ -2729,7 +2729,7 @@
     \@@_array_if_all_fp:nTF {#3}
       { #2 #3 @ }
       {
-        \@@_error:nffn { fp-bad-args }
+        \@@_error:nffn { bad-args }
           {#1}
           { \fp_to_tl:n { \s_@@_tuple \@@_tuple_chk:w {#3} ; } }
           { }
@@ -2768,7 +2768,7 @@
   }
 \cs_new:Npn \@@_parse_function_one_two_error_o:w #1#2#3#4 @
   {
-    \@@_error:nffn { fp-bad-args }
+    \@@_error:nffn { bad-args }
       {#2}
       { \fp_to_tl:n { \s_@@_tuple \@@_tuple_chk:w {#4} ; } }
       { }
@@ -2859,37 +2859,37 @@
 % \subsection{Messages}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { kernel } { fp-deprecated }
+\__kernel_msg_new:nnn { fp } { deprecated }
   { '#1'~deprecated;~use~'#2' }
-\__kernel_msg_new:nnn { kernel } { unknown-fp-word }
+\__kernel_msg_new:nnn { fp } { unknown-fp-word }
   { Unknown~fp~word~#1. }
-\__kernel_msg_new:nnn { kernel } { fp-missing }
+\__kernel_msg_new:nnn { fp } { missing }
   { Missing~#1~inserted #2. }
-\__kernel_msg_new:nnn { kernel } { fp-extra }
+\__kernel_msg_new:nnn { fp } { extra }
   { Extra~#1~ignored. }
-\__kernel_msg_new:nnn { kernel } { fp-early-end }
+\__kernel_msg_new:nnn { fp } { early-end }
   { Premature~end~in~fp~expression. }
-\__kernel_msg_new:nnn { kernel } { fp-after-e }
+\__kernel_msg_new:nnn { fp } { after-e }
   { Cannot~use~#1 after~'e'. }
-\__kernel_msg_new:nnn { kernel } { fp-missing-number }
+\__kernel_msg_new:nnn { fp } { missing-number }
   { Missing~number~before~'#1'. }
-\__kernel_msg_new:nnn { kernel } { fp-unknown-symbol }
+\__kernel_msg_new:nnn { fp } { unknown-symbol }
   { Unknown~symbol~#1~ignored. }
-\__kernel_msg_new:nnn { kernel } { fp-extra-comma }
+\__kernel_msg_new:nnn { fp } { extra-comma }
   { Unexpected~comma~turned~to~nan~result. }
-\__kernel_msg_new:nnn { kernel } { fp-no-arg }
+\__kernel_msg_new:nnn { fp } { no-arg }
   { #1~got~no~argument;~used~nan. }
-\__kernel_msg_new:nnn { kernel } { fp-multi-arg }
+\__kernel_msg_new:nnn { fp } { multi-arg }
   { #1~got~more~than~one~argument;~used~nan. }
-\__kernel_msg_new:nnn { kernel } { fp-num-args }
+\__kernel_msg_new:nnn { fp } { num-args }
   { #1~expects~between~#2~and~#3~arguments. }
-\__kernel_msg_new:nnn { kernel } { fp-bad-args }
+\__kernel_msg_new:nnn { fp } { bad-args }
   { Arguments~in~#1#2~are~invalid. }
-\__kernel_msg_new:nnn { kernel } { fp-infty-pi }
+\__kernel_msg_new:nnn { fp } { infty-pi }
   { Math~command~#1 is~not~an~fp }
 \cs_if_exist:cT { @unexpandable@protect }
   {
-    \__kernel_msg_new:nnn { kernel } { fp-robust-cmd }
+    \__kernel_msg_new:nnn { fp } { robust-cmd }
       { Robust~command~#1 invalid~in~fp~expression! }
   }
 %    \end{macrocode}

--- a/l3kernel/l3fp-random.dtx
+++ b/l3kernel/l3fp-random.dtx
@@ -334,7 +334,7 @@
           }
           {
             \__kernel_msg_expandable_error:nnnnn
-              { kernel } { fp-num-args } { rand() } { 0 } { 0 }
+              { fp } { num-args } { rand() } { 0 } { 0 }
             \exp_after:wN \c_nan_fp
           }
       }

--- a/l3kernel/l3fp-round.dtx
+++ b/l3kernel/l3fp-round.dtx
@@ -410,9 +410,9 @@
 \cs_new:Npn \@@_round_no_arg_o:Nw #1
   {
     \cs_if_eq:NNTF #1 \@@_round_to_nearest:NNN
-      { \@@_error:nnnn { fp-num-args } { round () } { 1 } { 3 } }
+      { \@@_error:nnnn { num-args } { round () } { 1 } { 3 } }
       {
-        \@@_error:nffn { fp-num-args }
+        \@@_error:nffn { num-args }
           { \@@_round_name_from_cs:N #1 () } { 1 } { 2 }
       }
     \exp_after:wN \c_nan_fp
@@ -443,12 +443,12 @@
             #2 ; #3 ;
           }
           {
-            \@@_error:nnnn { fp-num-args } { round () } { 1 } { 3 }
+            \@@_error:nnnn { num-args } { round () } { 1 } { 3 }
             \exp_after:wN \c_nan_fp
           }
       }
       {
-        \@@_error:nffn { fp-num-args }
+        \@@_error:nffn { num-args }
           { \@@_round_name_from_cs:N #1 () } { 1 } { 2 }
         \exp_after:wN \c_nan_fp
       }

--- a/l3kernel/l3fp-traps.dtx
+++ b/l3kernel/l3fp-traps.dtx
@@ -127,12 +127,12 @@
           { invalid_operation , division_by_zero , overflow , underflow }
           {#1}
           {
-            \__kernel_msg_error:nnxx { kernel }
+            \__kernel_msg_error:nnxx { fp }
               { unknown-fpu-trap-type } {#1} {#2}
           }
           {
             \__kernel_msg_error:nnx
-              { kernel } { unknown-fpu-exception } {#1}
+              { fp } { unknown-fpu-exception } {#1}
           }
       }
   }
@@ -164,7 +164,7 @@
       { \cs_set:Npn \@@_invalid_operation:nnw ##1##2##3; }
       {
         #1
-        \@@_error:nnfn { fp-invalid } {##2} { \fp_to_tl:n { ##3; } } { }
+        \@@_error:nnfn { invalid } {##2} { \fp_to_tl:n { ##3; } } { }
         \flag_raise_if_clear:n { fp_invalid_operation }
         ##1
       }
@@ -172,7 +172,7 @@
       { \cs_set:Npn \@@_invalid_operation_o:Nww ##1##2; ##3; }
       {
         #1
-        \@@_error:nffn { fp-invalid-ii }
+        \@@_error:nffn { invalid-ii }
           { \fp_to_tl:n { ##2; } } { \fp_to_tl:n { ##3; } } {##1}
         \flag_raise_if_clear:n { fp_invalid_operation }
         \exp_after:wN \c_nan_fp
@@ -181,7 +181,7 @@
       { \cs_set:Npn \@@_invalid_operation_tl_o:ff ##1##2 }
       {
         #1
-        \@@_error:nffn { fp-invalid } {##1} {##2} { }
+        \@@_error:nffn { invalid } {##1} {##2} { }
         \flag_raise_if_clear:n { fp_invalid_operation }
         \exp_after:wN \c_nan_fp
       }
@@ -214,7 +214,7 @@
       { \cs_set:Npn \@@_division_by_zero_o:Nnw ##1##2##3; }
       {
         #1
-        \@@_error:nnfn { fp-zero-div } {##2} { \fp_to_tl:n { ##3; } } { }
+        \@@_error:nnfn { zero-div } {##2} { \fp_to_tl:n { ##3; } } { }
         \flag_raise_if_clear:n { fp_division_by_zero }
         \exp_after:wN ##1
       }
@@ -222,7 +222,7 @@
       { \cs_set:Npn \@@_division_by_zero_o:NNww ##1##2##3; ##4; }
       {
         #1
-        \@@_error:nffn { fp-zero-div-ii }
+        \@@_error:nffn { zero-div-ii }
           { \fp_to_tl:n { ##3; } } { \fp_to_tl:n { ##4; } } {##2}
         \flag_raise_if_clear:n { fp_division_by_zero }
         \exp_after:wN ##1
@@ -283,7 +283,7 @@
       {
         #1
         \@@_error:nffn
-          { fp-flow \if_meaning:w 1 ##1 -to \fi: }
+          { flow \if_meaning:w 1 ##1 -to \fi: }
           { \fp_to_tl:n { \s_@@ \@@_chk:w ##1##2##3; } }
           { \token_if_eq_meaning:NNF 0 ##2 { - } #4 }
           {#2}
@@ -338,7 +338,7 @@
 % \begin{macro}[EXP]{\@@_error:nnnn, \@@_error:nnfn, \@@_error:nffn, \@@_error:nfff}
 %    \begin{macrocode}
 \cs_new:Npn \@@_error:nnnn
-  { \__kernel_msg_expandable_error:nnnnn { kernel } }
+  { \__kernel_msg_expandable_error:nnnnn { fp } }
 \cs_generate_variant:Nn \@@_error:nnnn { nnf, nff , nfff }
 %    \end{macrocode}
 % \end{macro}
@@ -347,7 +347,7 @@
 %
 % Some messages.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { unknown-fpu-exception }
+\__kernel_msg_new:nnnn { fp } { unknown-fpu-exception }
   {
     The~FPU~exception~'#1'~is~not~known:~
     that~trap~will~never~be~triggered.
@@ -362,7 +362,7 @@
         * ~ underflow
       }
   }
-\__kernel_msg_new:nnnn { kernel } { unknown-fpu-trap-type }
+\__kernel_msg_new:nnnn { fp } { unknown-fpu-trap-type }
   { The~FPU~trap~type~'#2'~is~not~known. }
   {
     The~trap~type~must~be~one~of \\
@@ -373,19 +373,19 @@
         * ~ none
       }
   }
-\__kernel_msg_new:nnn { kernel } { fp-flow }
+\__kernel_msg_new:nnn { fp } { flow }
   { An ~ #3 ~ occurred. }
-\__kernel_msg_new:nnn { kernel } { fp-flow-to }
+\__kernel_msg_new:nnn { fp } { flow-to }
   { #1 ~ #3 ed ~ to ~ #2 . }
-\__kernel_msg_new:nnn { kernel } { fp-zero-div }
+\__kernel_msg_new:nnn { fp } { zero-div }
   { Division~by~zero~in~ #1 (#2) }
-\__kernel_msg_new:nnn { kernel } { fp-zero-div-ii }
+\__kernel_msg_new:nnn { fp } { zero-div-ii }
   { Division~by~zero~in~ (#1) #3 (#2) }
-\__kernel_msg_new:nnn { kernel } { fp-invalid }
+\__kernel_msg_new:nnn { fp } { invalid }
   { Invalid~operation~ #1 (#2) }
-\__kernel_msg_new:nnn { kernel } { fp-invalid-ii }
+\__kernel_msg_new:nnn { fp } { invalid-ii }
   { Invalid~operation~ (#1) #3 (#2) }
-\__kernel_msg_new:nnn { kernel } { fp-unknown-type }
+\__kernel_msg_new:nnn { fp } { unknown-type }
   { Unknown~type~for~'#1' }
 %    \end{macrocode}
 %

--- a/l3kernel/l3fparray.dtx
+++ b/l3kernel/l3fparray.dtx
@@ -263,7 +263,7 @@
   }
 \cs_new_protected:Npn \@@_array_gset_recover:Nw #1#2 ;
   {
-    \@@_error:nffn { fp-unknown-type } { \tl_to_str:n { #2 ; } } { } { }
+    \@@_error:nffn { unknown-type } { \tl_to_str:n { #2 ; } } { } { }
     \exp_after:wN #1 \c_nan_fp
   }
 \cs_new_protected:Npn \@@_array_gset:w \s_@@ \@@_chk:w #1#2

--- a/l3kernel/l3intarray.dtx
+++ b/l3kernel/l3intarray.dtx
@@ -517,7 +517,7 @@
   {
     \__kernel_chk_defined:NT #2
       {
-        #1 { LaTeX/kernel } { show-intarray }
+        #1 { LaTeX / intarray } { show }
           { \token_to_str:N #2 }
           { \intarray_count:N #2 }
           { >~ \@@_to_clist:Nn #2 { , ~ } }

--- a/l3kernel/l3intarray.dtx
+++ b/l3kernel/l3intarray.dtx
@@ -509,15 +509,15 @@
 % \begin{macro}{\intarray_show:N, \intarray_show:c, \intarray_log:N, \intarray_log:c}
 %   Convert the list to a comma list (with spaces after each comma)
 %    \begin{macrocode}
-\cs_new_protected:Npn \intarray_show:N { \@@_show:NN \msg_show:nnxxxx }
+\cs_new_protected:Npn \intarray_show:N { \@@_show:NN \__kernel_msg_show:nnxxxx }
 \cs_generate_variant:Nn \intarray_show:N { c }
-\cs_new_protected:Npn \intarray_log:N { \@@_show:NN \msg_log:nnxxxx }
+\cs_new_protected:Npn \intarray_log:N { \@@_show:NN \__kernel_msg_log:nnxxxx }
 \cs_generate_variant:Nn \intarray_log:N { c }
 \cs_new_protected:Npn \@@_show:NN #1#2
   {
     \__kernel_chk_defined:NT #2
       {
-        #1 { LaTeX / intarray } { show }
+        #1 { intarray } { show }
           { \token_to_str:N #2 }
           { \intarray_count:N #2 }
           { >~ \@@_to_clist:Nn #2 { , ~ } }

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1613,7 +1613,7 @@
       {
         \str_if_empty:NF \l_@@_property_str
           {
-            \__kernel_msg_error:nnxx { keys } { key-property-unknown }
+            \__kernel_msg_error:nnxx { keys } { property-unknown }
               \l_@@_property_str \l_keys_path_str
           }
       }
@@ -1676,7 +1676,7 @@
     #1 \s_@@_nil #2 \@@_property_find_err:w
   {
     \str_clear:N \l__keys_property_str
-    \__kernel_msg_error:nnn { keys } { key-no-property } {#1}
+    \__kernel_msg_error:nnn { keys } { no-property } {#1}
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1698,7 +1698,7 @@
           \l_@@_property_str \s_@@_stop
           { \use:c { \c_@@_props_root_str \l_@@_property_str } }
           {
-            \__kernel_msg_error:nnxx { keys } { key-property-requires-value }
+            \__kernel_msg_error:nnxx { keys } { property-requires-value }
               \l_@@_property_str \l_keys_path_str
           }
       }
@@ -1793,7 +1793,7 @@
     \@@_cmd_set:nn \l_keys_path_str { #1 {##1} }
     \@@_cmd_set:nn { \l_keys_path_str / unknown }
       {
-        \__kernel_msg_error:nnxx { keys } { key-choice-unknown }
+        \__kernel_msg_error:nnxx { keys } { choice-unknown }
           \l_keys_path_str {##1}
       }
   }
@@ -2018,7 +2018,7 @@
       }
       {
         \__kernel_msg_error:nnx { keys }
-          { key-property-boolean-values-only }
+          { property-boolean-values-only }
           { .value_ #1 :n }
       }
   }
@@ -2875,7 +2875,7 @@
           { \c_@@_code_root_str \l_@@_module_str / unknown }
           { \@@_execute:no { \l_@@_module_str / unknown } \l_keys_value_tl }
           {
-            \__kernel_msg_error:nnxx { keys } { key-unknown }
+            \__kernel_msg_error:nnxx { keys } { unknown }
               \l_keys_path_str \l_@@_module_str
           }
       }
@@ -3154,13 +3154,13 @@
 \__kernel_msg_new:nnnn { keys } { boolean-values-only }
   { Key~'#1'~accepts~boolean~values~only. }
   { The~key~'#1'~only~accepts~the~values~'true'~and~'false'. }
-\__kernel_msg_new:nnnn { keys } { key-choice-unknown }
+\__kernel_msg_new:nnnn { keys } { choice-unknown }
   { Key~'#1'~accepts~only~a~fixed~set~of~choices. }
   {
     The~key~'#1'~only~accepts~predefined~values,~
     and~'#2'~is~not~one~of~these.
   }
-\__kernel_msg_new:nnnn { keys } { key-unknown }
+\__kernel_msg_new:nnnn { keys } { unknown }
   { The~key~'#1'~is~unknown~and~is~being~ignored. }
   {
     The~module~'#2'~does~not~have~a~key~called~'#1'.\\

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -3119,12 +3119,12 @@
 %   To show a key, show its code using a message.
 %    \begin{macrocode}
 \cs_new_protected:Npn \keys_show:nn
-  { \@@_show:Nnn \msg_show:nnxxxx }
+  { \@@_show:Nnn \__kernel_msg_show:nnxxxx }
 \cs_new_protected:Npn \keys_log:nn
-  { \@@_show:Nnn \msg_log:nnxxxx }
+  { \@@_show:Nnn \__kernel_msg_log:nnxxxx }
 \cs_new_protected:Npn \@@_show:Nnn #1#2#3
   {
-    #1 { LaTeX / keys } { show-key }
+    #1 { keys } { show-key }
       { \@@_trim_spaces:n { #2 / #3 } }
       {
         \keys_if_exist:nnT {#2} {#3}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1223,7 +1223,7 @@
            #2 \s_@@_mark \@@_clean_up_active:w
         {
           \__kernel_msg_expandable_error:nn
-            { kernel } { misplaced-equals-sign }
+            { keyval } { misplaced-equals-sign }
           \@@_loop_other:nnw
         }
       \cs_new:Npn \@@_misplaced_equal_in_split_error:w
@@ -1231,7 +1231,7 @@
           ##3 \s_@@_mark ##4 ##5
         {
           \__kernel_msg_expandable_error:nn
-            { kernel } { misplaced-equals-sign }
+            { keyval } { misplaced-equals-sign }
           \@@_loop_other:nnw
         }
 %    \end{macrocode}
@@ -1314,16 +1314,16 @@
 \cs_new:Npn \@@_blank_key_error:w \s_@@_mark \s_@@_stop \exp_not:n #1
   {
     \__kernel_msg_expandable_error:nn
-      { kernel } { blank-key-name }
+      { keyval } { blank-key-name }
   }
 %    \end{macrocode}
 % \end{macro}
 %
 % Two messages for the low level parsing system.
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { kernel } { misplaced-equals-sign }
+\__kernel_msg_new:nnn { keyval } { misplaced-equals-sign }
   { Misplaced~equals~sign~in~key-value~input~\msg_line_context: }
-\__kernel_msg_new:nnn { kernel } { blank-key-name }
+\__kernel_msg_new:nnn { keyval } { blank-key-name }
   { Blank~key~name~in~key-value~input~\msg_line_context: }
 %    \end{macrocode}
 %
@@ -1613,7 +1613,7 @@
       {
         \str_if_empty:NF \l_@@_property_str
           {
-            \__kernel_msg_error:nnxx { kernel } { key-property-unknown }
+            \__kernel_msg_error:nnxx { keys } { key-property-unknown }
               \l_@@_property_str \l_keys_path_str
           }
       }
@@ -1676,7 +1676,7 @@
     #1 \s_@@_nil #2 \@@_property_find_err:w
   {
     \str_clear:N \l__keys_property_str
-    \__kernel_msg_error:nnn { kernel } { key-no-property } {#1}
+    \__kernel_msg_error:nnn { keys } { key-no-property } {#1}
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1698,7 +1698,7 @@
           \l_@@_property_str \s_@@_stop
           { \use:c { \c_@@_props_root_str \l_@@_property_str } }
           {
-            \__kernel_msg_error:nnxx { kernel } { key-property-requires-value }
+            \__kernel_msg_error:nnxx { keys } { key-property-requires-value }
               \l_@@_property_str \l_keys_path_str
           }
       }
@@ -1728,7 +1728,7 @@
       { \exp_not:c { bool_ #2 set_false:N } \exp_not:N #1 }
     \@@_cmd_set:nn { \l_keys_path_str / unknown }
       {
-        \__kernel_msg_error:nnx { kernel } { boolean-values-only }
+        \__kernel_msg_error:nnx { keys } { boolean-values-only }
           \l_keys_key_str
       }
     \@@_default_set:n { true }
@@ -1750,7 +1750,7 @@
       { \exp_not:c { bool_ #2 set_true:N } \exp_not:N #1 }
     \@@_cmd_set:nn { \l_keys_path_str / unknown }
       {
-        \__kernel_msg_error:nnx { kernel } { boolean-values-only }
+        \__kernel_msg_error:nnx { keys } { boolean-values-only }
           \l_keys_key_str
       }
     \@@_default_set:n { true }
@@ -1779,7 +1779,7 @@
           { \c_@@_type_root_str \@@_parent:o \l_keys_path_str }
           { choice }
           {
-            \__kernel_msg_error:nnxx { kernel } { nested-choice-key }
+            \__kernel_msg_error:nnxx { keys } { nested-choice-key }
               \l_keys_path_tl { \@@_parent:o \l_keys_path_str }
           }
           { \@@_choice_make_aux:N #1 }
@@ -1793,7 +1793,7 @@
     \@@_cmd_set:nn \l_keys_path_str { #1 {##1} }
     \@@_cmd_set:nn { \l_keys_path_str / unknown }
       {
-        \__kernel_msg_error:nnxx { kernel } { key-choice-unknown }
+        \__kernel_msg_error:nnxx { keys } { key-choice-unknown }
           \l_keys_path_str {##1}
       }
   }
@@ -2017,7 +2017,7 @@
           }
       }
       {
-        \__kernel_msg_error:nnx { kernel }
+        \__kernel_msg_error:nnx { keys }
           { key-property-boolean-values-only }
           { .value_ #1 :n }
       }
@@ -2026,7 +2026,7 @@
   {
     \bool_if:NF \l_@@_no_value_bool
       {
-        \__kernel_msg_error:nnxx { kernel } { value-forbidden }
+        \__kernel_msg_error:nnxx { keys } { value-forbidden }
           \l_keys_path_str \l_keys_value_tl
         \use_none:nnn
       }
@@ -2035,7 +2035,7 @@
   {
     \bool_if:NT \l_@@_no_value_bool
       {
-        \__kernel_msg_error:nnx { kernel } { value-required }
+        \__kernel_msg_error:nnx { keys } { value-required }
           \l_keys_path_str
         \use_none:nnn
       }
@@ -2875,7 +2875,7 @@
           { \c_@@_code_root_str \l_@@_module_str / unknown }
           { \@@_execute:no { \l_@@_module_str / unknown } \l_keys_value_tl }
           {
-            \__kernel_msg_error:nnxx { kernel } { key-unknown }
+            \__kernel_msg_error:nnxx { keys } { key-unknown }
               \l_keys_path_str \l_@@_module_str
           }
       }
@@ -2948,7 +2948,7 @@
         {
           \tl_if_blank:nF {##1}
             {
-              \__kernel_msg_error:nnxx { kernel } { bad-relative-key-path }
+              \__kernel_msg_error:nnxx { keys } { bad-relative-key-path }
                 \l_keys_path_str
                 \l_@@_relative_tl
             }
@@ -3124,7 +3124,7 @@
   { \@@_show:Nnn \msg_log:nnxxxx }
 \cs_new_protected:Npn \@@_show:Nnn #1#2#3
   {
-    #1 { LaTeX / kernel } { show-key }
+    #1 { LaTeX / keys } { show-key }
       { \@@_trim_spaces:n { #2 / #3 } }
       {
         \keys_if_exist:nnT {#2} {#3}
@@ -3148,43 +3148,43 @@
 %
 % For when there is a need to complain.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { bad-relative-key-path }
+\__kernel_msg_new:nnnn { keys } { bad-relative-key-path }
   { The~key~'#1'~is~not~inside~the~'#2'~path. }
   { The~key~'#1'~cannot~be~expressed~relative~to~path~'#2'. }
-\__kernel_msg_new:nnnn { kernel } { boolean-values-only }
+\__kernel_msg_new:nnnn { keys } { boolean-values-only }
   { Key~'#1'~accepts~boolean~values~only. }
   { The~key~'#1'~only~accepts~the~values~'true'~and~'false'. }
-\__kernel_msg_new:nnnn { kernel } { key-choice-unknown }
+\__kernel_msg_new:nnnn { keys } { key-choice-unknown }
   { Key~'#1'~accepts~only~a~fixed~set~of~choices. }
   {
     The~key~'#1'~only~accepts~predefined~values,~
     and~'#2'~is~not~one~of~these.
   }
-\__kernel_msg_new:nnnn { kernel } { key-unknown }
+\__kernel_msg_new:nnnn { keys } { key-unknown }
   { The~key~'#1'~is~unknown~and~is~being~ignored. }
   {
     The~module~'#2'~does~not~have~a~key~called~'#1'.\\
     Check~that~you~have~spelled~the~key~name~correctly.
   }
-\__kernel_msg_new:nnnn { kernel } { nested-choice-key }
+\__kernel_msg_new:nnnn { keys } { nested-choice-key }
   { Attempt~to~define~'#1'~as~a~nested~choice~key. }
   {
     The~key~'#1'~cannot~be~defined~as~a~choice~as~the~parent~key~'#2'~is~
     itself~a~choice.
   }
-\__kernel_msg_new:nnnn { kernel } { value-forbidden }
+\__kernel_msg_new:nnnn { keys } { value-forbidden }
   { The~key~'#1'~does~not~take~a~value. }
   {
     The~key~'#1'~should~be~given~without~a~value.\\
     The~value~'#2'~was~present:~the~key~will~be~ignored.
   }
-\__kernel_msg_new:nnnn { kernel } { value-required }
+\__kernel_msg_new:nnnn { keys } { value-required }
   { The~key~'#1'~requires~a~value. }
   {
     The~key~'#1'~must~have~a~value.\\
     No~value~was~present:~the~key~will~be~ignored.
   }
-\__kernel_msg_new:nnn { kernel } { show-key }
+\__kernel_msg_new:nnn { keys } { show-key }
   {
     The~key~#1~
     \tl_if_empty:nTF {#2}

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -280,7 +280,7 @@
         \cs_set:Npn #1 ##1
           {
             \__kernel_msg_expandable_error:nnn
-              { kernel } { luatex-required } { #1 }
+              { luatex } { luatex-required } { #1 }
           }
       }
     \clist_map_inline:nn
@@ -289,7 +289,7 @@
         \cs_set_protected:Npn #1 ##1
           {
             \__kernel_msg_error:nnn
-              { kernel } { luatex-required } { #1 }
+              { luatex } { luatex-required } { #1 }
           }
       }
   }
@@ -301,7 +301,7 @@
 % \subsection{Messages}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { luatex-required }
+\__kernel_msg_new:nnnn { luatex } { luatex-required }
   { LuaTeX~engine~not~in~use!~Ignoring~#1. }
   {
     The~feature~you~are~using~is~only~available~

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -1756,6 +1756,22 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}
+%   {
+%     \__kernel_msg_log:nnnnnn, \__kernel_msg_log:nnxxxx,
+%     \__kernel_msg_show:nnnnnn, \__kernel_msg_show:nnxxxx
+%   }
+%   For showing messages.
+%    \begin{macrocode}
+\cs_new_protected:Npn \__kernel_msg_log:nnnnnn #1
+  { \msg_log:nnnnnn { LaTeX / #1 } }
+\cs_generate_variant:Nn \__kernel_msg_log:nnnnnn { nnxxxx }
+\cs_new_protected:Npn \__kernel_msg_show:nnnnnn #1
+  { \msg_show:nnnnnn { LaTeX / #1 } }
+\cs_generate_variant:Nn \__kernel_msg_show:nnnnnn { nnxxxx }
+%    \end{macrocode}
+% \end{macro}
+%
 % End the group to eliminate \cs{@@_kernel_class_new:nN}.
 %    \begin{macrocode}
 \group_end:

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -665,7 +665,7 @@
   {
     \msg_if_exist:nnT {#1} {#2}
       {
-        \__kernel_msg_error:nnxx { msg } { message-already-defined }
+        \__kernel_msg_error:nnxx { msg } { already-defined }
           {#1} {#2}
       }
   }
@@ -1370,7 +1370,7 @@
 \cs_new:Npn \@@_class_chk_exist:nT #1
   {
     \cs_if_free:cTF { @@_ #1 _code:nnnnnn }
-      { \__kernel_msg_error:nnx { msg } { message-class-unknown } {#1} }
+      { \__kernel_msg_error:nnx { msg } { class-unknown } {#1} }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1440,7 +1440,7 @@
             \@@_use_redirect_name:n { #2 / #3 }
           }
       }
-      { \__kernel_msg_error:nnxx { msg } { message-unknown } {#2} {#3} }
+      { \__kernel_msg_error:nnxx { msg } { unknown } {#2} {#3} }
     \cs_if_exist_use:N \conditionally@traceon
   }
 \cs_new_protected:Npn \@@_use_code: { }
@@ -1591,7 +1591,7 @@
               {
                 \prop_put:cnn { l_@@_redirect_ #2 _prop } {#3} {#2}
                 \__kernel_msg_warning:nnxxxx
-                  { msg } { message-redirect-loop }
+                  { msg } { redirect-loop }
                   { \seq_item:Nn \l_@@_class_loop_seq { 1 } }
                   { \seq_item:Nn \l_@@_class_loop_seq { 2 } }
                   {#3}
@@ -1780,7 +1780,7 @@
 % Error messages needed to actually implement the message system
 % itself.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { msg } { message-already-defined }
+\__kernel_msg_new:nnnn { msg } { already-defined }
   { Message~'#2'~for~module~'#1'~already~defined. }
   {
     \c_@@_coding_error_text_tl
@@ -1788,7 +1788,7 @@
     by~the~module~'#1':~this~message~already~exists.
     \c_@@_return_text_tl
   }
-\__kernel_msg_new:nnnn { msg } { message-unknown }
+\__kernel_msg_new:nnnn { msg } { unknown }
   { Unknown~message~'#2'~for~module~'#1'. }
   {
     \c_@@_coding_error_text_tl
@@ -1796,14 +1796,14 @@
     by~the~module~'#1':~this~message~does~not~exist.
     \c_@@_return_text_tl
   }
-\__kernel_msg_new:nnnn { msg } { message-class-unknown }
+\__kernel_msg_new:nnnn { msg } { class-unknown }
   { Unknown~message~class~'#1'. }
   {
     LaTeX~has~been~asked~to~redirect~messages~to~a~class~'#1':\\
     this~was~never~defined.
     \c_@@_return_text_tl
   }
-\__kernel_msg_new:nnnn { msg } { message-redirect-loop }
+\__kernel_msg_new:nnnn { msg } { redirect-loop }
   {
     Message~redirection~loop~caused~by~ {#1} ~=>~ {#2}
     \tl_if_empty:nF {#3} { ~for~module~' \use_none:n #3 ' } .
@@ -1952,7 +1952,7 @@
 \__kernel_msg_new:nnnn { ior } { quote-in-shell }
   { Quotes~in~shell~command~'#1'. }
   { Shell~commands~cannot~contain~quotes~("). }
-\__kernel_msg_new:nnnn { keys } { key-no-property }
+\__kernel_msg_new:nnnn { keys } no-property }
   { No~property~given~in~definition~of~key~'#1'. }
   {
     \c_@@_coding_error_text_tl
@@ -1961,20 +1961,20 @@
     \iow_indent:n { #1 .<property> } \\ \\
     LaTeX~did~not~find~a~'.'~to~indicate~the~start~of~a~property.
   }
-\__kernel_msg_new:nnnn { keys } { key-property-boolean-values-only }
+\__kernel_msg_new:nnnn { keys } { property-boolean-values-only }
   { The~property~'#1'~accepts~boolean~values~only. }
   {
     \c_@@_coding_error_text_tl
     The~property~'#1'~only~accepts~the~values~'true'~and~'false'.
   }
-\__kernel_msg_new:nnnn { keys } { key-property-requires-value }
+\__kernel_msg_new:nnnn { keys } { property-requires-value }
   { The~property~'#1'~requires~a~value. }
   {
     \c_@@_coding_error_text_tl
     LaTeX~was~asked~to~set~property~'#1'~for~key~'#2'.\\
     No~value~was~given~for~the~property,~and~one~is~required.
   }
-\__kernel_msg_new:nnnn { keys } { key-property-unknown }
+\__kernel_msg_new:nnnn { keys } { property-unknown }
   { The~key~property~'#1'~is~unknown. }
   {
     \c_@@_coding_error_text_tl

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -1952,7 +1952,7 @@
 \__kernel_msg_new:nnnn { ior } { quote-in-shell }
   { Quotes~in~shell~command~'#1'. }
   { Shell~commands~cannot~contain~quotes~("). }
-\__kernel_msg_new:nnnn { keys } no-property }
+\__kernel_msg_new:nnnn { keys } { no-property }
   { No~property~given~in~definition~of~key~'#1'. }
   {
     \c_@@_coding_error_text_tl

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -637,7 +637,7 @@
   {
     \msg_if_exist:nnT {#1} {#2}
       {
-        \__kernel_msg_error:nnxx { kernel } { message-already-defined }
+        \__kernel_msg_error:nnxx { msg } { message-already-defined }
           {#1} {#2}
       }
   }
@@ -1342,7 +1342,7 @@
 \cs_new:Npn \@@_class_chk_exist:nT #1
   {
     \cs_if_free:cTF { @@_ #1 _code:nnnnnn }
-      { \__kernel_msg_error:nnx { kernel } { message-class-unknown } {#1} }
+      { \__kernel_msg_error:nnx { msg } { message-class-unknown } {#1} }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1412,7 +1412,7 @@
             \@@_use_redirect_name:n { #2 / #3 }
           }
       }
-      { \__kernel_msg_error:nnxx { kernel } { message-unknown } {#2} {#3} }
+      { \__kernel_msg_error:nnxx { msg } { message-unknown } {#2} {#3} }
     \cs_if_exist_use:N \conditionally@traceon
   }
 \cs_new_protected:Npn \@@_use_code: { }
@@ -1563,7 +1563,7 @@
               {
                 \prop_put:cnn { l_@@_redirect_ #2 _prop } {#3} {#2}
                 \__kernel_msg_warning:nnxxxx
-                  { kernel } { message-redirect-loop }
+                  { msg } { message-redirect-loop }
                   { \seq_item:Nn \l_@@_class_loop_seq { 1 } }
                   { \seq_item:Nn \l_@@_class_loop_seq { 2 } }
                   {#3}
@@ -1736,7 +1736,7 @@
 % Error messages needed to actually implement the message system
 % itself.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { message-already-defined }
+\__kernel_msg_new:nnnn { msg } { message-already-defined }
   { Message~'#2'~for~module~'#1'~already~defined. }
   {
     \c_@@_coding_error_text_tl
@@ -1744,7 +1744,7 @@
     by~the~module~'#1':~this~message~already~exists.
     \c_@@_return_text_tl
   }
-\__kernel_msg_new:nnnn { kernel } { message-unknown }
+\__kernel_msg_new:nnnn { msg } { message-unknown }
   { Unknown~message~'#2'~for~module~'#1'. }
   {
     \c_@@_coding_error_text_tl
@@ -1752,14 +1752,14 @@
     by~the~module~'#1':~this~message~does~not~exist.
     \c_@@_return_text_tl
   }
-\__kernel_msg_new:nnnn { kernel } { message-class-unknown }
+\__kernel_msg_new:nnnn { msg } { message-class-unknown }
   { Unknown~message~class~'#1'. }
   {
     LaTeX~has~been~asked~to~redirect~messages~to~a~class~'#1':\\
     this~was~never~defined.
     \c_@@_return_text_tl
   }
-\__kernel_msg_new:nnnn { kernel } { message-redirect-loop }
+\__kernel_msg_new:nnnn { msg } { message-redirect-loop }
   {
     Message~redirection~loop~caused~by~ {#1} ~=>~ {#2}
     \tl_if_empty:nF {#3} { ~for~module~' \use_none:n #3 ' } .
@@ -1783,16 +1783,6 @@
     #2~arguments.~
     TeX~allows~between~0~and~9~arguments~for~a~single~function.
   }
-\__kernel_msg_new:nnn { kernel } { char-active }
-  { Cannot~generate~active~chars. }
-\__kernel_msg_new:nnn { kernel } { char-invalid-catcode }
-  { Invalid~catcode~for~char~generation. }
-\__kernel_msg_new:nnn { kernel } { char-null-space }
-  { Cannot~generate~null~char~as~a~space. }
-\__kernel_msg_new:nnn { kernel } { char-out-of-range }
-  { Charcode~requested~out~of~engine~range. }
-\__kernel_msg_new:nnn { kernel } { char-space }
-  { Cannot~generate~space~chars. }
 \__kernel_msg_new:nnnn { kernel } { command-already-defined }
   { Control~sequence~#1~already~defined. }
   {
@@ -1870,72 +1860,6 @@
     LaTeX~has~been~asked~to~define~the~conditional~form~'#1'~of~
     the~function~'#2',~but~only~'TF',~'T',~'F',~and~'p'~forms~exist.
   }
-\__kernel_msg_new:nnnn { kernel } { key-no-property }
-  { No~property~given~in~definition~of~key~'#1'. }
-  {
-    \c_@@_coding_error_text_tl
-    Inside~\keys_define:nn  each~key~name~
-    needs~a~property:  \\ \\
-    \iow_indent:n { #1 .<property> } \\ \\
-    LaTeX~did~not~find~a~'.'~to~indicate~the~start~of~a~property.
-  }
-\__kernel_msg_new:nnnn { kernel } { key-property-boolean-values-only }
-  { The~property~'#1'~accepts~boolean~values~only. }
-  {
-    \c_@@_coding_error_text_tl
-    The~property~'#1'~only~accepts~the~values~'true'~and~'false'.
-  }
-\__kernel_msg_new:nnnn { kernel } { key-property-requires-value }
-  { The~property~'#1'~requires~a~value. }
-  {
-    \c_@@_coding_error_text_tl
-    LaTeX~was~asked~to~set~property~'#1'~for~key~'#2'.\\
-    No~value~was~given~for~the~property,~and~one~is~required.
-  }
-\__kernel_msg_new:nnnn { kernel } { key-property-unknown }
-  { The~key~property~'#1'~is~unknown. }
-  {
-    \c_@@_coding_error_text_tl
-    LaTeX~has~been~asked~to~set~the~property~'#1'~for~key~'#2':~
-    this~property~is~not~defined.
-  }
-\__kernel_msg_new:nnnn { kernel } { quote-in-shell }
-  { Quotes~in~shell~command~'#1'. }
-  { Shell~commands~cannot~contain~quotes~("). }
-\__kernel_msg_new:nnnn { kernel } { invalid-quark-function }
-  { Quark~test~function~'#1'~is~invalid. }
-  {
-    \c__msg_coding_error_text_tl
-    LaTeX~has~been~asked~to~create~quark~test~function~'#1'~
-    \tl_if_empty:nTF {#2}
-      { but~that~name~ }
-      { with~signature~'#2',~but~that~signature~ }
-    is~not~valid.
-  }
-\__kernel_msg_new:nnn { kernel } { invalid-quark }
-  { Invalid~quark~variable~'#1'. }
-\__kernel_msg_new:nnnn { kernel } { scanmark-already-defined }
-  { Scan~mark~#1~already~defined. }
-  {
-    \c_@@_coding_error_text_tl
-    LaTeX~has~been~asked~to~create~a~new~scan~mark~'#1'~
-    but~this~name~has~already~been~used~for~a~scan~mark.
-  }
-\__kernel_msg_new:nnnn { kernel } { shuffle-too-large }
-  { The~sequence~#1~is~too~long~to~be~shuffled~by~TeX. }
-  {
-    TeX~has~ \int_eval:n { \c_max_register_int + 1 } ~
-    toks~registers:~this~only~allows~to~shuffle~up~to~
-    \int_use:N \c_max_register_int \ items.~
-    The~list~will~not~be~shuffled.
-  }
-\__kernel_msg_new:nnnn { kernel } { variable-not-defined }
-  { Variable~#1~undefined. }
-  {
-    \c_@@_coding_error_text_tl
-    LaTeX~has~been~asked~to~show~a~variable~#1,~but~this~has~not~
-    been~defined~yet.
-  }
 \__kernel_msg_new:nnnn { kernel } { variant-too-long }
   { Variant~form~'#1'~longer~than~base~signature~of~'#2'. }
   {
@@ -1971,6 +1895,82 @@
         {#4} { :~base~form~is~already~a~variant. }
       } { . }
   }
+\__kernel_msg_new:nnn { char } { active }
+  { Cannot~generate~active~chars. }
+\__kernel_msg_new:nnn { char } { invalid-catcode }
+  { Invalid~catcode~for~char~generation. }
+\__kernel_msg_new:nnn { char } { null-space }
+  { Cannot~generate~null~char~as~a~space. }
+\__kernel_msg_new:nnn { char } { out-of-range }
+  { Charcode~requested~out~of~engine~range. }
+\__kernel_msg_new:nnn { char } { space }
+  { Cannot~generate~space~chars. }
+\__kernel_msg_new:nnnn { ior } { quote-in-shell }
+  { Quotes~in~shell~command~'#1'. }
+  { Shell~commands~cannot~contain~quotes~("). }
+\__kernel_msg_new:nnnn { keys } { key-no-property }
+  { No~property~given~in~definition~of~key~'#1'. }
+  {
+    \c_@@_coding_error_text_tl
+    Inside~\keys_define:nn  each~key~name~
+    needs~a~property:  \\ \\
+    \iow_indent:n { #1 .<property> } \\ \\
+    LaTeX~did~not~find~a~'.'~to~indicate~the~start~of~a~property.
+  }
+\__kernel_msg_new:nnnn { keys } { key-property-boolean-values-only }
+  { The~property~'#1'~accepts~boolean~values~only. }
+  {
+    \c_@@_coding_error_text_tl
+    The~property~'#1'~only~accepts~the~values~'true'~and~'false'.
+  }
+\__kernel_msg_new:nnnn { keys } { key-property-requires-value }
+  { The~property~'#1'~requires~a~value. }
+  {
+    \c_@@_coding_error_text_tl
+    LaTeX~was~asked~to~set~property~'#1'~for~key~'#2'.\\
+    No~value~was~given~for~the~property,~and~one~is~required.
+  }
+\__kernel_msg_new:nnnn { keys } { key-property-unknown }
+  { The~key~property~'#1'~is~unknown. }
+  {
+    \c_@@_coding_error_text_tl
+    LaTeX~has~been~asked~to~set~the~property~'#1'~for~key~'#2':~
+    this~property~is~not~defined.
+  }
+\__kernel_msg_new:nnnn { quark } { invalid-quark-function }
+  { Quark~test~function~'#1'~is~invalid. }
+  {
+    \c__msg_coding_error_text_tl
+    LaTeX~has~been~asked~to~create~quark~test~function~'#1'~
+    \tl_if_empty:nTF {#2}
+      { but~that~name~ }
+      { with~signature~'#2',~but~that~signature~ }
+    is~not~valid.
+  }
+\__kernel_msg_new:nnn { quark } { invalid-quark }
+  { Invalid~quark~variable~'#1'. }
+\__kernel_msg_new:nnnn { scanmark } { scanmark-already-defined }
+  { Scan~mark~#1~already~defined. }
+  {
+    \c_@@_coding_error_text_tl
+    LaTeX~has~been~asked~to~create~a~new~scan~mark~'#1'~
+    but~this~name~has~already~been~used~for~a~scan~mark.
+  }
+\__kernel_msg_new:nnnn { seq } { shuffle-too-large }
+  { The~sequence~#1~is~too~long~to~be~shuffled~by~TeX. }
+  {
+    TeX~has~ \int_eval:n { \c_max_register_int + 1 } ~
+    toks~registers:~this~only~allows~to~shuffle~up~to~
+    \int_use:N \c_max_register_int \ items.~
+    The~list~will~not~be~shuffled.
+  }
+\__kernel_msg_new:nnnn { kernel } { variable-not-defined }
+  { Variable~#1~undefined. }
+  {
+    \c_@@_coding_error_text_tl
+    LaTeX~has~been~asked~to~show~a~variable~#1,~but~this~has~not~
+    been~defined~yet.
+  }
 %    \end{macrocode}
 %
 % Some errors are only needed in package mode if debugging is enabled by
@@ -1978,7 +1978,7 @@
 % \texttt{log-functions}, or on the contrary if debugging is turned off.
 % In format mode the error is somewhat different.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { enable-debug }
+\__kernel_msg_new:nnnn { debug } { enable-debug }
   { To~use~'#1'~set~the~'enable-debug'~option. }
   {
     The~function~'#1'~will~be~ignored~because~it~can~only~work~if~
@@ -1996,13 +1996,13 @@
   { Misused~\exp_end_continue_f:w or~:nw }
 \__kernel_msg_new:nnn { kernel } { bad-variable }
   { Erroneous~variable~#1 used! }
-\__kernel_msg_new:nnn { kernel } { misused-sequence }
+\__kernel_msg_new:nnn { seq } { misused-sequence }
   { A~sequence~was~misused. }
-\__kernel_msg_new:nnn { kernel } { misused-prop }
+\__kernel_msg_new:nnn { prop } { misused-prop }
   { A~property~list~was~misused. }
-\__kernel_msg_new:nnn { kernel } { negative-replication }
+\__kernel_msg_new:nnn { prg } { negative-replication }
   { Negative~argument~for~\iow_char:N\\prg_replicate:nn. }
-\__kernel_msg_new:nnn { kernel } { prop-keyval }
+\__kernel_msg_new:nnn { prop } { prop-keyval }
   { Missing/extra~'='~in~'#1'~(in~'..._keyval:Nn') }
 \__kernel_msg_new:nnn { kernel } { unknown-comparison }
   { Relation~'#1'~unknown:~use~=,~<,~>,~==,~!=,~<=,~>=. }
@@ -2017,23 +2017,23 @@
 %
 % Messages used by the \enquote{\texttt{show}} functions.
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { kernel } { show-clist }
+\__kernel_msg_new:nnn { clist } { show }
   {
     The~comma~list~ \tl_if_empty:nF {#1} { #1 ~ }
     \tl_if_empty:nTF {#2}
       { is~empty \\>~ . }
       { contains~the~items~(without~outer~braces): #2 . }
   }
-\__kernel_msg_new:nnn { kernel } { show-intarray }
+\__kernel_msg_new:nnn { intarray } { show }
   { The~integer~array~#1~contains~#2~items: \\ #3 . }
-\__kernel_msg_new:nnn { kernel } { show-prop }
+\__kernel_msg_new:nnn { prop } { show }
   {
     The~property~list~#1~
     \tl_if_empty:nTF {#2}
       { is~empty \\>~ . }
       { contains~the~pairs~(without~outer~braces): #2 . }
   }
-\__kernel_msg_new:nnn { kernel } { show-seq }
+\__kernel_msg_new:nnn { seq } { show }
   {
     The~sequence~#1~
     \tl_if_empty:nTF {#2}

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -1993,7 +1993,7 @@
   }
 \__kernel_msg_new:nnn { quark } { invalid-quark }
   { Invalid~quark~variable~'#1'. }
-\__kernel_msg_new:nnnn { scanmark } { scanmark-already-defined }
+\__kernel_msg_new:nnnn { scanmark } { already-defined }
   { Scan~mark~#1~already~defined. }
   {
     \c_@@_coding_error_text_tl
@@ -2040,9 +2040,9 @@
   { Misused~\exp_end_continue_f:w or~:nw }
 \__kernel_msg_new:nnn { kernel } { bad-variable }
   { Erroneous~variable~#1 used! }
-\__kernel_msg_new:nnn { seq } { misused-sequence }
+\__kernel_msg_new:nnn { seq } { misused }
   { A~sequence~was~misused. }
-\__kernel_msg_new:nnn { prop } { misused-prop }
+\__kernel_msg_new:nnn { prop } { misused }
   { A~property~list~was~misused. }
 \__kernel_msg_new:nnn { prg } { negative-replication }
   { Negative~argument~for~\iow_char:N\\prg_replicate:nn. }

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -1981,7 +1981,7 @@
     LaTeX~has~been~asked~to~set~the~property~'#1'~for~key~'#2':~
     this~property~is~not~defined.
   }
-\__kernel_msg_new:nnnn { quark } { invalid-quark-function }
+\__kernel_msg_new:nnnn { quark } { invalid-function }
   { Quark~test~function~'#1'~is~invalid. }
   {
     \c__msg_coding_error_text_tl
@@ -1991,7 +1991,7 @@
       { with~signature~'#2',~but~that~signature~ }
     is~not~valid.
   }
-\__kernel_msg_new:nnn { quark } { invalid-quark }
+\__kernel_msg_new:nnn { quark } { invalid }
   { Invalid~quark~variable~'#1'. }
 \__kernel_msg_new:nnnn { scanmark } { already-defined }
   { Scan~mark~#1~already~defined. }

--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -1540,7 +1540,7 @@
 \cs_new:cpn { @@_replicate_first_-:n } #1
   {
     \exp_end:
-    \__kernel_msg_expandable_error:nn { kernel } { negative-replication }
+    \__kernel_msg_expandable_error:nn { prg } { negative-replication }
   }
 \cs_new:cpn { @@_replicate_first_0:n } #1 { \exp_end: }
 \cs_new:cpn { @@_replicate_first_1:n } #1 { \exp_end: #1 }

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -1351,15 +1351,15 @@
 %   we use \cs{msg_show_item:nn} to format both the key and the value
 %   for each pair.
 %    \begin{macrocode}
-\cs_new_protected:Npn \prop_show:N { \@@_show:NN \msg_show:nnxxxx }
+\cs_new_protected:Npn \prop_show:N { \@@_show:NN \__kernel_msg_show:nnxxxx }
 \cs_generate_variant:Nn \prop_show:N { c }
-\cs_new_protected:Npn \prop_log:N { \@@_show:NN \msg_log:nnxxxx }
+\cs_new_protected:Npn \prop_log:N { \@@_show:NN \__kernel_msg_log:nnxxxx }
 \cs_generate_variant:Nn \prop_log:N { c }
 \cs_new_protected:Npn \@@_show:NN #1#2
   {
     \__kernel_chk_defined:NT #2
       {
-        #1 { LaTeX / prop } { show }
+        #1 { prop } { show }
           { \token_to_str:N #2 }
           { \prop_map_function:NN #2 \msg_show_item:nn }
           { } { }

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -602,7 +602,7 @@
 %   error and removes its argument.
 %    \begin{macrocode}
 \cs_new:Npn \@@_pair:wn #1 \s_@@ #2
-  { \__kernel_msg_expandable_error:nn { prop } { misused-prop } }
+  { \__kernel_msg_expandable_error:nn { prop } { misused } }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -146,16 +146,16 @@
 % \begin{function}[updated = 2012-07-09]
 %   {
 %     \prop_put:Nnn,  \prop_put:NnV,  \prop_put:Nno,  \prop_put:Nnx,
-%     \prop_put:NVn,  \prop_put:NVV,  \prop_put:NVx,  \prop_put:Nvx, 
+%     \prop_put:NVn,  \prop_put:NVV,  \prop_put:NVx,  \prop_put:Nvx,
 %     \prop_put:Non,  \prop_put:Noo,, \prop_put:Nxx,
 %     \prop_put:cnn,  \prop_put:cnV,  \prop_put:cno,  \prop_put:cnx,
-%     \prop_put:cVn,  \prop_put:cVV,  \prop_put:cVx,  \prop_put:cvx, 
+%     \prop_put:cVn,  \prop_put:cVV,  \prop_put:cVx,  \prop_put:cvx,
 %     \prop_put:con,  \prop_put:coo,  \prop_put:cxx,
 %     \prop_gput:Nnn, \prop_gput:NnV, \prop_gput:Nno, \prop_gput:Nnx,
 %     \prop_gput:NVn, \prop_gput:NVV, \prop_gput:NVx, \prop_gput:Nvx,
 %     \prop_gput:Non, \prop_gput:Noo, \prop_gput:Nxx,
 %     \prop_gput:cnn, \prop_gput:cnV, \prop_gput:cno, \prop_gput:cnx,
-%     \prop_gput:cVn, \prop_gput:cVV, \prop_gput:cVx, \prop_gput:cvx, 
+%     \prop_gput:cVn, \prop_gput:cVV, \prop_gput:cVx, \prop_gput:cvx,
 %     \prop_gput:con, \prop_gput:coo, \prop_gput:cxx
 %   }
 %   \begin{syntax}
@@ -602,7 +602,7 @@
 %   error and removes its argument.
 %    \begin{macrocode}
 \cs_new:Npn \@@_pair:wn #1 \s_@@ #2
-  { \__kernel_msg_expandable_error:nn { kernel } { misused-prop } }
+  { \__kernel_msg_expandable_error:nn { prop } { misused-prop } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -813,7 +813,7 @@
         \str_if_eq:nnTF {#2} { = }
           { \prop_put:Nnn \l_@@_internal_prop {#3} {#1} }
           {
-            \__kernel_msg_error:nnx { kernel } { prop-keyval }
+            \__kernel_msg_error:nnx { prop } { prop-keyval }
               { \exp_not:o {#4} }
           }
       }
@@ -1359,7 +1359,7 @@
   {
     \__kernel_chk_defined:NT #2
       {
-        #1 { LaTeX/kernel } { show-prop }
+        #1 { LaTeX / prop } { show }
           { \token_to_str:N #2 }
           { \prop_map_function:NN #2 \msg_show_item:nn }
           { } { }

--- a/l3kernel/l3quark.dtx
+++ b/l3kernel/l3quark.dtx
@@ -961,7 +961,7 @@
   {
     \tl_if_in:NnTF \g_@@_marks_tl { #1 }
       {
-        \__kernel_msg_error:nnx { scanmark } { scanmark-already-defined }
+        \__kernel_msg_error:nnx { scanmark } { already-defined }
           { \token_to_str:N #1 }
       }
       {

--- a/l3kernel/l3quark.dtx
+++ b/l3kernel/l3quark.dtx
@@ -641,7 +641,7 @@
 \cs_new_protected:Npn \@@_new_test_aux:Nn #1 #2
   {
     \if_meaning:w \q_nil #2 \q_nil
-      \__kernel_msg_error:nnx { kernel } { invalid-quark-function }
+      \__kernel_msg_error:nnx { quark } { invalid-quark-function }
         { \token_to_str:N #1 }
     \else:
       \@@_new_test:Nccn #1
@@ -665,11 +665,11 @@
 \cs_new_protected:Npn \@@_new_conditional:Nnnn #1#2#3#4
   {
     \if_meaning:w \q_nil #2 \q_nil
-      \__kernel_msg_error:nnx { kernel } { invalid-quark-function }
+      \__kernel_msg_error:nnx { quark } { invalid-quark-function }
         { \token_to_str:N #1 }
     \else:
       \if_meaning:w \q_nil #3 \q_nil
-        \__kernel_msg_error:nnx { kernel } { invalid-quark-function }
+        \__kernel_msg_error:nnx { quark } { invalid-quark-function }
           { \token_to_str:N #1 }
       \else:
         \exp_last_unbraced:Nf \@@_new_test_aux:nnNNnnnn
@@ -684,7 +684,7 @@
   {
     \cs_if_exist_use:cTF { @@_new_#5_#2:Nnnn } { #4 }
       {
-        \__kernel_msg_error:nnxx { kernel } { invalid-quark-function }
+        \__kernel_msg_error:nnxx { quark } { invalid-quark-function }
           { \token_to_str:N #4 } {#2}
         \use_none:nnn
       }
@@ -961,7 +961,7 @@
   {
     \tl_if_in:NnTF \g_@@_marks_tl { #1 }
       {
-        \__kernel_msg_error:nnx { kernel } { scanmark-already-defined }
+        \__kernel_msg_error:nnx { scanmark } { scanmark-already-defined }
           { \token_to_str:N #1 }
       }
       {

--- a/l3kernel/l3quark.dtx
+++ b/l3kernel/l3quark.dtx
@@ -641,7 +641,7 @@
 \cs_new_protected:Npn \@@_new_test_aux:Nn #1 #2
   {
     \if_meaning:w \q_nil #2 \q_nil
-      \__kernel_msg_error:nnx { quark } { invalid-quark-function }
+      \__kernel_msg_error:nnx { quark } { invalid-function }
         { \token_to_str:N #1 }
     \else:
       \@@_new_test:Nccn #1
@@ -665,11 +665,11 @@
 \cs_new_protected:Npn \@@_new_conditional:Nnnn #1#2#3#4
   {
     \if_meaning:w \q_nil #2 \q_nil
-      \__kernel_msg_error:nnx { quark } { invalid-quark-function }
+      \__kernel_msg_error:nnx { quark } { invalid-function }
         { \token_to_str:N #1 }
     \else:
       \if_meaning:w \q_nil #3 \q_nil
-        \__kernel_msg_error:nnx { quark } { invalid-quark-function }
+        \__kernel_msg_error:nnx { quark } { invalid-function }
           { \token_to_str:N #1 }
       \else:
         \exp_last_unbraced:Nf \@@_new_test_aux:nnNNnnnn
@@ -684,7 +684,7 @@
   {
     \cs_if_exist_use:cTF { @@_new_#5_#2:Nnnn } { #4 }
       {
-        \__kernel_msg_error:nnxx { quark } { invalid-quark-function }
+        \__kernel_msg_error:nnxx { quark } { invalid-function }
           { \token_to_str:N #4 } {#2}
         \use_none:nnn
       }

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -1583,7 +1583,7 @@
 \cs_new_eq:NN \@@_escape_break:w \prg_break:
 \cs_new:cpn { @@_escape_/break:w }
   {
-    \__kernel_msg_expandable_error:nn { kernel } { trailing-backslash }
+    \__kernel_msg_expandable_error:nn { regex } { trailing-backslash }
     \prg_break:
   }
 \cs_new:cpn { @@_escape_~:w } { }
@@ -1620,7 +1620,7 @@
   {
     \int_compare:nNnTF {#1} > \c_max_char_int
       {
-        \__kernel_msg_expandable_error:nnff { kernel } { x-overflow }
+        \__kernel_msg_expandable_error:nnff { regex } { x-overflow }
           {#1} { \int_to_Hex:n {#1} }
       }
       {
@@ -1706,7 +1706,7 @@
   }
 \cs_new:Npn \@@_escape_x_loop_error:n #1
   {
-    \__kernel_msg_expandable_error:nnn { kernel } { x-missing-rbrace } {#1}
+    \__kernel_msg_expandable_error:nnn { regex } { x-missing-rbrace } {#1}
     \@@_escape_loop:N #1
   }
 %    \end{macrocode}
@@ -2143,7 +2143,7 @@
       \if_int_compare:w \l_@@_mode_int = \c_@@_class_mode_int
         \exp_after:wN \exp_after:wN \exp_after:wN \use:n
       \else:
-        \__kernel_msg_error:nn { kernel } { c-bad-mode }
+        \__kernel_msg_error:nn { regex } { c-bad-mode }
         \exp_after:wN \exp_after:wN \exp_after:wN \use_none:n
       \fi:
     \fi:
@@ -2196,13 +2196,13 @@
   {
       \@@_if_in_class:TF
         {
-          \__kernel_msg_error:nn { kernel } { missing-rbrack }
+          \__kernel_msg_error:nn { regex } { missing-rbrack }
           \use:c { @@_compile_]: }
           \prg_do_nothing: \prg_do_nothing:
         }
         { }
       \if_int_compare:w \l_@@_group_level_int > 0 \exp_stop_f:
-        \__kernel_msg_error:nnx { kernel } { missing-rparen }
+        \__kernel_msg_error:nnx { regex } { missing-rparen }
           { \int_use:N \l_@@_group_level_int }
         \prg_replicate:nn
           { \l_@@_group_level_int }
@@ -2259,10 +2259,10 @@
       \prg_do_nothing: \prg_do_nothing:
       \prg_do_nothing: \prg_do_nothing:
       \int_compare:nNnT \l_@@_mode_int = \c_@@_catcode_mode_int
-        { \__kernel_msg_error:nn { kernel } { c-trailing } }
+        { \__kernel_msg_error:nn { regex } { c-trailing } }
       \int_compare:nNnT \l_@@_mode_int < \c_@@_outer_mode_int
         {
-          \__kernel_msg_error:nn { kernel } { c-missing-rbrace }
+          \__kernel_msg_error:nn { regex } { c-missing-rbrace }
           \@@_compile_end_cs:
           \prg_do_nothing: \prg_do_nothing:
           \prg_do_nothing: \prg_do_nothing:
@@ -2373,7 +2373,7 @@
 \cs_new_protected:Npn \@@_compile_quantifier_abort:xNN #1#2#3
   {
     \@@_compile_quantifier_none:
-    \__kernel_msg_warning:nnxx { kernel } { invalid-quantifier } {#1} {#3}
+    \__kernel_msg_warning:nnxx { regex } { invalid-quantifier } {#1} {#3}
     \@@_compile_abort_tokens:x {#1}
     #2 #3
   }
@@ -2489,7 +2489,7 @@
       {
         \if_int_compare:w \l_@@_internal_a_int >
           \l_@@_internal_b_int
-          \__kernel_msg_error:nnxx { kernel } { backwards-quantifier }
+          \__kernel_msg_error:nnxx { regex } { backwards-quantifier }
             { \int_use:N \l_@@_internal_a_int }
             { \int_use:N \l_@@_internal_b_int }
           \int_zero:N \l_@@_internal_b_int
@@ -2523,7 +2523,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_compile_raw_error:N #1
   {
-    \__kernel_msg_error:nnx { kernel } { bad-escape } {#1}
+    \__kernel_msg_error:nnx { regex } { bad-escape } {#1}
     \@@_compile_raw:N #1
   }
 %    \end{macrocode}
@@ -2582,7 +2582,7 @@
     \@@_if_end_range:NNTF #2 #3
       {
         \if_int_compare:w `#1 > `#3 \exp_stop_f:
-          \__kernel_msg_error:nnxx { kernel } { range-backwards } {#1} {#3}
+          \__kernel_msg_error:nnxx { regex } { range-backwards } {#1} {#3}
         \else:
           \tl_build_put_right:Nx \l_@@_build_tl
             {
@@ -2596,7 +2596,7 @@
         \fi:
       }
       {
-        \__kernel_msg_warning:nnxx { kernel } { range-missing-end }
+        \__kernel_msg_warning:nnxx { regex } { range-missing-end }
           {#1} { \c_backslash_str #3 }
         \tl_build_put_right:Nx \l_@@_build_tl
           {
@@ -2859,11 +2859,11 @@
           {
             : { \@@_compile_class_posix:NNNNw }
             = {
-                \__kernel_msg_warning:nnx { kernel }
+                \__kernel_msg_warning:nnx { regex }
                   { posix-unsupported } { = }
               }
             . {
-                \__kernel_msg_warning:nnx { kernel }
+                \__kernel_msg_warning:nnx { regex }
                   { posix-unsupported } { . }
               }
           }
@@ -2905,7 +2905,7 @@
               }
           }
           {
-            \__kernel_msg_warning:nnx { kernel } { posix-unknown }
+            \__kernel_msg_warning:nnx { regex } { posix-unknown }
               { \l_@@_internal_a_tl }
             \@@_compile_abort_tokens:x
               {
@@ -2915,7 +2915,7 @@
           }
       }
       {
-        \__kernel_msg_error:nnxx { kernel } { posix-missing-close }
+        \__kernel_msg_error:nnxx { regex } { posix-missing-close }
           { [: \l_@@_internal_a_tl } { #2 #4 }
         \@@_compile_abort_tokens:x { [: \l_@@_internal_a_tl }
         #1 #2 #3 #4
@@ -2961,7 +2961,7 @@
       \int_set_eq:NN \l_@@_catcodes_int \l_@@_default_catcodes_int
       \exp_after:wN \@@_compile_quantifier:w
     \else:
-      \__kernel_msg_warning:nn { kernel } { extra-rparen }
+      \__kernel_msg_warning:nn { regex } { extra-rparen }
       \exp_after:wN \@@_compile_raw:N \exp_after:wN )
     \fi:
   }
@@ -2980,7 +2980,7 @@
       {
         \if_int_compare:w \l_@@_mode_int =
           \c_@@_catcode_in_class_mode_int
-          \__kernel_msg_error:nn { kernel } { c-lparen-in-class }
+          \__kernel_msg_error:nn { regex } { c-lparen-in-class }
           \exp_after:wN \@@_compile_raw:N \exp_after:wN (
         \else:
           \exp_after:wN \@@_compile_lparen:w
@@ -2994,7 +2994,7 @@
         \cs_if_exist_use:cF
           { @@_compile_special_group_\token_to_str:N #4 :w }
           {
-            \__kernel_msg_warning:nnx { kernel } { special-group-unknown }
+            \__kernel_msg_warning:nnx { regex } { special-group-unknown }
               { (? #4 }
             \@@_compile_group_begin:N \@@_group:nnnN
               \@@_compile_raw:N ? #3 #4
@@ -3063,7 +3063,7 @@
           { \@@_item_caseless_range:nn }
       }
       {
-        \__kernel_msg_warning:nnx { kernel } { unknown-option } { (?i #2 }
+        \__kernel_msg_warning:nnx { regex } { unknown-option } { (?i #2 }
         \@@_compile_raw:N (
         \@@_compile_raw:N ?
         \@@_compile_raw:N i
@@ -3082,7 +3082,7 @@
           { \@@_item_caseful_range:nn }
       }
       {
-        \__kernel_msg_warning:nnx { kernel } { unknown-option } { (?-#2#4 }
+        \__kernel_msg_warning:nnx { regex } { unknown-option } { (?-#2#4 }
         \@@_compile_raw:N (
         \@@_compile_raw:N ?
         \@@_compile_raw:N -
@@ -3121,7 +3121,7 @@
       }
       { \cs_if_exist_use:cF { @@_compile_c_#2:w } }
           {
-            \__kernel_msg_error:nnx { kernel } { c-missing-category } {#2}
+            \__kernel_msg_error:nnx { regex } { c-missing-category } {#2}
             #1 #2
           }
   }
@@ -3142,7 +3142,7 @@
           { \token_if_eq_charcode:NNF #2 ( } % )
       }
       { \use:n }
-    { \__kernel_msg_error:nnn { kernel } { c-C-invalid } {#2} }
+    { \__kernel_msg_error:nnn { regex } { c-C-invalid } {#2} }
     #1 #2
   }
 %    \end{macrocode}
@@ -3195,7 +3195,7 @@
           { \@@_compile_c_lbrack_end: }
       }
           {
-            \__kernel_msg_error:nnx { kernel } { c-missing-rbrack } {#2}
+            \__kernel_msg_error:nnx { regex } { c-missing-rbrack } {#2}
             \@@_compile_c_lbrack_end:
             #1 #2
           }
@@ -3345,7 +3345,7 @@
             \@@_compile_u_loop:NN
           }
           {
-            \__kernel_msg_error:nn { kernel } { u-missing-lbrace }
+            \__kernel_msg_error:nn { regex } { u-missing-lbrace }
             \@@_compile_raw:N u #1 #2
           }
       }
@@ -3363,7 +3363,7 @@
           }
           {
             \if_false: { \fi: }
-            \__kernel_msg_error:nnx { kernel } { u-missing-rbrace } {#2}
+            \__kernel_msg_error:nnx { regex } { u-missing-rbrace } {#2}
             \@@_compile_u_end:
             #1 #2
           }
@@ -5253,14 +5253,14 @@
         {#1}
       \prg_do_nothing: \prg_do_nothing:
       \if_int_compare:w \l_@@_replacement_csnames_int > 0 \exp_stop_f:
-        \__kernel_msg_error:nnx { kernel } { replacement-missing-rbrace }
+        \__kernel_msg_error:nnx { regex } { replacement-missing-rbrace }
           { \int_use:N \l_@@_replacement_csnames_int }
         \tl_build_put_right:Nx \l_@@_build_tl
           { \prg_replicate:nn \l_@@_replacement_csnames_int \cs_end: }
       \fi:
       \seq_if_empty:NF \l_@@_replacement_category_seq
         {
-          \__kernel_msg_error:nnx { kernel } { replacement-missing-rparen }
+          \__kernel_msg_error:nnx { regex } { replacement-missing-rparen }
             { \seq_count:N \l_@@_replacement_category_seq }
           \seq_clear:N \l_@@_replacement_category_seq
         }
@@ -5528,12 +5528,12 @@
 \cs_new_protected:Npn \@@_replacement_cat:NNN #1#2#3
   {
     \token_if_eq_meaning:NNTF \prg_do_nothing: #3
-      { \__kernel_msg_error:nn { kernel } { replacement-catcode-end } }
+      { \__kernel_msg_error:nn { regex } { replacement-catcode-end } }
       {
         \int_compare:nNnTF { \l_@@_replacement_csnames_int } > 0
           {
             \__kernel_msg_error:nnnn
-              { kernel } { replacement-catcode-in-cs } {#1} {#3}
+              { regex } { replacement-catcode-in-cs } {#1} {#3}
             #2 #3
           }
           {
@@ -5549,7 +5549,7 @@
                     \@@_char_if_alphanumeric:NTF #3
                       {
                         \__kernel_msg_error:nnnn
-                          { kernel } { replacement-catcode-escaped }
+                          { regex } { replacement-catcode-escaped }
                           {#1} {#3}
                       }
                       { }
@@ -5713,7 +5713,7 @@
   \cs_new_protected:Npn \@@_replacement_c_S:w #1#2
     {
       \if_int_compare:w `#2 = 0 \exp_stop_f:
-        \__kernel_msg_error:nn { kernel } { replacement-null-space }
+        \__kernel_msg_error:nn { regex } { replacement-null-space }
       \fi:
       \tex_lccode:D `\ = `#2 \scan_stop:
       \tex_lowercase:D { \@@_replacement_put:n {~} }
@@ -5756,7 +5756,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_replacement_error:NNN #1#2#3
   {
-    \__kernel_msg_error:nnx { kernel } { replacement-#1 } {#3}
+    \__kernel_msg_error:nnx { regex } { replacement-#1 } {#3}
     #2 #3
   }
 %    \end{macrocode}
@@ -5814,7 +5814,7 @@
   {
     \@@_compile:n {#1}
     \@@_show:N \l_@@_internal_regex
-    \msg_show:nnxxxx { LaTeX / kernel } { show-regex }
+    \msg_show:nnxxxx { LaTeX / regex } { show }
       { \tl_to_str:n {#1} } { }
       { \l_@@_internal_a_tl } { }
   }
@@ -5823,7 +5823,7 @@
     \__kernel_chk_defined:NT #1
       {
         \@@_show:N #1
-        \msg_show:nnxxxx { LaTeX / kernel } { show-regex }
+        \msg_show:nnxxxx { LaTeX / regex } { show }
           { } { \token_to_str:N #1 }
           { \l_@@_internal_a_tl } { }
       }
@@ -6148,7 +6148,7 @@
         }
           = 0
         {
-          \__kernel_msg_error:nnxxx { kernel } { result-unbalanced }
+          \__kernel_msg_error:nnxxx { regex } { result-unbalanced }
             { splitting~or~extracting~submatches }
             { \flag_height:n { @@_end } }
             { \flag_height:n { @@_begin } }
@@ -6330,7 +6330,7 @@
   {
     \if_int_compare:w \l_@@_balance_int = 0 \exp_stop_f:
     \else:
-      \__kernel_msg_error:nnxxx { kernel } { result-unbalanced }
+      \__kernel_msg_error:nnxxx { regex } { result-unbalanced }
         { replacing }
         { \int_max:nn { - \l_@@_balance_int } { 0 } }
         { \int_max:nn { \l_@@_balance_int } { 0 } }
@@ -6731,14 +6731,14 @@
 %    \begin{macrocode}
 \use:x
   {
-    \__kernel_msg_new:nnn { kernel } { trailing-backslash }
+    \__kernel_msg_new:nnn { regex } { trailing-backslash }
       { Trailing~escape~char~'\iow_char:N\\'~in~regex~or~replacement. }
-    \__kernel_msg_new:nnn { kernel } { x-missing-rbrace }
+    \__kernel_msg_new:nnn { regex } { x-missing-rbrace }
       {
         Missing~brace~'\iow_char:N\}'~in~regex~
         '...\iow_char:N\\x\iow_char:N\{...##1'.
       }
-    \__kernel_msg_new:nnn { kernel } { x-overflow }
+    \__kernel_msg_new:nnn { regex } { x-overflow }
       {
         Character~code~##1~too~large~in~
         \iow_char:N\\x\iow_char:N\{##2\iow_char:N\}~regex.
@@ -6748,7 +6748,7 @@
 %
 % Invalid quantifier.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { invalid-quantifier }
+\__kernel_msg_new:nnnn { regex } { invalid-quantifier }
   { Braced~quantifier~'#1'~may~not~be~followed~by~'#2'. }
   {
     The~character~'#2'~is~invalid~in~the~braced~quantifier~'#1'.~
@@ -6760,13 +6760,13 @@
 % Messages for missing or extra closing brackets and parentheses, with
 % some fancy singular/plural handling for the case of parentheses.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { missing-rbrack }
+\__kernel_msg_new:nnnn { regex } { missing-rbrack }
   { Missing~right~bracket~inserted~in~regular~expression. }
   {
     LaTeX~was~given~a~regular~expression~where~a~character~class~
     was~started~with~'[',~but~the~matching~']'~is~missing.
   }
-\__kernel_msg_new:nnnn { kernel } { missing-rparen }
+\__kernel_msg_new:nnnn { regex } { missing-rparen }
   {
     Missing~right~
     \int_compare:nTF { #1 = 1 } { parenthesis } { parentheses } ~
@@ -6776,7 +6776,7 @@
     LaTeX~was~given~a~regular~expression~with~\int_eval:n {#1} ~
     more~left~parentheses~than~right~parentheses.
   }
-\__kernel_msg_new:nnnn { kernel } { extra-rparen }
+\__kernel_msg_new:nnnn { regex } { extra-rparen }
   { Extra~right~parenthesis~ignored~in~regular~expression. }
   {
     LaTeX~came~across~a~closing~parenthesis~when~no~submatch~group~
@@ -6786,7 +6786,7 @@
 %
 % Some escaped alphanumerics are not allowed everywhere.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { bad-escape }
+\__kernel_msg_new:nnnn { regex } { bad-escape }
   {
     Invalid~escape~'\iow_char:N\\#1'~
     \@@_if_in_cs:TF { within~a~control~sequence. }
@@ -6814,14 +6814,14 @@
 %
 % Range errors.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { range-missing-end }
+\__kernel_msg_new:nnnn { regex } { range-missing-end }
   { Invalid~end-point~for~range~'#1-#2'~in~character~class. }
   {
     The~end-point~'#2'~of~the~range~'#1-#2'~may~not~serve~as~an~
     end-point~for~a~range:~alphanumeric~characters~should~not~be~
     escaped,~and~non-alphanumeric~characters~should~be~escaped.
   }
-\__kernel_msg_new:nnnn { kernel } { range-backwards }
+\__kernel_msg_new:nnnn { regex } { range-backwards }
   { Range~'[#1-#2]'~out~of~order~in~character~class. }
   {
     In~ranges~of~characters~'[x-y]'~appearing~in~character~classes,~
@@ -6833,7 +6833,7 @@
 %
 % Errors related to |\c| and |\u|.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { c-bad-mode }
+\__kernel_msg_new:nnnn { regex } { c-bad-mode }
   { Invalid~nested~'\iow_char:N\\c'~escape~in~regular~expression. }
   {
     The~'\iow_char:N\\c'~escape~cannot~be~used~within~
@@ -6841,33 +6841,33 @@
     nor~another~category~test.~
     To~combine~several~category~tests,~use~'\iow_char:N\\c[...]'.
   }
-\__kernel_msg_new:nnnn { kernel } { c-C-invalid }
+\__kernel_msg_new:nnnn { regex } { c-C-invalid }
   { '\iow_char:N\\cC'~should~be~followed~by~'.'~or~'(',~not~'#1'. }
   {
     The~'\iow_char:N\\cC'~construction~restricts~the~next~item~to~be~a~
     control~sequence~or~the~next~group~to~be~made~of~control~sequences.~
     It~only~makes~sense~to~follow~it~by~'.'~or~by~a~group.
   }
-\__kernel_msg_new:nnnn { kernel } { c-lparen-in-class }
+\__kernel_msg_new:nnnn { regex } { c-lparen-in-class }
   { Catcode~test~cannot~apply~to~group~in~character~class }
   {
     Construction~such~as~'\iow_char:N\\cL(abc)'~are~not~allowed~inside~a~
     class~'[...]'~because~classes~do~not~match~multiple~characters~at~once.
   }
-\__kernel_msg_new:nnnn { kernel } { c-missing-rbrace }
+\__kernel_msg_new:nnnn { regex } { c-missing-rbrace }
   { Missing~right~brace~inserted~for~'\iow_char:N\\c'~escape. }
   {
     LaTeX~was~given~a~regular~expression~where~a~
     '\iow_char:N\\c\iow_char:N\{...'~construction~was~not~ended~
     with~a~closing~brace~'\iow_char:N\}'.
   }
-\__kernel_msg_new:nnnn { kernel } { c-missing-rbrack }
+\__kernel_msg_new:nnnn { regex } { c-missing-rbrack }
   { Missing~right~bracket~inserted~for~'\iow_char:N\\c'~escape. }
   {
     A~construction~'\iow_char:N\\c[...'~appears~in~a~
     regular~expression,~but~the~closing~']'~is~not~present.
   }
-\__kernel_msg_new:nnnn { kernel } { c-missing-category }
+\__kernel_msg_new:nnnn { regex } { c-missing-category }
   { Invalid~character~'#1'~following~'\iow_char:N\\c'~escape. }
   {
     In~regular~expressions,~the~'\iow_char:N\\c'~escape~sequence~
@@ -6875,19 +6875,19 @@
     capital~letter~representing~a~character~category,~namely~
     one~of~'ABCDELMOPSTU'.
   }
-\__kernel_msg_new:nnnn { kernel } { c-trailing }
+\__kernel_msg_new:nnnn { regex } { c-trailing }
   { Trailing~category~code~escape~'\iow_char:N\\c'... }
   {
     A~regular~expression~ends~with~'\iow_char:N\\c'~followed~
     by~a~letter.~It~will~be~ignored.
   }
-\__kernel_msg_new:nnnn { kernel } { u-missing-lbrace }
+\__kernel_msg_new:nnnn { regex } { u-missing-lbrace }
   { Missing~left~brace~following~'\iow_char:N\\u'~escape. }
   {
     The~'\iow_char:N\\u'~escape~sequence~must~be~followed~by~
     a~brace~group~with~the~name~of~the~variable~to~use.
   }
-\__kernel_msg_new:nnnn { kernel } { u-missing-rbrace }
+\__kernel_msg_new:nnnn { regex } { u-missing-rbrace }
   { Missing~right~brace~inserted~for~'\iow_char:N\\u'~escape. }
   {
     LaTeX~
@@ -6901,14 +6901,14 @@
 %
 % Errors when encountering the \textsc{posix} syntax |[:...:]|.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { posix-unsupported }
+\__kernel_msg_new:nnnn { regex } { posix-unsupported }
   { POSIX~collating~element~'[#1 ~ #1]'~not~supported. }
   {
     The~'[.foo.]'~and~'[=bar=]'~syntaxes~have~a~special~meaning~
     in~POSIX~regular~expressions.~This~is~not~supported~by~LaTeX.~
     Maybe~you~forgot~to~escape~a~left~bracket~in~a~character~class?
   }
-\__kernel_msg_new:nnnn { kernel } { posix-unknown }
+\__kernel_msg_new:nnnn { regex } { posix-unknown }
   { POSIX~class~'[:#1:]'~unknown. }
   {
     '[:#1:]'~is~not~among~the~known~POSIX~classes~
@@ -6917,7 +6917,7 @@
     '[:print:]',~'[:punct:]',~'[:space:]',~'[:upper:]',~
     '[:word:]',~and~'[:xdigit:]'.
   }
-\__kernel_msg_new:nnnn { kernel } { posix-missing-close }
+\__kernel_msg_new:nnnn { regex } { posix-missing-close }
   { Missing~closing~':]'~for~POSIX~class. }
   { The~POSIX~syntax~'#1'~must~be~followed~by~':]',~not~'#2'. }
 %    \end{macrocode}
@@ -6926,7 +6926,7 @@
 % with an unbalanced token list, which we must re-balance by adding
 % begin-group or end-group character tokens.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { result-unbalanced }
+\__kernel_msg_new:nnnn { regex } { result-unbalanced }
   { Missing~brace~inserted~when~#1. }
   {
     LaTeX~was~asked~to~do~some~regular~expression~operation,~
@@ -6938,13 +6938,13 @@
 %
 % Error message for unknown options.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { unknown-option }
+\__kernel_msg_new:nnnn { regex } { unknown-option }
   { Unknown~option~'#1'~for~regular~expressions. }
   {
     The~only~available~option~is~'case-insensitive',~toggled~by~
     '(?i)'~and~'(?-i)'.
   }
-\__kernel_msg_new:nnnn { kernel } { special-group-unknown }
+\__kernel_msg_new:nnnn { regex } { special-group-unknown }
   { Unknown~special~group~'#1~...'~in~a~regular~expression. }
   {
     The~only~valid~constructions~starting~with~'(?'~are~
@@ -6954,21 +6954,21 @@
 %
 % Errors in the replacement text.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { replacement-c }
+\__kernel_msg_new:nnnn { regex } { replacement-c }
   { Misused~'\iow_char:N\\c'~command~in~a~replacement~text. }
   {
     In~a~replacement~text,~the~'\iow_char:N\\c'~escape~sequence~
     can~be~followed~by~one~of~the~letters~'ABCDELMOPSTU'~
     or~a~brace~group,~not~by~'#1'.
   }
-\__kernel_msg_new:nnnn { kernel } { replacement-u }
+\__kernel_msg_new:nnnn { regex } { replacement-u }
   { Misused~'\iow_char:N\\u'~command~in~a~replacement~text. }
   {
     In~a~replacement~text,~the~'\iow_char:N\\u'~escape~sequence~
     must~be~~followed~by~a~brace~group~holding~the~name~of~the~
     variable~to~use.
   }
-\__kernel_msg_new:nnnn { kernel } { replacement-g }
+\__kernel_msg_new:nnnn { regex } { replacement-g }
   {
     Missing~brace~for~the~'\iow_char:N\\g'~construction~
     in~a~replacement~text.
@@ -6978,7 +6978,7 @@
     submatches~are~represented~either~as~'\iow_char:N \\g{dd..d}',~
     or~'\\d',~where~'d'~are~single~digits.~Here,~a~brace~is~missing.
   }
-\__kernel_msg_new:nnnn { kernel } { replacement-catcode-end }
+\__kernel_msg_new:nnnn { regex } { replacement-catcode-end }
   {
     Missing~character~for~the~'\iow_char:N\\c<category><character>'~
     construction~in~a~replacement~text.
@@ -6989,7 +6989,7 @@
     the~character~category.~Then,~a~character~must~follow.~LaTeX~
     reached~the~end~of~the~replacement~when~looking~for~that.
   }
-\__kernel_msg_new:nnnn { kernel } { replacement-catcode-escaped }
+\__kernel_msg_new:nnnn { regex } { replacement-catcode-escaped }
   {
     Escaped~letter~or~digit~after~category~code~in~replacement~text.
   }
@@ -6999,7 +6999,7 @@
     the~character~category.~Then,~a~character~must~follow,~not~
     '\iow_char:N\\#2'.
   }
-\__kernel_msg_new:nnnn { kernel } { replacement-catcode-in-cs }
+\__kernel_msg_new:nnnn { regex } { replacement-catcode-in-cs }
   {
     Category~code~'\iow_char:N\\c#1#3'~ignored~inside~
     '\iow_char:N\\c\{...\}'~in~a~replacement~text.
@@ -7009,7 +7009,7 @@
     '\iow_char:N\\c\{...\}'~are~ignored~when~building~the~control~
     sequence~name.
   }
-\__kernel_msg_new:nnnn { kernel } { replacement-null-space }
+\__kernel_msg_new:nnnn { regex } { replacement-null-space }
   { TeX~cannot~build~a~space~token~with~character~code~0. }
   {
     You~asked~for~a~character~token~with~category~space,~
@@ -7018,13 +7018,13 @@
     This~specific~case~is~impossible~and~will~be~replaced~
     by~a~normal~space.
   }
-\__kernel_msg_new:nnnn { kernel } { replacement-missing-rbrace }
+\__kernel_msg_new:nnnn { regex } { replacement-missing-rbrace }
   { Missing~right~brace~inserted~in~replacement~text. }
   {
     There~ \int_compare:nTF { #1 = 1 } { was } { were } ~ #1~
     missing~right~\int_compare:nTF { #1 = 1 } { brace } { braces } .
   }
-\__kernel_msg_new:nnnn { kernel } { replacement-missing-rparen }
+\__kernel_msg_new:nnnn { regex } { replacement-missing-rparen }
   { Missing~right~parenthesis~inserted~in~replacement~text. }
   {
     There~ \int_compare:nTF { #1 = 1 } { was } { were } ~ #1~
@@ -7035,14 +7035,14 @@
 %
 % Some escaped alphanumerics are not allowed everywhere.
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { backwards-quantifier }
+\__kernel_msg_new:nnnn { regex } { backwards-quantifier }
   { Quantifer~"{#1,#2}"~is~backwards. }
   { The~values~given~in~a~quantifier~must~be~in~order. }
 %    \end{macrocode}
 %
 % Used when showing a regex.
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { kernel } { show-regex }
+\__kernel_msg_new:nnn { regex } { show }
   {
     >~Compiled~regex~
     \tl_if_empty:nTF {#1} { variable~ #2 } { {#1} } :

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -5814,7 +5814,7 @@
   {
     \@@_compile:n {#1}
     \@@_show:N \l_@@_internal_regex
-    \msg_show:nnxxxx { LaTeX / regex } { show }
+    \__kernel_msg_show:nnxxxx { regex } { show }
       { \tl_to_str:n {#1} } { }
       { \l_@@_internal_a_tl } { }
   }
@@ -5823,7 +5823,7 @@
     \__kernel_chk_defined:NT #1
       {
         \@@_show:N #1
-        \msg_show:nnxxxx { LaTeX / regex } { show }
+        \__kernel_msg_show:nnxxxx { regex } { show }
           { } { \token_to_str:N #1 }
           { \l_@@_internal_a_tl } { }
       }

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1054,7 +1054,7 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_item:n
   {
-    \__kernel_msg_expandable_error:nn { seq } { misused-sequence }
+    \__kernel_msg_expandable_error:nn { seq } { misused }
     \use_none:n
   }
 %    \end{macrocode}

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -2327,15 +2327,15 @@
 % \UnitTested
 %   Apply the general \cs{msg_show:nnnnnn}.
 %    \begin{macrocode}
-\cs_new_protected:Npn \seq_show:N { \@@_show:NN \msg_show:nnxxxx }
+\cs_new_protected:Npn \seq_show:N { \@@_show:NN \__kernel_msg_show:nnxxxx }
 \cs_generate_variant:Nn \seq_show:N { c }
-\cs_new_protected:Npn \seq_log:N { \@@_show:NN \msg_log:nnxxxx }
+\cs_new_protected:Npn \seq_log:N { \@@_show:NN \__kernel_msg_log:nnxxxx }
 \cs_generate_variant:Nn \seq_log:N { c }
 \cs_new_protected:Npn \@@_show:NN #1#2
   {
     \__kernel_chk_defined:NT #2
       {
-        #1 { LaTeX / seq } { show }
+        #1 { seq } { show }
           { \token_to_str:N #2 }
           { \seq_map_function:NN #2 \msg_show_item:n }
           { } { }

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1054,7 +1054,7 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_item:n
   {
-    \__kernel_msg_expandable_error:nn { kernel } { misused-sequence }
+    \__kernel_msg_expandable_error:nn { seq } { misused-sequence }
     \use_none:n
   }
 %    \end{macrocode}
@@ -1582,7 +1582,7 @@
       {
         \int_compare:nNnTF { \seq_count:N #2 } > \c_max_register_int
           {
-            \__kernel_msg_error:nnx { kernel } { shuffle-too-large }
+            \__kernel_msg_error:nnx { seq } { shuffle-too-large }
               { \token_to_str:N #2 }
           }
           {
@@ -2335,7 +2335,7 @@
   {
     \__kernel_chk_defined:NT #2
       {
-        #1 { LaTeX/kernel } { show-seq }
+        #1 { LaTeX / seq } { show }
           { \token_to_str:N #2 }
           { \seq_map_function:NN #2 \msg_show_item:n }
           { } { }

--- a/l3kernel/l3sort.dtx
+++ b/l3kernel/l3sort.dtx
@@ -590,14 +590,14 @@
 \cs_new_protected:Npn \@@_return_mark:w #1 \s_@@_mark { }
 \cs_new_protected:Npn \@@_return_none_error:
   {
-    \__kernel_msg_error:nnxx { kernel } { return-none }
+    \__kernel_msg_error:nnxx { sort } { return-none }
       { \tex_the:D \tex_toks:D \l_@@_A_int }
       { \tex_the:D \tex_toks:D \l_@@_C_int }
     \@@_return_same:w \@@_return_none_error:
   }
 \cs_new_protected:Npn \@@_return_two_error:
   {
-    \__kernel_msg_error:nnxx { kernel } { return-two }
+    \__kernel_msg_error:nnxx { sort } { return-two }
       { \tex_the:D \tex_toks:D \l_@@_A_int }
       { \tex_the:D \tex_toks:D \l_@@_C_int }
   }
@@ -1025,12 +1025,12 @@
   { \cs_set_eq:NN \toksdef \@@_disabled_toksdef:n }
 \cs_new_protected:Npn \@@_disabled_toksdef:n #1
   {
-    \__kernel_msg_error:nnx { kernel } { toksdef }
+    \__kernel_msg_error:nnx { sort } { toksdef }
       { \token_to_str:N #1 }
     \@@_error:
     \tex_toksdef:D #1
   }
-\__kernel_msg_new:nnnn { kernel } { toksdef }
+\__kernel_msg_new:nnnn { sort } { toksdef }
   { Allocation~of~\iow_char:N\\toks~registers~impossible~while~sorting. }
   {
     The~comparison~code~used~for~sorting~a~list~has~attempted~to~
@@ -1049,13 +1049,13 @@
 \cs_new_protected:Npn \@@_too_long_error:NNw #1#2 \fi:
   {
     \fi:
-    \__kernel_msg_error:nnxxx { kernel } { too-large }
+    \__kernel_msg_error:nnxxx { sort } { too-large }
       { \token_to_str:N #2 }
       { \int_eval:n { \l_@@_true_max_int - \l_@@_min_int } }
       { \int_eval:n { \l_@@_top_int - \l_@@_min_int } }
     #1 \@@_error:
   }
-\__kernel_msg_new:nnnn { kernel } { too-large }
+\__kernel_msg_new:nnnn { sort } { too-large }
   { The~list~#1~is~too~long~to~be~sorted~by~TeX. }
   {
     TeX~has~#2~toks~registers~still~available:~
@@ -1066,7 +1066,7 @@
 % \end{macro}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { return-none }
+\__kernel_msg_new:nnnn { sort } { return-none }
   { The~comparison~code~did~not~return. }
   {
     When~sorting~a~list,~the~code~to~compare~items~#1~and~#2~
@@ -1075,7 +1075,7 @@
     \iow_char:N\\sort_return_swapped: .~
     Exactly~one~of~these~should~be~called.
   }
-\__kernel_msg_new:nnnn { kernel } { return-two }
+\__kernel_msg_new:nnnn { sort } { return-two }
   { The~comparison~code~returned~multiple~times. }
   {
     When~sorting~a~list,~the~code~to~compare~items~#1~and~#2~called~

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -990,7 +990,7 @@
     \tl_if_exist:NTF #1
       {
         \exp_args:No \@@_analysis:n {#1}
-        \msg_show:nnxxxx { LaTeX / kernel } { show-tl-analysis }
+        \msg_show:nnxxxx { LaTeX / tl } { show-tl-analysis }
           { \token_to_str:N #1 } { \@@_analysis_show: } { } { }
       }
       { \tl_show:N #1 }
@@ -998,7 +998,7 @@
 \cs_new_protected:Npn \tl_analysis_show:n #1
   {
     \@@_analysis:n {#1}
-    \msg_show:nnxxxx { LaTeX / kernel } { show-tl-analysis }
+    \msg_show:nnxxxx { LaTeX / tl } { show-tl-analysis }
       { } { \@@_analysis_show: } { } { }
   }
 %    \end{macrocode}
@@ -1482,7 +1482,7 @@
 % \end{variable}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { kernel } { show-tl-analysis }
+\__kernel_msg_new:nnn { tl } { show-tl-analysis }
   {
     The~token~list~ \tl_if_empty:nF {#1} { #1 ~ }
     \tl_if_empty:nTF {#2}

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -990,7 +990,7 @@
     \tl_if_exist:NTF #1
       {
         \exp_args:No \@@_analysis:n {#1}
-        \__kernel_msg_show:nnxxxx { tl } { show-tl-analysis }
+        \__kernel_msg_show:nnxxxx { tl } { show-analysis }
           { \token_to_str:N #1 } { \@@_analysis_show: } { } { }
       }
       { \tl_show:N #1 }
@@ -998,7 +998,7 @@
 \cs_new_protected:Npn \tl_analysis_show:n #1
   {
     \@@_analysis:n {#1}
-    \__kernel_msg_show:nnxxxx { tl } { show-tl-analysis }
+    \__kernel_msg_show:nnxxxx { tl } { show-analysis }
       { } { \@@_analysis_show: } { } { }
   }
 %    \end{macrocode}
@@ -1482,7 +1482,7 @@
 % \end{variable}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { tl } { show-tl-analysis }
+\__kernel_msg_new:nnn { tl } { show-analysis }
   {
     The~token~list~ \tl_if_empty:nF {#1} { #1 ~ }
     \tl_if_empty:nTF {#2}

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -990,7 +990,7 @@
     \tl_if_exist:NTF #1
       {
         \exp_args:No \@@_analysis:n {#1}
-        \msg_show:nnxxxx { LaTeX / tl } { show-tl-analysis }
+        \__kernel_msg_show:nnxxxx { tl } { show-tl-analysis }
           { \token_to_str:N #1 } { \@@_analysis_show: } { } { }
       }
       { \tl_show:N #1 }
@@ -998,7 +998,7 @@
 \cs_new_protected:Npn \tl_analysis_show:n #1
   {
     \@@_analysis:n {#1}
-    \msg_show:nnxxxx { LaTeX / tl } { show-tl-analysis }
+    \__kernel_msg_show:nnxxxx { tl } { show-tl-analysis }
       { } { \@@_analysis_show: } { } { }
   }
 %    \end{macrocode}

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -1570,9 +1570,9 @@
   {
     \if_int_compare:w #2 = 10 \exp_stop_f:
       \if_int_compare:w #1 =  0 \exp_stop_f:
-        \__kernel_msg_expandable_error:nn { kernel } { char-null-space }
+        \__kernel_msg_expandable_error:nn { char } { null-space }
       \else:
-        \__kernel_msg_expandable_error:nn { kernel } { char-space }
+        \__kernel_msg_expandable_error:nn { char } { space }
       \fi:
     \else:
       \if_int_odd:w 0
@@ -1580,14 +1580,14 @@
           \if_int_compare:w #2 = 5  \exp_stop_f: 1 \fi:
           \if_int_compare:w #2 = 9  \exp_stop_f: 1 \fi:
           \if_int_compare:w #2 > 13 \exp_stop_f: 1 \fi: \exp_stop_f:
-        \__kernel_msg_expandable_error:nn { kernel }
-          { char-invalid-catcode }
+        \__kernel_msg_expandable_error:nn { char }
+          { invalid-catcode }
       \else:
         \if_int_odd:w 0
           \if_int_compare:w #1 < 0 \exp_stop_f: 1 \fi:
           \if_int_compare:w #1 > \c_max_char_int 1 \fi: \exp_stop_f:
-          \__kernel_msg_expandable_error:nn { kernel }
-            { char-out-of-range }
+          \__kernel_msg_expandable_error:nn { char }
+            { out-of-range }
         \else:
           \@@_generate_aux:nnw {#1} {#2}
         \fi:
@@ -1630,7 +1630,7 @@
             {
               #3
               \if_int_compare:w #2 = 13 \exp_stop_f:
-                \__kernel_msg_expandable_error:nn { kernel } { char-active }
+                \__kernel_msg_expandable_error:nn { char } { active }
               \else:
                 \@@_generate_auxii:nnw {#1} {#2}
               \fi:
@@ -1684,7 +1684,7 @@
 %   lists, one for each character code, using \tn{tex_lowercase:D} to
 %   convert |^^@| in each case. The \texttt{x}-type expansion ensures
 %   that \tn{tex_lowercase:D} receives the contents of the token list.
-%   |^^L| is awkward hence this is done in three parts: up to |^^L|, 
+%   |^^L| is awkward hence this is done in three parts: up to |^^L|,
 %   |^^L| itslef and above |^L|. Notice that at this stage |^^@| is active.
 %    \begin{macrocode}
       \cs_set_protected:Npn \@@_tmp:n #1

--- a/l3trial/l3fp-extras/l3fp-functions.dtx
+++ b/l3trial/l3fp-extras/l3fp-functions.dtx
@@ -370,11 +370,6 @@
 % ^^A todo: add check for number of args
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnn { fp } { num-args }
-  { Function~#1~received~#2~arguments,~not~#3. }
-%    \end{macrocode}
-%
-%    \begin{macrocode}
 %</package>
 %    \end{macrocode}
 %

--- a/l3trial/l3fp-extras/l3fp-functions.dtx
+++ b/l3trial/l3fp-extras/l3fp-functions.dtx
@@ -124,7 +124,7 @@
       { #1 #3 }
       {
         \__kernel_msg_expandable_error:nnnnn
-          { kernel } { fp-num-args } { #1() } {#2} {#2}
+          { fp } { num-args } { #1() } {#2} {#2}
         \c_nan_fp
       }
   }
@@ -187,7 +187,7 @@
         \cs_if_exist:cT { @@_parse_word_#1:N }
           {
             \__kernel_msg_error:nnn
-              { kernel } { fp-id-already-defined } {#1}
+              { fp } { id-already-defined } {#1}
             \cs_undefine:c { @@_parse_word_#1:N }
             \cs_undefine:c { @@_#1_o:w }
           }
@@ -219,7 +219,7 @@
         \cs_if_exist:NTF #2
           {
             \__kernel_msg_warning:nnnn
-              { kernel } { fp-id-used-elsewhere } {#3} { function }
+              { fp } { id-used-elsewhere } {#3} { function }
             #1 #2 \@@_tmp:w
           }
           {

--- a/l3trial/l3fp-extras/l3fp-symbolic.dtx
+++ b/l3trial/l3fp-extras/l3fp-symbolic.dtx
@@ -153,7 +153,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_symbolic_chk:w #1,#2#3;
   {
-    \__kernel_msg_error:nnx { kernel } { misused-fp }
+    \__kernel_msg_error:nnx { fp } { misused-fp }
       {
         \@@_to_tl_dispatch:w
           \s_@@_symbolic \@@_symbolic_chk:w #1,{#2};
@@ -568,7 +568,7 @@
         \cs_if_exist:NTF #2
           {
             \__kernel_msg_warning:nnnn
-              { kernel } { fp-id-used-elsewhere } {#3} { variable }
+              { fp } { id-used-elsewhere } {#3} { variable }
             #1 #2 \@@_tmp:w
           }
           {
@@ -586,7 +586,7 @@
 \cs_new_protected:Npn \fp_clear_variable:n #1
   {
     \@@_id_if_invalid:nTF {#1}
-      { \__kernel_msg_error:nnn { kernel } { fp-id-invalid } {#1} }
+      { \__kernel_msg_error:nnn { fp } { id-invalid } {#1} }
       { \exp_args:No \@@_clear_variable:n { \tl_to_str:n {#1} } }
   }
 \cs_new_protected:Npn \@@_clear_variable:n #1
@@ -607,7 +607,7 @@
 \cs_new_protected:Npn \fp_new_variable:n #1
   {
     \@@_id_if_invalid:nTF {#1}
-      { \__kernel_msg_error:nnn { kernel } { fp-id-invalid } {#1} }
+      { \__kernel_msg_error:nnn { fp } { id-invalid } {#1} }
       { \exp_args:No \@@_new_variable:n { \tl_to_str:n {#1} } }
   }
 \cs_new_protected:Npn \@@_new_variable:n #1
@@ -615,7 +615,7 @@
     \cs_if_exist:cT { @@_parse_word_#1:N }
       {
         \__kernel_msg_error:nnn
-          { kernel } { fp-id-already-defined } {#1}
+          { fp } { id-already-defined } {#1}
         \cs_undefine:c { @@_parse_word_#1:N }
         \cs_undefine:c { l_@@_variable_#1_fp }
       }
@@ -645,7 +645,7 @@
 \cs_new_protected:Npn \fp_set_variable:nn #1
   {
     \@@_id_if_invalid:nTF {#1}
-      { \__kernel_msg_error:nnn { kernel } { fp-id-invalid } {#1} }
+      { \__kernel_msg_error:nnn { fp } { id-invalid } {#1} }
       { \exp_args:No \@@_set_variable:nn { \tl_to_str:n {#1} } }
   }
 \cs_new_protected:Npn \@@_set_variable:nn #1#2
@@ -658,7 +658,7 @@
     \fp_set:cn { l_@@_variable_#1_fp } { \l_@@_symbolic_fp }
     \flag_if_raised:nT { @@_symbolic }
       {
-        \__kernel_msg_error:nnxxx { kernel } { fp-id-loop }
+        \__kernel_msg_error:nnxxx { fp } { id-loop }
           { \tl_to_str:n {#1} }
           { \tl_to_str:n {#2} }
           { \fp_to_tl:N \l_@@_symbolic_fp }
@@ -689,27 +689,27 @@
 % \subsection{Messages}
 %
 %    \begin{macrocode}
-\__kernel_msg_new:nnnn { kernel } { fp-id-invalid }
+\__kernel_msg_new:nnnn { fp } { id-invalid }
   { Floating~point~identifier~'#1'~invalid. }
   {
     \c__msg_coding_error_text_tl
     LaTeX~has~been~asked~to~create~a~new~floating~point~identifier~'#1'~
     but~this~may~only~contain~ASCII~letters.
   }
-\__kernel_msg_new:nnnn { kernel } { fp-id-already-defined }
+\__kernel_msg_new:nnnn { fp } { id-already-defined }
   { Floating~point~identifier~'#1'~already~defined. }
   {
     \c__msg_coding_error_text_tl
     LaTeX~has~been~asked~to~create~a~new~floating~point~identifier~'#1'~
     but~this~name~has~already~been~used~elsewhere.
   }
-\__kernel_msg_new:nnnn { kernel } { fp-id-used-elsewhere }
+\__kernel_msg_new:nnnn { fp } { id-used-elsewhere }
   { Floating~point~identifier~'#1'~already~used~for~something~else. }
   {
     LaTeX~has~been~asked~to~create~a~new~floating~point~identifier~'#1'~
     but~this~name~is~used,~and~is~not~a~user-defined~#2.
   }
-\__kernel_msg_new:nnnn { kernel } { fp-id-loop }
+\__kernel_msg_new:nnnn { fp } { id-loop }
   { Variable~'#1'~used~in~the~definition~of~'#1'. }
   {
     \c__msg_coding_error_text_tl

--- a/l3trial/l3kernel-extras/l3kernel-extras.dtx
+++ b/l3trial/l3kernel-extras/l3kernel-extras.dtx
@@ -886,7 +886,7 @@
 \cs_new_protected:Npn \char_show:n #1
   {
     \int_set:Nn \l__char_code_int {#1}
-    \exp_after:wN \exp_after:wN \exp_after:wN \__char_show:N 
+    \exp_after:wN \exp_after:wN \exp_after:wN \__char_show:N
       \char_generate:nn { \l__char_code_int } { 12 }
   }
 \cs_new_protected:Npn \__char_show:N #1
@@ -941,7 +941,7 @@
           \tl_put_right:Nx \l__char_internal_tl
             { \\ not ~ in ~ current ~ font }
         }
-      \msg_show:nnxxxx { LaTeX/kernel } { show-char }
+      \msg_show:nnxxxx { LaTeX/char } { show-char }
         { \tl_to_str:n {#1} } { \tl_to_str:N \l__char_internal_tl } { } { }
     \group_end:
   }
@@ -1026,7 +1026,7 @@
       \prg_return_false:
     \fi:
   }
-\__kernel_msg_new:nnn { kernel } { show-char }
+\__kernel_msg_new:nnn { char } { show-char }
   {
     The ~ character ~ '#1' ~ has ~ character ~ code ~
     \int_eval:n { `#1 } , ~ and ~ properties #2


### PR DESCRIPTION
Messages that are truly cross-module are left as kernel,
plus those in the cs/prg modules (truly core), plus one
or two at the 'loading' stage where this seems the best description.

This is step one of looking at removing/reworking \__kernel_msg_ support.