### PR TITLE
Avoid hyphenation in the first run of _ in l3doc's \cs (fixes #479)

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1996,8 +1996,8 @@ and all files in that bundle must be distributed together.
             \bool_if:NT \g_@@_cs_break_bool
               {
                 \regex_replace_all:nnN
-                  {([^\\])_([^\_])}
-                  {\1\c{BreakableUnderscore}\2}
+                  { ([^\\\_]\_*) \_ ([^\_]) }
+                  { \1 \c{BreakableUnderscore} \2 }
                   \l_@@_cmd_tl
               }
           }


### PR DESCRIPTION
wspr had already done essentially all the work fixing this, but the regex
wasn't quite right: it didn't correctly omit hyphenation after a backslash
when it was followed by two (or more) underscores.