### PR TITLE
Add missing show and log commands (fixes #241)

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,6 +10,7 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - `\sys_timer:`
 - `\color_log:n`, `\tl_log_analysis:N`, `\tl_log_analysis:n` (issue #241)
+- `\coffin_show:Nnn` and related functions (issue #241)
 
 ## [2021-05-11]
 

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -12,6 +12,7 @@ this project uses date-based 'snapshot' version identifiers.
 - `\color_log:n`, `\tl_log_analysis:N`, `\tl_log_analysis:n` (issue #241)
 - `\coffin_show:Nnn` and related functions (issue #241)
 - `\ior_show:N`, `\iow_show:N` and log functions (issue #241)
+- `\group_show_list:` and log function (issue #241)
 
 ## [2021-05-11]
 

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -11,6 +11,7 @@ this project uses date-based 'snapshot' version identifiers.
 - `\sys_timer:`
 - `\color_log:n`, `\tl_log_analysis:N`, `\tl_log_analysis:n` (issue #241)
 - `\coffin_show:Nnn` and related functions (issue #241)
+- `\ior_show:N`, `\iow_show:N` and log functions (issue #241)
 
 ## [2021-05-11]
 

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,7 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 - `\sys_timer:`
-- `\tl_log_analysis:N`, `\tl_log_analysis:n` (issue #241)
+- `\color_log:n`, `\tl_log_analysis:N`, `\tl_log_analysis:n` (issue #241)
 
 ## [2021-05-11]
 

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,10 +9,11 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 - `\sys_timer:`
-- `\color_log:n`, `\tl_log_analysis:N`, `\tl_log_analysis:n` (issue #241)
-- `\coffin_show:Nnn` and related functions (issue #241)
-- `\ior_show:N`, `\iow_show:N` and log functions (issue #241)
-- `\group_show_list:` and log function (issue #241)
+- Functions to show and log various datatypes (issue #241):
+  `\coffin_show:Nnn`, `\coffin_show:N`, `\coffin_log:Nnn`, `\coffin_log:N`,
+  `\color_log:n`, `\group_show_list:`, `\group_log_list:`,
+  `\ior_show:N`, `\ior_log:N`, `\iow_show:N`, `\iow_log:N`,
+  `\tl_log_analysis:N`, `\tl_log_analysis:n`
 
 ## [2021-05-11]
 

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 - `\sys_timer:`
+- `\tl_log_analysis:N`, `\tl_log_analysis:n` (issue #241)
 
 ## [2021-05-11]
 

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -108,6 +108,18 @@
 %   |}| if standard category codes apply.
 % \end{function}
 %
+% \begin{function}[added = 2021-05-11]{\group_show_list:, \group_log_list:}
+%   \begin{syntax}
+%     \cs{group_show_list:}
+%     \cs{group_log_list:}
+%   \end{syntax}
+%   Display (to the terminal or log file) a list of the groups that are
+%   currently opened.  This is intended for tracking down problems.
+%   \begin{texnote}
+%     This is a wrapper around the \tn{showgroups} primitive.
+%   \end{texnote}
+% \end{function}
+%
 % \section{Control sequences and functions}
 %
 % As \TeX{} is a macro language, creating new functions means
@@ -3149,6 +3161,35 @@
       \exp_args:NNx
     \group_end:
     #1 { \token_to_str:N #2 = \cs_meaning:N #2 }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\group_show_list:, \group_log_list:, \@@_group_show:NN}
+%   Wrapper around \tn{showgroups}.  Getting \TeX{} to write to the log
+%   without interruption the run is done by altering the interaction
+%   mode.
+%    \begin{macrocode}
+\cs_new_protected:Npn \group_show_list:
+  { \@@_group_show:NN \use_none:n 1 }
+\cs_new_protected:Npn \group_log_list:
+  { \@@_group_show:NN \int_zero:N 0 }
+\cs_new_protected:Npn \@@_group_show:NN #1#2
+  {
+    \use:x
+      {
+        #1 \tex_interactionmode:D
+        \int_set:Nn \tex_tracingonline:D  {#2}
+        \int_set:Nn \tex_errorcontextlines:D { -1 }
+        \exp_not:N \exp_after:wN \scan_stop:
+        \tex_showgroups:D
+        \int_set:Nn \tex_interactionmode:D
+          { \int_use:N \tex_interactionmode:D }
+        \int_set:Nn \tex_tracingonline:D
+          { \int_use:N \tex_tracingonline:D }
+        \int_set:Nn \tex_errorcontextlines:D
+          { \int_use:N \tex_errorcontextlines:D }
+      }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -381,6 +381,31 @@
 %   which displays the result in the terminal.
 % \end{function}
 %
+% \begin{function}[added = 2021-05-11]
+%   {\coffin_show:N, \coffin_show:c, \coffin_log:N, \coffin_log:c}
+%   \begin{syntax}
+%     \cs{coffin_show:N} \meta{coffin}
+%     \cs{coffin_log:N} \meta{coffin}
+%   \end{syntax}
+%   Shows full details of poles and contents of the \meta{coffin} in the
+%   terminal or log file.  See \cs{coffin_show_structure:N} and
+%   \cs{box_show:N} to show separately the pole structure and the
+%   contents.
+% \end{function}
+%
+% \begin{function}[added = 2021-05-11]
+%   {\coffin_show:Nnn, \coffin_show:cnn, \coffin_log:Nnn, \coffin_log:cnn}
+%   \begin{syntax}
+%     \cs{coffin_show:Nnn} \meta{coffin} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{coffin_log:Nnn} \meta{coffin} \Arg{intexpr_1} \Arg{intexpr_2}
+%   \end{syntax}
+%   Shows poles and contents of the \meta{coffin} in the terminal or log
+%   file, showing the first \meta{intexpr_1} items in the coffin, and
+%   descending into \meta{intexpr_2} group levels.  See
+%   \cs{coffin_show_structure:N} and \cs{box_show:Nnn} to show
+%   separately the pole structure and the contents.
+% \end{function}
+%
 % \section{Constants and variables}
 %
 % \begin{variable}{\c_empty_coffin}
@@ -2476,6 +2501,40 @@
               \msg_show_item_unbraced:nn
           }
           { }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}
+%   {
+%     \coffin_show:N, \coffin_show:c, \coffin_log:N, \coffin_log:c,
+%     \coffin_show:Nnn, \coffin_show:cnn, \coffin_log:Nnn, \coffin_log:cnn,
+%     \@@_show:NNNnn
+%   }
+%   Essentially a combination of \cs{coffin_show_structure:N} and
+%   \cs{box_show:Nnn}, but we need to avoid having two prompts, so we
+%   use \cs{__kernel_msg_term:nnxxxx} instead of
+%   \cs{__kernel_msg_show:nnxxxx} in the |show| case.
+%    \begin{macrocode}
+\cs_new_protected:Npn \coffin_show:N #1
+  { \coffin_show:Nnn #1 \c_max_int \c_max_int }
+\cs_generate_variant:Nn \coffin_show:N { c }
+\cs_new_protected:Npn \coffin_log:N #1
+  { \coffin_log:Nnn #1 \c_max_int \c_max_int }
+\cs_generate_variant:Nn \coffin_log:N { c }
+\cs_new_protected:Npn \coffin_show:Nnn
+  { \@@_show:NNNnn \__kernel_msg_term:nnxxxx \box_show:Nnn }
+\cs_generate_variant:Nn \coffin_show:Nnn { c }
+\cs_new_protected:Npn \coffin_log:Nnn
+  { \@@_show:NNNnn \__kernel_msg_log:nnxxxx \box_show:Nnn }
+\cs_generate_variant:Nn \coffin_log:Nnn { c }
+\cs_new_protected:Npn \@@_show:NNNnn #1#2#3#4#5
+  {
+    \@@_if_exist:NT #3
+      {
+        \@@_show_structure:NN #1 #3
+        #2 #3 {#4} {#5}
       }
   }
 %    \end{macrocode}

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -235,12 +235,13 @@
 %   it to be saved to a name.
 % \end{function}
 %
-% \begin{function}{\color_show:n}
+% \begin{function}[added = 2021-05-11]{\color_show:n, \color_log:n}
 %   \begin{syntax}
 %     \cs{color_show:n} \Arg{name}
+%     \cs{color_log:n} \Arg{name}
 %   \end{syntax}
 %   Displays the color specification stored in the \meta{name} on the
-%   terminal.
+%   terminal or log file.
 % \end{function}
 %
 % \section{Selecting colors}
@@ -2508,21 +2509,25 @@
 %
 % \subsection{Diagnostics}
 %
-% \begin{macro}{\color_show:n}
-% \begin{macro}{\@@_show:n}
+% \begin{macro}{\color_show:n, \color_log:n, \@@_show:Nn}
+% \begin{macro}[EXP]{\@@_show:n}
 %   Extract the information about a color and format for the user: the approach
 %   is similar to the keys module here.
 %    \begin{macrocode}
-\cs_new_protected:Npn \color_show:n #1
+\cs_new_protected:Npn \color_show:n
+  { \@@_show:Nn \__kernel_msg_show:nnxxxx }
+\cs_new_protected:Npn \color_log:n
+  { \@@_show:Nn \__kernel_msg_log:nnxxxx }
+\cs_new_protected:Npn \@@_show:Nn #1#2
   {
-    \__kernel_msg_show:nnxxxx { color } { show }
-      {#1}
+    #1 { color } { show }
+      {#2}
       {
-        \@@_if_defined:nT {#1}
+        \@@_if_defined:nT {#2}
           {
-            \exp_args:Nv \@@_show:n { l_@@_named_ #1 _tl }
+            \exp_args:Nv \@@_show:n { l_@@_named_ #2 _tl }
             \prop_map_function:cN
-              { l_@@_named_ #1 _prop }
+              { l_@@_named_ #2 _prop }
               \msg_show_item_unbraced:nn
           }
       }

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -151,6 +151,21 @@
 %   to other programmers.
 % \end{function}
 %
+% \begin{function}[added = 2021-05-11]
+%   {
+%     \ior_show:N, \ior_show:c, \ior_log:N, \ior_log:c,
+%     \iow_show:N, \iow_show:c, \iow_log:N, \iow_log:c
+%   }
+%   \begin{syntax}
+%     \cs{ior_show:N} \meta{stream}
+%     \cs{ior_log:N} \meta{stream}
+%     \cs{iow_show:N} \meta{stream}
+%     \cs{iow_log:N} \meta{stream}
+%   \end{syntax}
+%   Display (to the terminal or log file) the file name associated to
+%   the (read or write) \meta{stream}.
+% \end{function}
+%
 % \begin{function}[added = 2017-06-27]
 %   {
 %     \ior_show_list:, \ior_log_list:,
@@ -1118,6 +1133,29 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\ior_show:N, \ior_log:N, \@@_show:NN}
+%   Seek the stream in the \cs{g_@@_streams_prop} list, then show the
+%   stream as open or closed accordingly.
+%    \begin{macrocode}
+\cs_new_protected:Npn \ior_show:N { \@@_show:NN \tl_show:n }
+\cs_generate_variant:Nn \ior_show:N { c }
+\cs_new_protected:Npn \ior_log:N { \@@_show:NN \tl_log:n }
+\cs_generate_variant:Nn \ior_log:N { c }
+\cs_new_protected:Npn \@@_show:NN #1#2
+  {
+    \__kernel_chk_defined:NT #2
+      {
+        \prop_get:NVNTF \g_@@_streams_prop #2 \l_@@_internal_tl
+          {
+            \exp_args:Nx #1
+              { \token_to_str:N #2 ~ open: ~ \l_@@_internal_tl }
+          }
+          { \exp_args:Nx #1 { \token_to_str:N #2 ~ closed } }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{\ior_show_list:, \ior_log_list:}
 % \begin{macro}{\@@_list:N}
 %   Show the property lists, but with some \enquote{pretty printing}.
@@ -1354,6 +1392,13 @@
 %
 % \subsubsection{Variables and constants}
 %
+% \begin{variable}{\l_@@_internal_tl}
+%   Used as a short-term scratch variable.
+%    \begin{macrocode}
+\tl_new:N  \l_@@_internal_tl
+%    \end{macrocode}
+% \end{variable}
+%
 % \begin{variable}{\c_log_iow, \c_term_iow}
 %   Here we allocate two output streams for writing to the transcript
 %   file only (\cs{c_log_iow}) and to both the terminal and transcript
@@ -1517,6 +1562,29 @@
       }
   }
 \cs_generate_variant:Nn \iow_close:N { c }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\iow_show:N, \iow_log:N, \@@_show:NN}
+%   Seek the stream in the \cs{g_@@_streams_prop} list, then show the
+%   stream as open or closed accordingly.
+%    \begin{macrocode}
+\cs_new_protected:Npn \iow_show:N { \@@_show:NN \tl_show:n }
+\cs_generate_variant:Nn \iow_show:N { c }
+\cs_new_protected:Npn \iow_log:N { \@@_show:NN \tl_log:n }
+\cs_generate_variant:Nn \iow_log:N { c }
+\cs_new_protected:Npn \@@_show:NN #1#2
+  {
+    \__kernel_chk_defined:NT #2
+      {
+        \prop_get:NVNTF \g_@@_streams_prop #2 \l_@@_internal_tl
+          {
+            \exp_args:Nx #1
+              { \token_to_str:N #2 ~ open: ~ \l_@@_internal_tl }
+          }
+          { \exp_args:Nx #1 { \token_to_str:N #2 ~ closed } }
+      }
+  }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -1761,6 +1761,7 @@
 % \begin{macro}
 %   {
 %     \__kernel_msg_log:nnnnnn, \__kernel_msg_log:nnxxxx,
+%     \__kernel_msg_term:nnnnnn, \__kernel_msg_term:nnxxxx,
 %     \__kernel_msg_show:nnnnnn, \__kernel_msg_show:nnxxxx
 %   }
 %   For showing messages.
@@ -1768,6 +1769,9 @@
 \cs_new_protected:Npn \__kernel_msg_log:nnnnnn #1
   { \msg_log:nnnnnn { LaTeX / #1 } }
 \cs_generate_variant:Nn \__kernel_msg_log:nnnnnn { nnxxxx }
+\cs_new_protected:Npn \__kernel_msg_term:nnnnnn #1
+  { \msg_term:nnnnnn { LaTeX / #1 } }
+\cs_generate_variant:Nn \__kernel_msg_term:nnnnnn { nnxxxx }
 \cs_new_protected:Npn \__kernel_msg_show:nnnnnn #1
   { \msg_show:nnnnnn { LaTeX / #1 } }
 \cs_generate_variant:Nn \__kernel_msg_show:nnnnnn { nnxxxx }

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -75,11 +75,16 @@
 % In addition, there is a debugging function \cs{tl_analysis_show:n},
 % very similar to the \cs[no-index]{ShowTokens} macro from the \pkg{ted} package.
 %
-% \begin{function}[added = 2018-04-09]{\tl_analysis_show:N, \tl_analysis_show:n}
+% \begin{function}[added = 2021-05-11]
+%   {
+%     \tl_analysis_show:N, \tl_analysis_show:n,
+%     \tl_analysis_log:N, \tl_analysis_log:n
+%   }
 %   \begin{syntax}
 %     \cs{tl_analysis_show:n} \Arg{token list}
+%     \cs{tl_analysis_log:n} \Arg{token list}
 %   \end{syntax}
-%   Displays to the terminal the detailed decomposition of the
+%   Displays to the terminal (or log) the detailed decomposition of the
 %   \meta{token list} into tokens, showing the category code of each
 %   character token, the meaning of control sequences and active
 %   characters, and the value of registers.
@@ -978,26 +983,39 @@
 %
 % \subsection{Showing the results}
 %
-% \begin{macro}{\tl_analysis_show:N, \tl_analysis_show:n}
+% \begin{macro}{\tl_analysis_show:N, \tl_analysis_log:N, \@@_analysis_show:NNN}
 %   Add to \cs{@@_analysis:n} a third pass to display tokens to the terminal.
 %   If the token list variable is not defined, throw the same error
 %   as \cs{tl_show:N} by simply calling that function.
 %    \begin{macrocode}
-\cs_new_protected:Npn \tl_analysis_show:N #1
+\cs_new_protected:Npn \tl_analysis_show:N
+  { \@@_analysis_show:NNN \__kernel_msg_show:nnxxxx \tl_show:N }
+\cs_new_protected:Npn \tl_analysis_log:N
+  { \@@_analysis_show:NNN \__kernel_msg_log:nnxxxx \tl_log:N }
+\cs_new_protected:Npn \@@_analysis_show:NNN #1#2#3
   {
-    \tl_if_exist:NTF #1
+    \tl_if_exist:NTF #3
       {
-        \exp_args:No \@@_analysis:n {#1}
-        \__kernel_msg_show:nnxxxx { tl } { show-analysis }
-          { \token_to_str:N #1 } { \@@_analysis_show: } { } { }
+        \exp_args:No \@@_analysis:n {#3}
+        #1 { tl } { show-analysis }
+          { \token_to_str:N #3 } { \@@_analysis_show: } { } { }
       }
-      { \tl_show:N #1 }
+      { #2 #3 }
   }
-\cs_new_protected:Npn \tl_analysis_show:n #1
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\tl_analysis_show:n, \tl_analysis_log:n, \@@_analysis_show:Nn}
+%   No existence test needed here.
+%    \begin{macrocode}
+\cs_new_protected:Npn \tl_analysis_show:n
+  { \@@_analysis_show:Nn \__kernel_msg_show:nnxxxx }
+\cs_new_protected:Npn \tl_analysis_log:n
+  { \@@_analysis_show:Nn \__kernel_msg_log:nnxxxx }
+\cs_new_protected:Npn \@@_analysis_show:Nn #1#2
   {
-    \@@_analysis:n {#1}
-    \__kernel_msg_show:nnxxxx { tl } { show-analysis }
-      { } { \@@_analysis_show: } { } { }
+    \@@_analysis:n {#2}
+    #1 { tl } { show-analysis } { } { \@@_analysis_show: } { } { }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/testfiles/m3coffins001.luatex.tlg
+++ b/l3kernel/testfiles/m3coffins001.luatex.tlg
@@ -191,6 +191,14 @@ Poles of coffin \l_tmpb_coffin:
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 <recently read> }
 l. ...  }
+> \box...=
+\hbox(4.30554+1.94444)x5.00002, direction TLT
+.\pdfcolorstack 0 push {0 g 0 G}
+.\OT1/cmr/m/n/10 g
+.\pdfcolorstack 0 pop
+! OK.
+<argument> \l_tmpb_coffin 
+l. ...  }
 Size of coffin \g_tmpb_coffin:
 > ht = 4.30554pt
 > dp = 1.94444pt
@@ -205,16 +213,6 @@ Poles of coffin \g_tmpb_coffin:
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
-<recently read> }
-l. ...  }
-> \box...=
-\hbox(4.30554+1.94444)x5.00002, direction TLT
-.\pdfcolorstack 0 push {0 g 0 G}
-.\OT1/cmr/m/n/10 g
-.\pdfcolorstack 0 pop
-! OK.
-<argument> \l_tmpb_coffin 
-l. ...  }
 > \box...=
 \hbox(4.30554+1.94444)x5.00002, direction TLT
 .\pdfcolorstack 0 push {0 g 0 G}
@@ -544,6 +542,20 @@ l. ...}
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}
+Size of coffin \l_tmpa_coffin:
+> ht = 13.74443pt
+> dp = 0.0pt
+> wd = 49.43895pt
+Poles of coffin \l_tmpa_coffin:
+>  l  =>  {0pt}{0pt}{0pt}{1000pt}
+>  hc  =>  {0pt}{0pt}{0pt}{1000pt}
+>  r  =>  {0pt}{0pt}{0pt}{1000pt}
+>  b  =>  {0pt}{0pt}{1000pt}{0pt}
+>  vc  =>  {0pt}{0pt}{1000pt}{0pt}
+>  t  =>  {0pt}{0pt}{1000pt}{0pt}
+>  B  =>  {0pt}{0pt}{1000pt}{0pt}
+>  H  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 > \box...=
 \hbox(13.74443+0.0)x49.43895, direction TLT
 .\hbox(4.30554+0.0)x4.30554, direction TLT
@@ -573,18 +585,7 @@ l. ...}
 ...............\rule(*+*)x0.4
 ...............\vbox(12.94444+0.0)x44.33342, direction TLT
 ................\glue 3.0
-................\hbox(6.94444+0.0)x44.33342, direction TLT
-.................\kern3.0
-.................\OT1/cmr/m/n/10 c
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 ^^N (ligature ffi)
-.................\discretionary (penalty 50)
-..................< \OT1/cmr/m/n/10 -
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 e
-.................\kern3.0
+................\hbox(6.94444+0.0)x44.33342, direction TLT []
 ................\glue 3.0
 ...............\rule(*+*)x0.4
 ..............\rule(0.4+0.0)x*
@@ -693,7 +694,7 @@ l. ...}
 ....\OT1/cmss/m/n/5 b
 ....\OT1/cmss/m/n/5 )
 ....\pdfcolorstack 0 pop
-....\pdfcolorstack 0 pop
+....etc.
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}

--- a/l3kernel/testfiles/m3coffins001.lvt
+++ b/l3kernel/testfiles/m3coffins001.lvt
@@ -66,9 +66,8 @@
       \hcoffin_gset:Nn  \g_tmpb_coffin { g }
     \TIMO
     \coffin_show_structure:N \l_tmpb_coffin
-    \coffin_show_structure:N \g_tmpb_coffin
     \box_show:N \l_tmpb_coffin
-    \box_show:N \g_tmpb_coffin
+    \coffin_show:c { g_tmpb_coffin }
     \group_begin:
       \coffin_set_eq:NN \l_tmpb_coffin \l_tmpa_coffin
       \coffin_gset_eq:NN \g_tmpb_coffin \g_tmpa_coffin
@@ -106,7 +105,7 @@
     \coffin_mark_handle:Nnnn \0 {\1-l} {\1-b} {green}
     \hbox_set:Nn \l_tmpa_coffin
     { \rule{1ex}{1ex}\coffin_typeset:Nnnnn \0 {\1-l} {\1-b} {0pt} {0pt} }
-    \box_show:N \l_tmpa_coffin
+    \coffin_show:Nnn \l_tmpa_coffin { 14 } { 16 }
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3coffins001.ptex.tlg
+++ b/l3kernel/testfiles/m3coffins001.ptex.tlg
@@ -191,6 +191,15 @@ Poles of coffin \l_tmpb_coffin:
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 <recently read> }
 l. ...  }
+> \box...=
+\hbox(4.30554+1.94444)x5.00002
+.\special{color push gray 0}
+.\special{ps:SDict begin /color.sc {} def end}
+.\OT1/cmr/m/n/10 g
+.\special{color pop}
+! OK.
+<argument> \l_tmpb_coffin 
+l. ...  }
 Size of coffin \g_tmpb_coffin:
 > ht = 4.30554pt
 > dp = 1.94444pt
@@ -205,17 +214,6 @@ Poles of coffin \g_tmpb_coffin:
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
-<recently read> }
-l. ...  }
-> \box...=
-\hbox(4.30554+1.94444)x5.00002
-.\special{color push gray 0}
-.\special{ps:SDict begin /color.sc {} def end}
-.\OT1/cmr/m/n/10 g
-.\special{color pop}
-! OK.
-<argument> \l_tmpb_coffin 
-l. ...  }
 > \box...=
 \hbox(4.30554+1.94444)x5.00002
 .\special{color push gray 0}
@@ -562,6 +560,20 @@ l. ...}
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}
+Size of coffin \l_tmpa_coffin:
+> ht = 13.74443pt
+> dp = 0.0pt
+> wd = 49.43895pt
+Poles of coffin \l_tmpa_coffin:
+>  l  =>  {0pt}{0pt}{0pt}{1000pt}
+>  hc  =>  {0pt}{0pt}{0pt}{1000pt}
+>  r  =>  {0pt}{0pt}{0pt}{1000pt}
+>  b  =>  {0pt}{0pt}{1000pt}{0pt}
+>  vc  =>  {0pt}{0pt}{1000pt}{0pt}
+>  t  =>  {0pt}{0pt}{1000pt}{0pt}
+>  B  =>  {0pt}{0pt}{1000pt}{0pt}
+>  H  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 > \box...=
 \hbox(13.74443+0.0)x49.43895
 .\hbox(4.30554+0.0)x4.30554
@@ -592,16 +604,7 @@ l. ...}
 ...............\rule(*+*)x0.4
 ...............\vbox(12.94444+0.0)x44.33342
 ................\glue 3.0
-................\hbox(6.94444+0.0)x44.33342
-.................\kern 3.0
-.................\OT1/cmr/m/n/10 c
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 ^^N (ligature ffi)
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 e
-.................\kern 3.0
+................\hbox(6.94444+0.0)x44.33342 []
 ................\glue 3.0
 ...............\rule(*+*)x0.4
 ..............\rule(0.4+0.0)x*
@@ -716,10 +719,7 @@ l. ...}
 ....\OT1/cmss/m/n/5 \
 ....\OT1/cmss/m/n/5 1
 ....\OT1/cmss/m/n/5 -
-....\OT1/cmss/m/n/5 b
-....\OT1/cmss/m/n/5 )
-....\special{color pop}
-....\special{color pop}
+....etc.
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}

--- a/l3kernel/testfiles/m3coffins001.tlg
+++ b/l3kernel/testfiles/m3coffins001.tlg
@@ -191,6 +191,14 @@ Poles of coffin \l_tmpb_coffin:
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 <recently read> }
 l. ...  }
+> \box...=
+\hbox(4.30554+1.94444)x5.00002
+.\pdfcolorstack 0 push {0 g 0 G}
+.\OT1/cmr/m/n/10 g
+.\pdfcolorstack 0 pop
+! OK.
+<argument> \l_tmpb_coffin 
+l. ...  }
 Size of coffin \g_tmpb_coffin:
 > ht = 4.30554pt
 > dp = 1.94444pt
@@ -205,16 +213,6 @@ Poles of coffin \g_tmpb_coffin:
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
-<recently read> }
-l. ...  }
-> \box...=
-\hbox(4.30554+1.94444)x5.00002
-.\pdfcolorstack 0 push {0 g 0 G}
-.\OT1/cmr/m/n/10 g
-.\pdfcolorstack 0 pop
-! OK.
-<argument> \l_tmpb_coffin 
-l. ...  }
 > \box...=
 \hbox(4.30554+1.94444)x5.00002
 .\pdfcolorstack 0 push {0 g 0 G}
@@ -540,6 +538,20 @@ l. ...}
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}
+Size of coffin \l_tmpa_coffin:
+> ht = 13.74443pt
+> dp = 0.0pt
+> wd = 49.43895pt
+Poles of coffin \l_tmpa_coffin:
+>  l  =>  {0pt}{0pt}{0pt}{1000pt}
+>  hc  =>  {0pt}{0pt}{0pt}{1000pt}
+>  r  =>  {0pt}{0pt}{0pt}{1000pt}
+>  b  =>  {0pt}{0pt}{1000pt}{0pt}
+>  vc  =>  {0pt}{0pt}{1000pt}{0pt}
+>  t  =>  {0pt}{0pt}{1000pt}{0pt}
+>  B  =>  {0pt}{0pt}{1000pt}{0pt}
+>  H  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 > \box...=
 \hbox(13.74443+0.0)x49.43895
 .\hbox(4.30554+0.0)x4.30554
@@ -569,16 +581,7 @@ l. ...}
 ...............\rule(*+*)x0.4
 ...............\vbox(12.94444+0.0)x44.33342
 ................\glue 3.0
-................\hbox(6.94444+0.0)x44.33342
-.................\kern 3.0
-.................\OT1/cmr/m/n/10 c
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 ^^N (ligature ffi)
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 e
-.................\kern 3.0
+................\hbox(6.94444+0.0)x44.33342 []
 ................\glue 3.0
 ...............\rule(*+*)x0.4
 ..............\rule(0.4+0.0)x*
@@ -683,7 +686,7 @@ l. ...}
 ....\OT1/cmss/m/n/5 b
 ....\OT1/cmss/m/n/5 )
 ....\pdfcolorstack 0 pop
-....\pdfcolorstack 0 pop
+....etc.
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}

--- a/l3kernel/testfiles/m3coffins001.uptex.tlg
+++ b/l3kernel/testfiles/m3coffins001.uptex.tlg
@@ -191,6 +191,15 @@ Poles of coffin \l_tmpb_coffin:
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 <recently read> }
 l. ...  }
+> \box...=
+\hbox(4.30554+1.94444)x5.00002
+.\special{color push gray 0}
+.\special{ps:SDict begin /color.sc {} def end}
+.\OT1/cmr/m/n/10 g
+.\special{color pop}
+! OK.
+<argument> \l_tmpb_coffin 
+l. ...  }
 Size of coffin \g_tmpb_coffin:
 > ht = 4.30554pt
 > dp = 1.94444pt
@@ -205,17 +214,6 @@ Poles of coffin \g_tmpb_coffin:
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
-<recently read> }
-l. ...  }
-> \box...=
-\hbox(4.30554+1.94444)x5.00002
-.\special{color push gray 0}
-.\special{ps:SDict begin /color.sc {} def end}
-.\OT1/cmr/m/n/10 g
-.\special{color pop}
-! OK.
-<argument> \l_tmpb_coffin 
-l. ...  }
 > \box...=
 \hbox(4.30554+1.94444)x5.00002
 .\special{color push gray 0}
@@ -562,6 +560,20 @@ l. ...}
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}
+Size of coffin \l_tmpa_coffin:
+> ht = 13.74443pt
+> dp = 0.0pt
+> wd = 49.43895pt
+Poles of coffin \l_tmpa_coffin:
+>  l  =>  {0pt}{0pt}{0pt}{1000pt}
+>  hc  =>  {0pt}{0pt}{0pt}{1000pt}
+>  r  =>  {0pt}{0pt}{0pt}{1000pt}
+>  b  =>  {0pt}{0pt}{1000pt}{0pt}
+>  vc  =>  {0pt}{0pt}{1000pt}{0pt}
+>  t  =>  {0pt}{0pt}{1000pt}{0pt}
+>  B  =>  {0pt}{0pt}{1000pt}{0pt}
+>  H  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 > \box...=
 \hbox(13.74443+0.0)x49.43895
 .\hbox(4.30554+0.0)x4.30554
@@ -592,16 +604,7 @@ l. ...}
 ...............\rule(*+*)x0.4
 ...............\vbox(12.94444+0.0)x44.33342
 ................\glue 3.0
-................\hbox(6.94444+0.0)x44.33342
-.................\kern 3.0
-.................\OT1/cmr/m/n/10 c
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 ^^N (ligature ffi)
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 e
-.................\kern 3.0
+................\hbox(6.94444+0.0)x44.33342 []
 ................\glue 3.0
 ...............\rule(*+*)x0.4
 ..............\rule(0.4+0.0)x*
@@ -716,10 +719,7 @@ l. ...}
 ....\OT1/cmss/m/n/5 \
 ....\OT1/cmss/m/n/5 1
 ....\OT1/cmss/m/n/5 -
-....\OT1/cmss/m/n/5 b
-....\OT1/cmss/m/n/5 )
-....\special{color pop}
-....\special{color pop}
+....etc.
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}

--- a/l3kernel/testfiles/m3coffins001.xetex.tlg
+++ b/l3kernel/testfiles/m3coffins001.xetex.tlg
@@ -191,6 +191,14 @@ Poles of coffin \l_tmpb_coffin:
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 <recently read> }
 l. ...  }
+> \box...=
+\hbox(4.30554+1.94444)x5.00002
+.\special{pdfcolorstack 1 push (0 g 0 G)}
+.\OT1/cmr/m/n/10 g
+.\special{pdfcolorstack 1 pop}
+! OK.
+<argument> \l_tmpb_coffin 
+l. ...  }
 Size of coffin \g_tmpb_coffin:
 > ht = 4.30554pt
 > dp = 1.94444pt
@@ -205,16 +213,6 @@ Poles of coffin \g_tmpb_coffin:
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
 >  T  =>  {0pt}{0pt}{1000pt}{0pt}.
-<recently read> }
-l. ...  }
-> \box...=
-\hbox(4.30554+1.94444)x5.00002
-.\special{pdfcolorstack 1 push (0 g 0 G)}
-.\OT1/cmr/m/n/10 g
-.\special{pdfcolorstack 1 pop}
-! OK.
-<argument> \l_tmpb_coffin 
-l. ...  }
 > \box...=
 \hbox(4.30554+1.94444)x5.00002
 .\special{pdfcolorstack 1 push (0 g 0 G)}
@@ -540,6 +538,20 @@ l. ...}
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}
+Size of coffin \l_tmpa_coffin:
+> ht = 13.74443pt
+> dp = 0.0pt
+> wd = 49.43895pt
+Poles of coffin \l_tmpa_coffin:
+>  l  =>  {0pt}{0pt}{0pt}{1000pt}
+>  hc  =>  {0pt}{0pt}{0pt}{1000pt}
+>  r  =>  {0pt}{0pt}{0pt}{1000pt}
+>  b  =>  {0pt}{0pt}{1000pt}{0pt}
+>  vc  =>  {0pt}{0pt}{1000pt}{0pt}
+>  t  =>  {0pt}{0pt}{1000pt}{0pt}
+>  B  =>  {0pt}{0pt}{1000pt}{0pt}
+>  H  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0pt}{1000pt}{0pt}.
 > \box...=
 \hbox(13.74443+0.0)x49.43895
 .\hbox(4.30554+0.0)x4.30554
@@ -569,16 +581,7 @@ l. ...}
 ...............\rule(*+*)x0.4
 ...............\vbox(12.94444+0.0)x44.33342
 ................\glue 3.0
-................\hbox(6.94444+0.0)x44.33342
-.................\kern 3.0
-.................\OT1/cmr/m/n/10 c
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 ^^N (ligature ffi)
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 o
-.................\OT1/cmr/m/n/10 n
-.................\OT1/cmr/m/n/10 e
-.................\kern 3.0
+................\hbox(6.94444+0.0)x44.33342 []
 ................\glue 3.0
 ...............\rule(*+*)x0.4
 ..............\rule(0.4+0.0)x*
@@ -683,7 +686,7 @@ l. ...}
 ....\OT1/cmss/m/n/5 b
 ....\OT1/cmss/m/n/5 )
 ....\special{pdfcolorstack 1 pop}
-....\special{pdfcolorstack 1 pop}
+....etc.
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...}

--- a/l3kernel/testfiles/m3color002.lvt
+++ b/l3kernel/testfiles/m3color002.lvt
@@ -20,9 +20,9 @@
 \TEST { Gray~model }
   {
     \color_set:nnn { foo1 } { Gray } { 2 }
-    \color_show:n { foo1 }
+    \color_log:n { foo1 }
     \color_set:nnn { foo1 } { Gray } { 14 }
-    \color_show:n { foo1 }
+    \color_log:n { foo1 }
   }
 
 \TEST { hsb~model }

--- a/l3kernel/testfiles/m3color002.tlg
+++ b/l3kernel/testfiles/m3color002.tlg
@@ -8,14 +8,10 @@ Defining \l__color_named_foo1_tl on line ...
 Defining \l__color_named_foo1_prop on line ...
 The color foo1 has the properties:
 >  model  =>  gray
->  gray  =>  0.1333333333333333.
-<recently read> }
-l. ...  }
+>  gray  =>  0.1333333333333333
 The color foo1 has the properties:
 >  model  =>  gray
->  gray  =>  0.9333333333333333.
-<recently read> }
-l. ...  }
+>  gray  =>  0.9333333333333333
 ============================================================
 ============================================================
 TEST 2: hsb model

--- a/l3kernel/testfiles/m3ior002.lvt
+++ b/l3kernel/testfiles/m3ior002.lvt
@@ -23,6 +23,9 @@
   {
     \OMIT
     \ior_new:N \test
+    \TIMO
+    \ior_show:N \test
+    \OMIT
     \ior_open:Nn \test  { filetest.txt }
     \int_zero:N \l_tmpa_int
     \TIMO
@@ -36,11 +39,13 @@
     \ior_open:Nn \test { filetest.txt }
     \int_zero:N \l_tmpa_int
     \TIMO
+    \ior_show:c { test }
     \ior_str_map_inline:Nn \test
       {
         \TYPE {|#1|}
         \int_incr:N \l_tmpa_int
       }
+    \ior_log:c { test }
     \TYPE { \int_use:N \l_tmpa_int \c_space_tl lines }
   }
 

--- a/l3kernel/testfiles/m3ior002.tlg
+++ b/l3kernel/testfiles/m3ior002.tlg
@@ -4,15 +4,22 @@ Author: Bruno Le Floch
 ============================================================
 TEST 1: Mapping
 ============================================================
+> \test closed.
+<recently read> }
+l. ...  }
 |\ExplSyntaxOff |
 |Thisfileisneededbym3file001.lvt,m3ior001.lvtandm3ior002.lvt:|
 |Pleaseleaveitalone!|
 |\ExplSyntaxOn |
 4 lines
+> \test open: filetest.txt.
+<recently read> }
+l. ...  }
 |\ExplSyntaxOff|
 |This file is needed by m3file001.lvt, m3ior001.lvt and m3ior002.lvt:|
 |Please leave it alone!|
 |\ExplSyntaxOn|
+> \test open: filetest.txt.
 4 lines
 ============================================================
 ============================================================

--- a/l3kernel/testfiles/m3iow001.luatex.tlg
+++ b/l3kernel/testfiles/m3iow001.luatex.tlg
@@ -4,7 +4,15 @@ Author: Joseph Wright
 ============================================================
 TEST 1: Name a stream
 ============================================================
+! LaTeX3 Error: Variable \testa undefined.
+For immediate help type H <return>.
+ ...                                              
+l. ...}
+This is a coding error.
+LaTeX has been asked to show a variable \testa, but this has not been defined
+yet.
 Defining \testa on line ...
+> \testa closed.
 Defining \testb on line ...
 ! LaTeX3 Error: Control sequence \testa already defined.
 For immediate help type H <return>.
@@ -31,6 +39,9 @@ Defining \testb on line ...
 TEST 2: Open a write
 ============================================================
 \test=\write...
+> \test open: rubbish.log.
+<recently read> }
+l. ...}
 ============================================================
 ============================================================
 TEST 3: Close a write

--- a/l3kernel/testfiles/m3iow001.lvt
+++ b/l3kernel/testfiles/m3iow001.lvt
@@ -34,7 +34,9 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \TEST{Name~a~stream}{
+  \iow_show:c { testa }
   \iow_new:N \testa
+  \iow_log:c { testa }
   \iow_new:c {testb}
   \iow_new:N \testa
   \iow_new:c {testb}
@@ -45,6 +47,7 @@
 \TIMO
 \TEST{Open~a~write}{
   \iow_open:Nn \test { rubbish.log }
+  \iow_show:N \test
   \iow_open:cn {test} { rubbish.log }
 }
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3iow001.ptex.tlg
+++ b/l3kernel/testfiles/m3iow001.ptex.tlg
@@ -4,7 +4,15 @@ Author: Joseph Wright
 ============================================================
 TEST 1: Name a stream
 ============================================================
+! LaTeX3 Error: Variable \testa undefined.
+For immediate help type H <return>.
+ ...                                              
+l. ...}
+This is a coding error.
+LaTeX has been asked to show a variable \testa, but this has not been defined
+yet.
 Defining \testa on line ...
+> \testa closed.
 Defining \testb on line ...
 ! LaTeX3 Error: Control sequence \testa already defined.
 For immediate help type H <return>.
@@ -31,6 +39,9 @@ Defining \testb on line ...
 TEST 2: Open a write
 ============================================================
 \test=\write...
+> \test open: rubbish.log.
+<recently read> }
+l. ...}
 ============================================================
 ============================================================
 TEST 3: Close a write

--- a/l3kernel/testfiles/m3iow001.tlg
+++ b/l3kernel/testfiles/m3iow001.tlg
@@ -4,7 +4,15 @@ Author: Joseph Wright
 ============================================================
 TEST 1: Name a stream
 ============================================================
+! LaTeX3 Error: Variable \testa undefined.
+For immediate help type H <return>.
+ ...                                              
+l. ...}
+This is a coding error.
+LaTeX has been asked to show a variable \testa, but this has not been defined
+yet.
 Defining \testa on line ...
+> \testa closed.
 Defining \testb on line ...
 ! LaTeX3 Error: Control sequence \testa already defined.
 For immediate help type H <return>.
@@ -31,6 +39,9 @@ Defining \testb on line ...
 TEST 2: Open a write
 ============================================================
 \test=\write...
+> \test open: rubbish.log.
+<recently read> }
+l. ...}
 ============================================================
 ============================================================
 TEST 3: Close a write

--- a/l3kernel/testfiles/m3iow001.uptex.tlg
+++ b/l3kernel/testfiles/m3iow001.uptex.tlg
@@ -4,7 +4,15 @@ Author: Joseph Wright
 ============================================================
 TEST 1: Name a stream
 ============================================================
+! LaTeX3 Error: Variable \testa undefined.
+For immediate help type H <return>.
+ ...                                              
+l. ...}
+This is a coding error.
+LaTeX has been asked to show a variable \testa, but this has not been defined
+yet.
 Defining \testa on line ...
+> \testa closed.
 Defining \testb on line ...
 ! LaTeX3 Error: Control sequence \testa already defined.
 For immediate help type H <return>.
@@ -31,6 +39,9 @@ Defining \testb on line ...
 TEST 2: Open a write
 ============================================================
 \test=\write...
+> \test open: rubbish.log.
+<recently read> }
+l. ...}
 ============================================================
 ============================================================
 TEST 3: Close a write

--- a/l3kernel/testfiles/m3iow001.xetex.tlg
+++ b/l3kernel/testfiles/m3iow001.xetex.tlg
@@ -4,7 +4,15 @@ Author: Joseph Wright
 ============================================================
 TEST 1: Name a stream
 ============================================================
+! LaTeX3 Error: Variable \testa undefined.
+For immediate help type H <return>.
+ ...                                              
+l. ...}
+This is a coding error.
+LaTeX has been asked to show a variable \testa, but this has not been defined
+yet.
 Defining \testa on line ...
+> \testa closed.
 Defining \testb on line ...
 ! LaTeX3 Error: Control sequence \testa already defined.
 For immediate help type H <return>.
@@ -31,6 +39,9 @@ Defining \testb on line ...
 TEST 2: Open a write
 ============================================================
 \test=\write...
+> \test open: rubbish.log.
+<recently read> }
+l. ...}
 ============================================================
 ============================================================
 TEST 3: Close a write

--- a/l3kernel/testfiles/m3show003.lvt
+++ b/l3kernel/testfiles/m3show003.lvt
@@ -256,4 +256,27 @@
     \regex_show:N \l_tmpa_tl
   }
 
+% padding to help keep line number constant
+%
+%
+%
+%
+%
+%
+%
+%
+%
+%
+%
+%
+%
+%
+%
+
+\TEST { group_show_list }
+  {
+    \hbox:n { \vbox:n { { \group_log_list: } } }
+    \group_show_list:
+  }
+
 \END

--- a/l3kernel/testfiles/m3show003.tlg
+++ b/l3kernel/testfiles/m3show003.tlg
@@ -386,3 +386,22 @@ structure:
     {\__regex_item_caseful_equal:n {101}\__regex_item_caseful_equal:n
     {102}}{0}{-1}\c_true_bool \__regex_command_K: }}{1}{0}\c_false_bool }
 ============================================================
+============================================================
+TEST 19: group_show_list
+============================================================
+### simple group (level 6) entered at line 280 ({)
+### semi simple group (level 5) entered at line 280 (\begingroup)
+### vbox group (level 4) entered at line 280 (\vbox{)
+### semi simple group (level 3) entered at line 280 (\begingroup)
+### adjusted hbox group (level 2) entered at line 280 (\hbox{)
+### semi simple group (level 1) entered at line 280 (\begingroup)
+### bottom level
+! OK.
+<recently read> \tex_showgroups:D 
+l. ...  }
+### semi simple group (level 1) entered at line 280 (\begingroup)
+### bottom level
+! OK.
+<recently read> \tex_showgroups:D 
+l. ...  }
+============================================================

--- a/l3kernel/testfiles/m3tl-analysis001.luatex.tlg
+++ b/l3kernel/testfiles/m3tl-analysis001.luatex.tlg
@@ -9,9 +9,7 @@ The token list \c_empty_tl is empty
 <recently read> }
 l. ...  }
 The token list \c_catcode_other_space_tl contains the tokens:
->    (the character  ).
-<recently read> }
-l. ...  }
+>    (the character  )
 The token list is empty
 > .
 <recently read> }
@@ -21,9 +19,7 @@ The token list contains the tokens:
 <recently read> }
 l. ...  }
 The token list contains the tokens:
->  \  (control sequence=\ ).
-<recently read> }
-l. ...  }
+>  \  (control sequence=\ )
 The token list contains the tokens:
 >  & (alignment tab character &).
 <recently read> }

--- a/l3kernel/testfiles/m3tl-analysis001.lvt
+++ b/l3kernel/testfiles/m3tl-analysis001.lvt
@@ -29,10 +29,10 @@
 \TEST { tl_analysis_show~basic }
   {
     \tl_analysis_show:N \c_empty_tl
-    \tl_analysis_show:N \c_catcode_other_space_tl
+    \tl_analysis_log:N \c_catcode_other_space_tl
     \tl_analysis_show:n { }
     \tl_analysis_show:n { ~ }
-    \tl_analysis_show:n { \ }
+    \tl_analysis_log:n { \ }
     \tl_analysis_show:n { & }
     \tl_analysis_show:n { { } }
     \tl_analysis_show:n { abc }

--- a/l3kernel/testfiles/m3tl-analysis001.tlg
+++ b/l3kernel/testfiles/m3tl-analysis001.tlg
@@ -9,9 +9,7 @@ The token list \c_empty_tl is empty
 <recently read> }
 l. ...  }
 The token list \c_catcode_other_space_tl contains the tokens:
->    (the character  ).
-<recently read> }
-l. ...  }
+>    (the character  )
 The token list is empty
 > .
 <recently read> }
@@ -21,9 +19,7 @@ The token list contains the tokens:
 <recently read> }
 l. ...  }
 The token list contains the tokens:
->  \  (control sequence=\ ).
-<recently read> }
-l. ...  }
+>  \  (control sequence=\ )
 The token list contains the tokens:
 >  & (alignment tab character &).
 <recently read> }

--- a/l3kernel/testfiles/m3tl-analysis001.xetex.tlg
+++ b/l3kernel/testfiles/m3tl-analysis001.xetex.tlg
@@ -9,9 +9,7 @@ The token list \c_empty_tl is empty
 <recently read> }
 l. ...  }
 The token list \c_catcode_other_space_tl contains the tokens:
->    (the character  ).
-<recently read> }
-l. ...  }
+>    (the character  )
 The token list is empty
 > .
 <recently read> }
@@ -21,9 +19,7 @@ The token list contains the tokens:
 <recently read> }
 l. ...  }
 The token list contains the tokens:
->  \  (control sequence=\ ).
-<recently read> }
-l. ...  }
+>  \  (control sequence=\ )
 The token list contains the tokens:
 >  & (alignment tab character &).
 <recently read> }


### PR DESCRIPTION
This adds `\coffin_show:Nnn`, `\coffin_show:N`, `\coffin_log:Nnn`, `\coffin_log:N`, `\color_log:n`, `\group_show_list:`, `\group_log_list:`, `\ior_show:N`, `\ior_log:N`, `\iow_show:N`, `\iow_log:N`, `\tl_log_analysis:N`, `\tl_log_analysis:n`.