### PR TITLE
Implement expanded-fix for keyval

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1016,10 +1016,26 @@
 %   The use of \cs{s_@@_mark} here prevents loss of braces from the key
 %   argument.
 %    \begin{macrocode}
-      \cs_new:Npn \keyval_parse:nnn ##1 ##2 ##3
+      \cs_if_exist:NTF \tex_expanded:D
         {
-          \group_align_safe_begin:
-          \@@_loop_active:nnw {##1} {##2} \s_@@_mark ##3 #1 \s_@@_tail #1
+          \cs_new:Npn \keyval_parse:nnn ##1 ##2 ##3
+            {
+              \__kernel_exp_not:w \tex_expanded:D
+                {
+                  {
+                    \@@_loop_active:nnw
+                      {##1} {##2} \s_@@_mark ##3 #1 \s_@@_tail #1
+                  } 
+                }
+            }
+        }
+        {
+          \cs_new:Npn \keyval_parse:nnn ##1 ##2 ##3
+            {
+              \group_align_safe_begin:
+              \@@_loop_active:nnw {##1} {##2} \s_@@_mark ##3 #1 \s_@@_tail #1
+              \group_align_safe_end:
+            }
         }
       \cs_new_eq:NN \keyval_parse:NNn \keyval_parse:nnn
 %    \end{macrocode}
@@ -1258,7 +1274,7 @@
       \cs_new:Npn \@@_end_loop_active:w
           \s_@@_tail
           \@@_loop_other:nnw ##1 \s_@@_mark \s_@@_tail , \s_@@_tail ,
-        { \group_align_safe_end: }
+        { }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -1279,23 +1295,42 @@
 %   \cs{exp_not:n} with the correct arguments. Afterwards they insert the next
 %   iteration of the other loop.
 %    \begin{macrocode}
-\cs_new:Npn \@@_pair:nnnn #1 #2 #3 #4
+\cs_if_exist:NTF \tex_expanded:D
   {
-    \@@_if_blank:w \s_@@_mark #2 \s_@@_nil \s_@@_stop \@@_blank_key_error:w
-      \s_@@_mark \s_@@_stop
-    \group_align_safe_end:
-    \exp_not:n { #4 { #2 } { #1 } }
-    \group_align_safe_begin:
-    \@@_loop_other:nnw {#3} {#4}
+    \cs_new:Npn \@@_pair:nnnn #1 #2 #3 #4
+      {
+        \@@_if_blank:w \s_@@_mark #2 \s_@@_nil \s_@@_stop \@@_blank_key_error:w
+          \s_@@_mark \s_@@_stop
+        \exp_not:n { #4 { #2 } { #1 } }
+        \@@_loop_other:nnw {#3} {#4}
+      }
+    \cs_new:Npn \@@_key:nn #1 #2
+      {
+        \@@_if_blank:w \s_@@_mark #1 \s_@@_nil \s_@@_stop \@@_blank_key_error:w
+          \s_@@_mark \s_@@_stop
+        \exp_not:n { #2 { #1 } }
+        \@@_loop_other:nnw {#2}
+      }
   }
-\cs_new:Npn \@@_key:nn #1 #2
   {
-    \@@_if_blank:w \s_@@_mark #1 \s_@@_nil \s_@@_stop \@@_blank_key_error:w
-      \s_@@_mark \s_@@_stop
-    \group_align_safe_end:
-    \exp_not:n { #2 { #1 } }
-    \group_align_safe_begin:
-    \@@_loop_other:nnw {#2}
+    \cs_new:Npn \@@_pair:nnnn #1 #2 #3 #4
+      {
+        \@@_if_blank:w \s_@@_mark #2 \s_@@_nil \s_@@_stop \@@_blank_key_error:w
+          \s_@@_mark \s_@@_stop
+        \group_align_safe_end:
+        \exp_not:n { #4 { #2 } { #1 } }
+        \group_align_safe_begin:
+        \@@_loop_other:nnw {#3} {#4}
+      }
+    \cs_new:Npn \@@_key:nn #1 #2
+      {
+        \@@_if_blank:w \s_@@_mark #1 \s_@@_nil \s_@@_stop \@@_blank_key_error:w
+          \s_@@_mark \s_@@_stop
+        \group_align_safe_end:
+        \exp_not:n { #2 { #1 } }
+        \group_align_safe_begin:
+        \@@_loop_other:nnw {#2}
+      }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1318,11 +1353,25 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_blank_true:w \s_@@_mark \s_@@_stop \@@_trim:nN #1 \@@_key:nn
   { \@@_loop_other:nnw }
-\cs_new:Npn \@@_blank_key_error:w
-  \s_@@_mark \s_@@_stop \group_align_safe_end: \exp_not:n #1
+\cs_if_exist:NTF \tex_expanded:D
   {
-    \__kernel_msg_expandable_error:nn
-      { keyval } { blank-key-name }
+    \cs_new:Npn \@@_blank_key_error:w
+        \s_@@_mark \s_@@_stop \exp_not:n #1
+      {
+        \__kernel_msg_expandable_error:nn
+          { keyval } { blank-key-name }
+      }
+  }
+  {
+    \cs_new:Npn \@@_blank_key_error:w
+        \s_@@_mark \s_@@_stop
+        \group_align_safe_end:
+        \exp_not:n #1
+        \group_align_safe_begin:
+      {
+        \__kernel_msg_expandable_error:nn
+          { keyval } { blank-key-name }
+      }
   }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
This PR implements the `\unexpanded\expanded` fix for `\keyval_parse:nnn` to make it alignment safe. As a fall back, fix number 2 from https://github.com/latex3/latex3/issues/896 is used (with proper adjustments to the error recovery for blank key names).

I ran the testsuite locally on the code used if `\expanded` isn't available. One should be aware that the testsuite will henceforth only test the expanded variant (at least without manual modifications).