### PR TITLE
Support ICC profiles for device colour spaces

### DIFF
--- a/l3backend/l3backend-color.dtx
+++ b/l3backend/l3backend-color.dtx
@@ -913,6 +913,37 @@
 % \end{macro}
 % \end{macro}
 %
+% \begin{macro}{\@@_backend_iccbased_device:nnn}
+%   This is very similar to setting up a color space: the only part we
+%   skip is adding it to the page resources.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_backend_iccbased_device:nnn #1#2#3
+  {
+    \pdf_object_if_exist:nF { @@_icc_ #1 }
+      {
+        \pdf_object_new:nn { @@_icc_ #1 } { fstream }
+        \pdf_object_write:nn { @@_icc_ #1 }
+          {
+            { /N ~ #3 }
+            {#1}
+          }
+      }
+    \pdf_object_unnamed_write:nx { array }
+      { /ICCBased ~ \pdf_object_ref:n { @@_icc_ #1 } }
+    \cs_if_exist:NT \pdfmanagement_add:nnn
+      {
+        \use:x
+          {
+            \pdfmanagement_add:nnn
+              { Page / Resources / ColorSpace }
+              { Default #2 }
+              { \pdf_object_ref_last: }
+          }
+      }
+  }
+%    \end{macrocode}
+% \end{macro} 
+%
 %    \begin{macrocode}
 %</dvipdfmx|luatex|pdftex|xetex>
 %    \end{macrocode}

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- `\color_iccprofile_apply:nn`
+
 ## [2021-02-18]
 
 ### Added

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -431,6 +431,23 @@
 %   a process color name (\texttt{cyan}, etc.) or the special name \texttt{none}.
 % \end{itemize}
 %
+% \subection{Color profiles}
+%
+% Color profiles are used to ensure color accuracy by linking to collaboration.
+% Applying a profile can be used to standardise color which is otherwise
+% device-dependence.
+%
+% \begin{function}[added = 2020-02-23]{\color_iccprofile_apply:nn}
+%   \begin{syntax}
+%     \cs{color_iccprofile_apply:nn} \Arg{profile} \Arg{model}
+%   \end{syntax}
+%   This function applies a \meta{profile} to one of the device \meta{models}.
+%   The profile will then apply to all color of the selected \meta{model}. The
+%   \meta{profile} should specify an ICC profile file. The \meta{model} has to
+%   be one the standard device models: \texttt{cmyk}, \texttt{gray} or
+%   \texttt{rgb}.
+% \end{function}
+%
 % \end{documentation}
 %
 % \begin{implementation}
@@ -2482,6 +2499,42 @@
 % \end{macro}
 % \end{macro}
 % \end{macro}
+% \end{macro}
+% \end{macro}
+%
+% \subsection{Applying profiles}
+%
+% \begin{macro}{\color_iccprofile_apply:nn, \@@_iccprofile_apply:nn}
+% \begin{macro}
+%   {
+%     \@@_iccprofile_apply_gray:n ,
+%     \@@_iccprofile_apply_rgb:n  ,
+%     \@@_iccprofile_apply_cmyk:n
+%   }
+%   With a limited range of outcomes, this is largely about getting data to the
+%   backend.
+%    \begin{macrocode}
+\cs_new_protected:Npn \color_iccprofile_apply:nn #1#2
+  {
+    \exp_args:Ne \@@_iccprofile_apply:nn
+      { \file_full_name:n {#1} } {#2}
+  }
+\cs_new_protected:Npn \@@_iccprofile_apply:nn #1#2
+  {
+    \cs_if_exist_use:cF { @@_iccprofile_apply_ \tl_to_str:n {#2} :n }
+      {
+        \__kernel_msg_error:nnn { color } { ICC-Device-unknown } {#2}
+        \use_none:n
+      }
+        {#1}
+  }
+\cs_new_protected:Npn \@@_iccprofile_apply_gray:n #1
+  { \@@_backend_iccbased_device:nnn {#1} { Gray } { 1 } }
+\cs_new_protected:Npn \@@_iccprofile_apply_rgb:n #1
+  { \@@_backend_iccbased_device:nnn {#1} { RGB } { 3 } }
+\cs_new_protected:Npn \@@_iccprofile_apply_cmyk:n #1
+  { \@@_backend_iccbased_device:nnn {#1} { CMYK } { 4 } }
+%    \end{macrocode}
 % \end{macro}
 % \end{macro}
 %

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -2610,6 +2610,12 @@
     \\ \\
     key~was~given~with~the~correct~information.
   }
+\__kernel_msg_new:nnnn { color } { ICC-Device-unknown }
+  { Unknown~device~color~space~'#1'. }
+  {
+    LaTeX~has~been~asked~to~apply~an~ICC~profile~but~the~device~color~space~
+    '#1'~is~unknown.
+  }
 \__kernel_msg_new:nnnn { color } { model-already-defined }
   { Color~model~'#1'~already~defined. }
   {


### PR DESCRIPTION
Parallel to #855, this approach only covers modifying the 'matching' device
spaces.