### PR TITLE
Changing items at specific positions of a sequence (fixes #844)

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -12,7 +12,7 @@ this project uses date-based 'snapshot' version identifiers.
 - `\tracingstacklevels`
 - Color export in comma-separated format
 - `\ur{...}` escape in `l3regex` to compose regexes
-- `\seq_put_item:Nnn(TF)` to change an entry of a sequence
+- `\seq_put_item:Nnn(TF)` and `\seq_pop_item:NnN(TF)`
 
 ### Changed
 - Breaking change: use prevailing catcodes instead of string in

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -12,6 +12,7 @@ this project uses date-based 'snapshot' version identifiers.
 - `\tracingstacklevels`
 - Color export in comma-separated format
 - `\ur{...}` escape in `l3regex` to compose regexes
+- `\seq_put_item:Nnn(TF)` to change an entry of a sequence
 
 ### Changed
 - Breaking change: use prevailing catcodes instead of string in

--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -434,6 +434,24 @@
 %   mappings.
 % \end{function}
 %
+% \begin{function}[added = 2021-04-28, noTF]
+%   {\seq_put_item:Nnn, \seq_put_item:cnn, \seq_gput_item:Nnn, \seq_gput_item:cnn}
+%   \begin{syntax}
+%     \cs{seq_put_item:Nnn} \meta{seq~var} \Arg{intexpr} \Arg{item}
+%     \cs{seq_put_item:NnnTF} \meta{seq~var} \Arg{intexpr} \Arg{item} \Arg{true code} \Arg{false code}
+%   \end{syntax}
+%   Removes the item of \meta{sequence} at the position given by
+%   evaluating the \meta{integer expression} and replaces it by
+%   \meta{item}.  Items are indexed from $1$ on the left/top of the
+%   \meta{sequence}, or from $-1$ on the right/bottom.  If the
+%   \meta{integer expression} is zero or is larger (in absolute value)
+%   than the number of items in the sequence, the \meta{sequence} is not
+%   modified.  In these cases, \cs{seq_put_item:Nnn} raises an error
+%   while \cs{seq_put_item:NnnTF} runs the \meta{false code}.  In cases
+%   where the assignment was successful, \meta{true code} is run
+%   afterwards.
+% \end{function}
+%
 % \section{Additions to \pkg{l3sys}}
 %
 % \begin{variable}[added = 2018-05-02]{\c_sys_engine_version_str}
@@ -1124,6 +1142,123 @@
 \cs_new_protected:Npn \seq_gset_from_function:NnN #1#2#3
   { \seq_gset_from_inline_x:Nnn #1 {#2} { #3 {##1} } }
 %    \end{macrocode}
+% \end{macro}
+%
+%
+% \begin{macro}{\@@_int_eval:w}
+%   Useful to more quickly go through items.
+%    \begin{macrocode}
+\cs_new_eq:NN \@@_int_eval:w \tex_numexpr:D
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[noTF]{\seq_put_item:Nnn, \seq_put_item:cnn, \seq_gput_item:Nnn, \seq_gput_item:cnn}
+% \begin{macro}{\@@_put_item:NnnNN, \@@_put_item:nnNNNN, \@@_put_item_false:nnNNNN, \@@_put_item:nNnnNNNN}
+% \begin{macro}[rEXP]{\@@_put_item:wn, \@@_put_item_end:w}
+%   The conditionals are distinguished from the |Nnn| versions by the
+%   last argument \cs{use_ii:nn} vs \cs{use_i:nn}.
+%    \begin{macrocode}
+\cs_new_protected:Npn \seq_put_item:Nnn #1#2#3
+  { \@@_put_item:NnnNN #1 {#2} {#3} \__kernel_tl_set:Nx \use_i:nn }
+\cs_new_protected:Npn \seq_gput_item:Nnn #1#2#3
+  { \@@_put_item:NnnNN #1 {#2} {#3} \__kernel_tl_gset:Nx \use_i:nn }
+\cs_generate_variant:Nn \seq_put_item:Nnn { c }
+\cs_generate_variant:Nn \seq_gput_item:Nnn { c }
+\prg_new_protected_conditional:Npnn \seq_put_item:Nnn #1#2#3 { TF , T , F }
+  { \@@_put_item:NnnNN #1 {#2} {#3} \__kernel_tl_set:Nx \use_ii:nn }
+\prg_new_protected_conditional:Npnn \seq_gput_item:Nnn #1#2#3 { TF , T , F }
+  { \@@_put_item:NnnNN #1 {#2} {#3} \__kernel_tl_gset:Nx \use_ii:nn }
+\prg_generate_conditional_variant:Nnn \seq_put_item:Nnn { c } { TF , T , F }
+\prg_generate_conditional_variant:Nnn \seq_gput_item:Nnn { c } { TF , T , F }
+%    \end{macrocode}
+%   Save the item to be stored and evaluate the position and the sequence
+%   length only once.  Then depending on the sign of the position, check
+%   that it is not bigger than the length (in absolute value) nor zero.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_put_item:NnnNN #1#2#3
+  {
+    \tl_set:Nn \l_@@_internal_a_tl { \@@_item:n {#3} }
+    \exp_args:Nff \@@_put_item:nnNNNN
+      { \int_eval:n {#2} } { \seq_count:N #1 } #1 \use_none:nn
+  }
+\cs_new_protected:Npn \@@_put_item:nnNNNN #1#2
+  {
+    \int_compare:nNnTF {#1} > 0
+      { \int_compare:nNnF {#1} > {#2} { \@@_put_item:nNnnNNNN { #1 - 1 } } }
+      {
+        \int_compare:nNnF {#1} < {-#2}
+          {
+            \int_compare:nNnF {#1} = 0
+              { \@@_put_item:nNnnNNNN { #2 + #1 } }
+          }
+      }
+    \@@_put_item_false:nnNNNN {#1} {#2}
+  }
+%    \end{macrocode}
+%   If the position is not ok, \cs{@@_put_item_false:nnNNNN} calls an
+%   error or returns \texttt{false} (depending on the \cs{use_i:nn} vs
+%   \cs{use_ii:nn} argument mentioned above).
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_put_item_false:nnNNNN #1#2#3#4#5#6
+  {
+    #6
+      {
+        \__kernel_msg_error:nnxxx { seq } { item-too-large }
+          { \token_to_str:N #3 } {#2} {#1}
+      }
+      { \prg_return_false: }
+  }
+\__kernel_msg_new:nnnn { seq } { item-too-large }
+  { Sequence~'#1'~does~not~have~an~item~#3 }
+  {
+    An~attempt~was~made~to~push~or~pop~the~item~at~position~#3~
+    of~'#1',~but~this~
+    \int_compare:nTF { #3 = 0 }
+      { position~does~not~exist. }
+      { sequence~only~has~#2~item \int_compare:nF { #2 = 1 } {s}. }
+  }
+%    \end{macrocode}
+%   If the position is ok, \cs{@@_put_item:nNnnNNNN} makes the assignment
+%   and returns \texttt{true} (in the case of conditionnals).  Here |#1|
+%   is an integer expression (position minus one), it needs to be
+%   evaluated.  The sequence |#5| starts with \cs{s_@@} (even if empty),
+%   which stops the integer expression and is absorbed by it.  The
+%   \cs{if_meaning:w} test is slightly faster than an integer test (but
+%   only works when testing against zero, hence the offset we chose in
+%   the position).  When we are done skipping items, insert the saved
+%   item \cs{l_@@_internal_a_tl}.  For |put| functions the last argument
+%   of \cs{@@_put_item_end:w} is \cs{use_none:nn} and it absorbs the
+%   item |#2| that we are removing: this is only useful for the |pop|
+%   functions.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_put_item:nNnnNNNN #1#2#3#4#5#6#7#8
+  {
+    #7 #5
+      {
+        \s_@@
+        \exp_after:wN \@@_put_item:wn
+        \int_value:w \@@_int_eval:w #1
+        #5 \s_@@_stop #6
+      }
+    #8 { } { \prg_return_true: }
+  }
+\cs_new:Npn \@@_put_item:wn #1 \@@_item:n #2
+  {
+    \if_meaning:w 0 #1 \@@_put_item_end:w \fi:
+    \exp_not:n { \@@_item:n {#2} }
+    \exp_after:wN \@@_put_item:wn
+    \int_value:w \@@_int_eval:w #1 - 1 \s_@@
+  }
+\cs_new:Npn \@@_put_item_end:w #1 \exp_not:n #2 #3 \s_@@ #4 \s_@@_stop #5
+  {
+    #1
+    \exp_not:o \l_@@_internal_a_tl
+    \exp_not:n {#4}
+    #5 #2
+  }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
 % \end{macro}
 %
 % \subsection{Additions to \pkg{l3sys}}

--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -452,6 +452,24 @@
 %   afterwards.
 % \end{function}
 %
+% \begin{function}[added = 2021-04-28, noTF]
+%   {\seq_pop_item:NnN, \seq_pop_item:cnN, \seq_gpop_item:NnN, \seq_gpop_item:cnN}
+%   \begin{syntax}
+%     \cs{seq_pop_item:NnN} \meta{seq~var} \Arg{intexpr} \Arg{tl~var}
+%     \cs{seq_pop_item:NnNTF} \meta{seq~var} \Arg{intexpr} \Arg{tl~var} \Arg{true code} \Arg{false code}
+%   \end{syntax}
+%   Removes the \meta{item} at position \meta{integer expression} in the
+%   \meta{sequence}, and places it in the \meta{token list variable}.
+%   Items are indexed from $1$ on the left/top of the \meta{sequence},
+%   or from $-1$ on the right/bottom.  If the position is zero or is
+%   larger (in absolute value) than the number of items in the sequence,
+%   the \meta{seq~var} is not modified, the \meta{token list} is set to
+%   the special marker \cs{q_no_value}, and the \meta{false code} is
+%   left in the input stream; otherwise the \meta{true code} is.  The
+%   \meta{token list} assignment is local while the \meta{sequence} is
+%   assigned locally for |pop| or globally for |gpop| functions.
+% \end{function}
+%
 % \section{Additions to \pkg{l3sys}}
 %
 % \begin{variable}[added = 2018-05-02]{\c_sys_engine_version_str}
@@ -1258,6 +1276,60 @@
   }
 %    \end{macrocode}
 % \end{macro}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}[noTF]{\seq_pop_item:NnN, \seq_pop_item:cnN, \seq_gpop_item:NnN, \seq_gpop_item:cnN}
+% \begin{macro}{\@@_pop_item:NnNNN}
+%   The |NnN| versions simply call the conditionals, for which we will
+%   rely on the internals of \cs{seq_put_item:Nnn}.
+%    \begin{macrocode}
+\cs_new_protected:Npn \seq_pop_item:NnN #1#2#3
+  { \seq_pop_item:NnNTF #1 {#2} #3 { } { } }
+\cs_new_protected:Npn \seq_gpop_item:NnN #1#2#3
+  { \seq_gpop_item:NnNTF #1 {#2} #3 { } { } }
+\cs_generate_variant:Nn \seq_pop_item:NnN { c }
+\cs_generate_variant:Nn \seq_gpop_item:NnN { c }
+\prg_new_protected_conditional:Npnn \seq_pop_item:NnN #1#2#3 { TF , T , F }
+  { \@@_pop_item:NnNN #1 {#2} #3 \__kernel_tl_set:Nx }
+\prg_new_protected_conditional:Npnn \seq_gpop_item:NnN #1#2#3 { TF , T , F }
+  { \@@_pop_item:NnNN #1 {#2} #3 \__kernel_tl_gset:Nx }
+\prg_generate_conditional_variant:Nnn \seq_pop_item:NnN { c } { TF , T , F }
+\prg_generate_conditional_variant:Nnn \seq_gpop_item:NnN { c } { TF , T , F }
+%    \end{macrocode}
+%   Save in \cs{l_@@_internal_b_tl} the token list variable |#3| in
+%   which we will store the item.  The \cs{@@_put_item:nnNNNN} auxiliary
+%   eventually inserts \cs{l_@@_internal_a_tl} in place of the item
+%   found in the sequence, so we empty that.  Instead of the last
+%   argument \cs{use_i:nn} or \cs{use_ii:nn} used for |put| functions,
+%   we introduce \cs{@@_pop_item:nn}, which stores \cs{q_no_value}
+%   before calling its second argument
+%   (\cs{prg_return_true:}/\texttt{false:}) to end the conditional.  The
+%   item found is passed to \cs{@@_pop_item_aux:w}, which interrupts the
+%   |x|-expanding sequence assignment and stores the item using the
+%   assignment function in \cs{l_@@_internal_b_tl}.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_pop_item:NnNN #1#2#3#4
+  {
+    \tl_clear:N \l_@@_internal_a_tl
+    \tl_set:Nn \l_@@_internal_b_tl { \__kernel_tl_set:Nx #3 }
+    \exp_args:Nff \@@_put_item:nnNNNN
+      { \int_eval:n {#2} } { \seq_count:N #1 }
+      #1 \@@_pop_item_aux:w #4 \@@_pop_item:nn
+  }
+\cs_new_protected:Npn \@@_pop_item:nn #1#2
+  {
+    \if_meaning:w \prg_return_false: #2
+      \l_@@_internal_b_tl { \exp_not:N \q_no_value }
+    \fi:
+    #2
+  }
+\cs_new:Npn \@@_pop_item_aux:w \@@_item:n #1
+  {
+    \if_false: { \fi: }
+    \l_@@_internal_b_tl { \if_false: } \fi: \exp_not:n {#1}
+  }
+%    \end{macrocode}
 % \end{macro}
 % \end{macro}
 %

--- a/l3kernel/testfiles/m3seq005.lvt
+++ b/l3kernel/testfiles/m3seq005.lvt
@@ -90,4 +90,47 @@
     \seq_gput_item:NnnTF \g_tmpa_seq { 5 } { #\par } { \TRUE } { \FALSE } \seq_show:N \g_tmpa_seq
   }
 
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { seq_pop_item:NnN }
+  {
+    \cs_set_protected:Npn \test_log: { \seq_log:N \l_tmpa_seq \tl_log:N \l_tmpa_tl }
+    %
+    \seq_clear:N \l_tmpa_seq
+    \tl_clear:N \l_tmpa_tl
+    \seq_pop_item:NnN \l_tmpa_seq { 0 } \l_tmpa_tl \test_log:
+    \tl_clear:N \l_tmpa_tl
+    \seq_pop_item:cnN { l_tmpa_seq } { 1 } \l_tmpa_tl \test_log:
+    \tl_clear:N \l_tmpa_tl
+    \seq_pop_item:cnNTF { l_tmpa_seq } { -11 } \l_tmpa_tl { \TRUE } { \FALSE } \test_log:
+    %
+    \SEPARATOR
+    \tl_clear:N \l_tmpa_tl
+    \seq_put_right:Nn \l_tmpa_seq { \AAA }
+    \seq_put_right:Nn \l_tmpa_seq { \BBB }
+    \seq_pop_item:cnN { l_tmpa_seq } { 0 } \l_tmpa_tl \test_log:
+    \group_begin:
+      \seq_pop_item:NnN \l_tmpa_seq { 1 } \l_tmpa_tl \test_log:
+    \group_end:
+    \seq_pop_item:cnNTF { l_tmpa_seq } { 0 } \l_tmpa_tl { \TRUE } { \FALSE } \test_log:
+    \seq_pop_item:NnNTF \l_tmpa_seq { 2+3-4 } \g_tmpa_tl { \TRUE } { \FALSE } \test_log:
+    \tl_log:N \g_tmpa_tl
+    \seq_gpop_item:cnNTF { l_tmpa_seq } { -1 } \l_tmpa_tl { \TRUE } { \FALSE } \test_log:
+    %
+    \SEPARATOR
+    \cs_set_protected:Npn \test_log: { \seq_log:N \g_tmpa_seq \tl_log:N \l_tmpa_tl }
+    \seq_gset_split:Nnn \g_tmpa_seq { } { { \AAA } { \B\B } { { } } { # } }
+    \tl_clear:N \l_tmpa_tl
+    \seq_gpop_item:cnN { g_tmpa_seq } { 0 } \l_tmpa_tl \test_log:
+    \seq_gpop_item:NnN \g_tmpa_seq { 1 } \l_tmpa_tl \test_log:
+    \group_begin:
+      \seq_gpop_item:cnN { g_tmpa_seq } { 1+2-5 } \l_tmpa_tl \test_log:
+      \seq_gpop_item:NnNTF \g_tmpa_seq { 0 } \l_tmpa_tl { \TRUE } { \FALSE } \test_log:
+      \seq_gpop_item:cnNTF { g_tmpa_seq } { -1 } \l_tmpa_tl { \TRUE } { \FALSE } \test_log:
+    \group_end:
+    \seq_gpop_item:NnNTF \g_tmpa_seq { 5 } \l_tmpa_tl { \TRUE } { \FALSE } \test_log:
+    \seq_gpop_item:NnNTF \g_tmpa_seq { 1 } \g_tmpa_tl { \TRUE } { \FALSE } \test_log:
+    \tl_show:N \g_tmpa_tl
+  }
+
 \END

--- a/l3kernel/testfiles/m3seq005.lvt
+++ b/l3kernel/testfiles/m3seq005.lvt
@@ -53,4 +53,41 @@
   \test:f { \seq_item:Nn \l_foo_seq {-4} }
 }
 
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { seq_put_item:Nnn }
+  {
+    \seq_clear:N \l_tmpa_seq
+    \seq_put_item:Nnn \l_tmpa_seq { 0 } { a }
+    \seq_put_item:cnn { l_tmpa_seq } { 1 } { a }
+    \seq_put_item:Nnn \l_tmpa_seq { 1+2-4 } { a }
+    \seq_put_item:cnnTF { l_tmpa_seq } { 0 } { a } { \TRUE } { \FALSE }
+    \seq_put_item:NnnTF \l_tmpa_seq { 12+3-4 } { a } { \TRUE } { \FALSE }
+    \seq_put_item:cnnTF { l_tmpa_seq } { -11 } { a } { \TRUE } { \FALSE }
+    %
+    \SEPARATOR
+    \seq_put_right:Nn \l_tmpa_seq { \AAA }
+    \seq_put_item:cnn { l_tmpa_seq } { 0 } { a } \seq_show:N \l_tmpa_seq
+    \group_begin:
+      \seq_put_item:Nnn \l_tmpa_seq { 1 } { a } \seq_show:N \l_tmpa_seq
+      \seq_put_item:cnn { l_tmpa_seq } { 2 } { a } \seq_show:N \l_tmpa_seq
+      \seq_put_item:Nnn \l_tmpa_seq { 1+2-4 } { \xy } \seq_show:N \l_tmpa_seq
+    \group_end:
+    \seq_put_item:cnnTF { l_tmpa_seq } { 0 } { # } { \TRUE } { \FALSE } \seq_show:N \l_tmpa_seq
+    \seq_put_item:NnnTF \l_tmpa_seq { 2+3-4 } { { \aa } } { \TRUE } { \FALSE } \seq_show:N \l_tmpa_seq
+    \seq_put_item:cnnTF { l_tmpa_seq } { -1 } { } { \TRUE } { \FALSE } \seq_show:N \l_tmpa_seq
+    %
+    \SEPARATOR
+    \seq_gset_split:Nnn \g_tmpa_seq { } { { \AAA } { \B\B } { { } } { # } }
+    \seq_gput_item:cnn { g_tmpa_seq } { 0 } { a } \seq_show:N \g_tmpa_seq
+    \seq_gput_item:Nnn \g_tmpa_seq { 1 } { \aaa } \seq_show:N \g_tmpa_seq
+    \group_begin:
+      \seq_gput_item:cnn { g_tmpa_seq } { 1+2-5 } { \ccc } \seq_show:N \g_tmpa_seq
+      \seq_gput_item:NnnTF \g_tmpa_seq { 0 } { a } { \TRUE } { \FALSE } \seq_show:N \g_tmpa_seq
+      \seq_gput_item:cnnTF { g_tmpa_seq } { -1 } { #\par } { \TRUE } { \FALSE } \seq_show:N \g_tmpa_seq
+    \group_end:
+    \seq_gput_item:NnnTF \g_tmpa_seq { 5 } { #\par } { \TRUE } { \FALSE } \seq_show:N \g_tmpa_seq
+  }
+
 \END

--- a/l3kernel/testfiles/m3seq005.tlg
+++ b/l3kernel/testfiles/m3seq005.tlg
@@ -144,3 +144,93 @@ The sequence \g_tmpa_seq contains the items (without outer braces):
 <recently read> }
 l. ...  }
 ============================================================
+============================================================
+TEST 4: seq_pop_item:NnN
+============================================================
+The sequence \l_tmpa_seq is empty
+> .
+> \l_tmpa_tl=\q_no_value .
+The sequence \l_tmpa_seq is empty
+> .
+> \l_tmpa_tl=\q_no_value .
+FALSE
+The sequence \l_tmpa_seq is empty
+> .
+> \l_tmpa_tl=\q_no_value .
+============================================================
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {\AAA }
+>  {\BBB }.
+> \l_tmpa_tl=\q_no_value .
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {\BBB }.
+> \l_tmpa_tl=\AAA .
+FALSE
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {\AAA }
+>  {\BBB }.
+> \l_tmpa_tl=\q_no_value .
+! LaTeX3 Error: Inconsistent local/global assignment
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+This is a coding error.
+Local assignment to a global variable '\g_tmpa_tl'.
+TRUE
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {\BBB }.
+> \l_tmpa_tl=\q_no_value .
+> \g_tmpa_tl=\AAA .
+! LaTeX3 Error: Inconsistent local/global assignment
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+This is a coding error.
+Global assignment to a local variable '\l_tmpa_seq'.
+TRUE
+The sequence \l_tmpa_seq is empty
+> .
+> \l_tmpa_tl=\BBB .
+============================================================
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\AAA }
+>  {\B \B }
+>  {{}}
+>  {##}.
+> \l_tmpa_tl=\q_no_value .
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\B \B }
+>  {{}}
+>  {##}.
+> \l_tmpa_tl=\AAA .
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\B \B }
+>  {##}.
+> \l_tmpa_tl={}.
+FALSE
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\B \B }
+>  {##}.
+> \l_tmpa_tl=\q_no_value .
+TRUE
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\B \B }.
+> \l_tmpa_tl=##.
+FALSE
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\B \B }.
+> \l_tmpa_tl=\q_no_value .
+! LaTeX3 Error: Inconsistent local/global assignment
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+This is a coding error.
+Local assignment to a global variable '\g_tmpa_tl'.
+TRUE
+The sequence \g_tmpa_seq is empty
+> .
+> \l_tmpa_tl=\q_no_value .
+> \g_tmpa_tl=\B \B .
+<recently read> }
+l. ...  }
+============================================================

--- a/l3kernel/testfiles/m3seq005.tlg
+++ b/l3kernel/testfiles/m3seq005.tlg
@@ -23,3 +23,124 @@ TEST 2: seq_item:Nn
 |\scan_stop: |
 ||
 ============================================================
+============================================================
+TEST 3: seq_put_item:Nnn
+============================================================
+! LaTeX3 Error: Sequence '\l_tmpa_seq' does not have an item 0
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+An attempt was made to push or pop the item at position 0 of '\l_tmpa_seq',
+but this position does not exist.
+! LaTeX3 Error: Sequence '\l_tmpa_seq' does not have an item 1
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+An attempt was made to push or pop the item at position 1 of '\l_tmpa_seq',
+but this sequence only has 0 items.
+! LaTeX3 Error: Sequence '\l_tmpa_seq' does not have an item -1
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+An attempt was made to push or pop the item at position -1 of '\l_tmpa_seq',
+but this sequence only has 0 items.
+FALSE
+FALSE
+FALSE
+============================================================
+! LaTeX3 Error: Sequence '\l_tmpa_seq' does not have an item 0
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+An attempt was made to push or pop the item at position 0 of '\l_tmpa_seq',
+but this position does not exist.
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {\AAA }.
+<recently read> }
+l. ...  }
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {a}.
+<recently read> }
+l. ...  }
+! LaTeX3 Error: Sequence '\l_tmpa_seq' does not have an item 2
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+An attempt was made to push or pop the item at position 2 of '\l_tmpa_seq',
+but this sequence only has 1 item.
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {a}.
+<recently read> }
+l. ...  }
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {\xy }.
+<recently read> }
+l. ...  }
+FALSE
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {\AAA }.
+<recently read> }
+l. ...  }
+TRUE
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {{\aa }}.
+<recently read> }
+l. ...  }
+TRUE
+The sequence \l_tmpa_seq contains the items (without outer braces):
+>  {}.
+<recently read> }
+l. ...  }
+============================================================
+! LaTeX3 Error: Sequence '\g_tmpa_seq' does not have an item 0
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+An attempt was made to push or pop the item at position 0 of '\g_tmpa_seq',
+but this position does not exist.
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\AAA }
+>  {\B \B }
+>  {{}}
+>  {##}.
+<recently read> }
+l. ...  }
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\aaa }
+>  {\B \B }
+>  {{}}
+>  {##}.
+<recently read> }
+l. ...  }
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\aaa }
+>  {\B \B }
+>  {\ccc }
+>  {##}.
+<recently read> }
+l. ...  }
+FALSE
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\aaa }
+>  {\B \B }
+>  {\ccc }
+>  {##}.
+<recently read> }
+l. ...  }
+TRUE
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\aaa }
+>  {\B \B }
+>  {\ccc }
+>  {##\par }.
+<recently read> }
+l. ...  }
+FALSE
+The sequence \g_tmpa_seq contains the items (without outer braces):
+>  {\aaa }
+>  {\B \B }
+>  {\ccc }
+>  {##\par }.
+<recently read> }
+l. ...  }
+============================================================


### PR DESCRIPTION
- `\seq_put_item:Nnn` places an item at a certain position in the sequence (removing the item that was previously there), and errors if the position is out of bounds (zero or larger [in absolute value] than the number of items)
- `\seq_put_item:NnnTF` does not error, it returns false if the position is out of bounds
- `\seq_pop_item:NnN(TF)` does not error: it removes the item if possible and stores it in `#3`, and if the position is out of bounds it does not change the sequence and it stores `\q_no_value` in `#3`

Thoughts about the interface are welcome.  Especially what `\seq_put_item:Nnn` should do when the position is out of bounds.  Two useful comparisons: the `\seq_item:Nn` function simply expands to nothing if the position is out of bounds, and the `\prop_put:Nnn` function of course adds the key to the prop.