### PR TITLE
Faster align safe groups

### DIFF
--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -1637,11 +1637,8 @@
 %   that the successive expansions of \cs{group_align_safe_begin/end:}
 %   are always brace balanced.
 %    \begin{macrocode}
-\group_begin:
-\tex_catcode:D `\^^@ = 2 \exp_stop_f:
 \cs_new:Npn \group_align_safe_begin:
-  { \exp:w \if_false: { \fi: `^^@ \exp_stop_f: }
-\group_end:
+  { \exp:w \if_false: { \fi: -`} \exp_stop_f: }
 \cs_new:Npn \group_align_safe_end:
   { \if_int_compare:w `{ = \c_zero_int } \fi: }
 %    \end{macrocode}

--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -1620,7 +1620,7 @@
 %   \TeX{}'s alignment structures present many problems. As Knuth says
 %   himself in \emph{\TeX : The Program}: \enquote{It's sort of a miracle
 %   whenever \tn{halign} or \tn{valign} work, [\ldots]} One problem relates
-%   to commands that internally issues a \tn{cr} but also peek ahead for
+%   to commands that internally issue a \tn{cr} but also peek ahead for
 %   the next character for use in, say, an optional argument. If the
 %   next token happens to be a |&| with category code~4 we get some
 %   sort of weird error message because the underlying
@@ -1631,8 +1631,12 @@
 %   special group so that \TeX{} still thinks it's on safe ground but at
 %   the same time we don't want to introduce any brace group that may
 %   find its way to the output. The following functions help with this
-%   by using code documented only in Appendix~D of
+%   by using behaviour documented only in Appendix~D of
 %   \emph{The \TeX{}book}\dots
+%   In short evaluating |`{| and |`}| as numbers will not change the counter
+%   \TeX{} uses to keep track of its state in an alignment, whereas gobbling a
+%   brace using \cs{if_false:} will affect \TeX's state without producing any
+%   real group.
 %   We place the \cs{if_false:} |{| \cs{fi:} part at that place so
 %   that the successive expansions of \cs{group_align_safe_begin/end:}
 %   are always brace balanced.

--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -1637,8 +1637,11 @@
 %   that the successive expansions of \cs{group_align_safe_begin/end:}
 %   are always brace balanced.
 %    \begin{macrocode}
+\group_begin:
+\tex_catcode:D `\^^@ = 2 \exp_stop_f:
 \cs_new:Npn \group_align_safe_begin:
-  { \if_int_compare:w \if_false: { \fi: `} = \c_zero_int \fi: }
+  { \exp:w \if_false: { \fi: `^^@ \exp_stop_f: }
+\group_end:
 \cs_new:Npn \group_align_safe_end:
   { \if_int_compare:w `{ = \c_zero_int } \fi: }
 %    \end{macrocode}


### PR DESCRIPTION
This PR changes the `\group_align_safe_begin:` macro to be faster. This is accomplished by using `\romannumeral` for the evaluation of `\`}` instead of an unnecessary `\ifnum` comparison.

The code in the first commit of this PR is faster than that of the second commit, but uses non-standard category codes and might therefore be slightly less stable in edge cases.

The implementation is more than 10% faster than the previous one.