### PR TITLE
Wrappers around \vtop (see #552 and #922)

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -15,6 +15,7 @@ this project uses date-based 'snapshot' version identifiers.
   `\ior_show:N`, `\ior_log:N`, `\iow_show:N`, `\iow_log:N`,
   `\tl_log_analysis:N`, `\tl_log_analysis:n`
 - `\legacy_if_set_true:n`, `\legacy_if_set_false:n`, `\legacy_if_set:nn`
+- `\vbox_set_top_to_ht:Nnn`, `\vbox_set_top:Nw`, `\vbox_set_top_to_ht:Nnw` (issue #922)
 
 ### Fixed
 - Checking brace balance in all regex functions (issue #377)

--- a/l3kernel/l3box.dtx
+++ b/l3kernel/l3box.dtx
@@ -513,69 +513,85 @@
 %   and then includes this box in the current list for typesetting.
 % \end{function}
 %
-%  \begin{function}[updated = 2017-04-05]
-%    {\vbox_set:Nn, \vbox_set:cn, \vbox_gset:Nn, \vbox_gset:cn}
+% \begin{function}[updated = 2017-04-05]
+%    {
+%      \vbox_set:Nn, \vbox_set:cn, \vbox_gset:Nn, \vbox_gset:cn,
+%      \vbox_set_top:Nn, \vbox_set_top:cn, \vbox_gset_top:Nn, \vbox_gset_top:cn,
+%    }
 %   \begin{syntax}
 %     \cs{vbox_set:Nn} \meta{box} \Arg{contents}
-%   \end{syntax}
-%   Typesets the \meta{contents} at natural height and then stores the
-%   result inside the \meta{box}.
-% \end{function}
-%
-% \begin{function}[updated = 2017-04-05]
-%   {\vbox_set_top:Nn, \vbox_set_top:cn, \vbox_gset_top:Nn, \vbox_gset_top:cn}
-%   \begin{syntax}
 %     \cs{vbox_set_top:Nn} \meta{box} \Arg{contents}
 %   \end{syntax}
 %   Typesets the \meta{contents} at natural height and then stores the
-%   result inside the \meta{box}. The baseline of the box is equal
-%   to that of the \emph{first} item added to the box.
+%   result inside the \meta{box}.  For \cs{vbox_set:Nn}, the baseline of
+%   the box is equal to that of the \emph{last} item added to the box,
+%   while for \cs{vbox_set_top:Nn} it is that of the \emph{first} item
+%   added to the box.
 % \end{function}
 %
-% \begin{function}[updated = 2017-04-05]
+% \begin{function}[added = 2021-05-16]
 %   {
 %     \vbox_set_to_ht:Nnn,  \vbox_set_to_ht:cnn,
-%     \vbox_gset_to_ht:Nnn, \vbox_gset_to_ht:cnn
+%     \vbox_gset_to_ht:Nnn, \vbox_gset_to_ht:cnn,
+%     \vbox_set_top_to_ht:Nnn, \vbox_set_top_to_ht:cnn,
+%     \vbox_gset_top_to_ht:Nnn, \vbox_gset_top_to_ht:cnn
 %   }
 %   \begin{syntax}
 %     \cs{vbox_set_to_ht:Nnn} \meta{box} \Arg{dimexpr} \Arg{contents}
+%     \cs{vbox_set_top_to_ht:Nnn} \meta{box} \Arg{dimexpr} \Arg{contents}
 %   \end{syntax}
 %   Typesets the \meta{contents} to the height given by the
 %   \meta{dimexpr} and then stores the result inside the \meta{box}.
+%   For \cs{vbox_set_to_ht:Nnn}, the baseline of the box is equal to
+%   that of the \emph{last} item added to the box, while for
+%   \cs{vbox_set_top_to_ht:Nnn} it is that of the \emph{first} item
+%   added to the box.
 % \end{function}
 %
-% \begin{function}[updated = 2017-04-05]
+% \begin{function}[added = 2021-05-16]
 %   {
 %     \vbox_set:Nw, \vbox_set:cw,
+%     \vbox_set_top:Nw, \vbox_set_top:cw,
 %     \vbox_set_end:,
 %     \vbox_gset:Nw, \vbox_gset:cw,
+%     \vbox_gset_top:Nw, \vbox_gset_top:cw,
 %     \vbox_gset_end:
 %   }
 %   \begin{syntax}
 %     \cs{vbox_set:Nw} \meta{box} \meta{contents} \cs{vbox_set_end:}
+%     \cs{vbox_set_top:Nw} \meta{box} \meta{contents} \cs{vbox_set_end:}
 %   \end{syntax}
 %   Typesets the \meta{contents} at natural height and then stores the
-%   result inside the \meta{box}. In contrast
-%   to \cs{vbox_set:Nn} this function does not absorb the argument
+%   result inside the \meta{box}.  For \cs{vbox_set:Nw}, the baseline of
+%   the box is equal to that of the \emph{last} item added to the box,
+%   while for \cs{vbox_set_top:Nw} it is that of the \emph{first} item
+%   added to the box.  In contrast to \cs{vbox_set:Nn} or
+%   \cs{vbox_set_top:Nn} these functions do not absorb the argument
 %   when finding the \meta{content}, and so can be used in circumstances
 %   where the \meta{content} may not be a simple argument.
 % \end{function}
 %
-% \begin{function}[added = 2017-06-08]
+% \begin{function}[added = 2021-05-16]
 %   {
 %     \vbox_set_to_ht:Nnw,  \vbox_set_to_ht:cnw,
-%     \vbox_gset_to_ht:Nnw, \vbox_gset_to_ht:cnw
+%     \vbox_gset_to_ht:Nnw, \vbox_gset_to_ht:cnw,
+%     \vbox_set_top_to_ht:Nnw,  \vbox_set_top_to_ht:cnw,
+%     \vbox_gset_top_to_ht:Nnw, \vbox_gset_top_to_ht:cnw
 %   }
 %   \begin{syntax}
 %     \cs{vbox_set_to_ht:Nnw} \meta{box} \Arg{dimexpr} \meta{contents} \cs{vbox_set_end:}
+%     \cs{vbox_set_top_to_ht:Nnw} \meta{box} \Arg{dimexpr} \meta{contents} \cs{vbox_set_end:}
 %   \end{syntax}
-%   Typesets the \meta{contents} to the height given by the \meta{dimexpr}
-%   and then stores the result inside the \meta{box}. In contrast
-%   to \cs{vbox_set_to_ht:Nnn} this function does not absorb the argument
-%   when finding the \meta{content}, and so can be used in circumstances
-%   where the \meta{content} may not be a simple argument
+%   Typesets the \meta{contents} to the height given by the
+%   \meta{dimexpr} and then stores the result inside the \meta{box}.
+%   For \cs{vbox_set:Nw}, the baseline of the box is equal to that of
+%   the \emph{last} item added to the box, while for
+%   \cs{vbox_set_top:Nw} it is that of the \emph{first} item added to
+%   the box.  In contrast to \cs{vbox_set_to_ht:Nnn} and
+%   \cs{vbox_set_top_to_ht:Nnn}, these functions do not absorb the
+%   argument when finding the \meta{content}, and so can be used in
+%   circumstances where the \meta{content} may not be a simple argument
 % \end{function}
-%
 %
 % \begin{function}[updated = 2018-12-29]
 %   {
@@ -1551,6 +1567,28 @@
 % \end{macro}
 % \end{macro}
 %
+% \begin{macro}{\vbox_set_top_to_ht:Nnn, \vbox_set_top_to_ht:cnn}
+% \begin{macro}{\vbox_gset_top_to_ht:Nnn, \vbox_gset_top_to_ht:cnn}
+% \testfile*
+%   Storing material in a vertical box with a specified height and reference
+%   point at the baseline of the first object in the box.
+%    \begin{macrocode}
+\cs_new_protected:Npn \vbox_set_top_to_ht:Nnn #1#2#3
+  {
+    \tex_setbox:D #1 \tex_vtop:D to \@@_dim_eval:n {#2}
+      { \color_group_begin: #3 \par \color_group_end: }
+  }
+\cs_new_protected:Npn \vbox_gset_top_to_ht:Nnn #1#2#3
+  {
+    \tex_global:D \tex_setbox:D #1 \tex_vtop:D to \@@_dim_eval:n {#2}
+      { \color_group_begin: #3 \par \color_group_end: }
+  }
+\cs_generate_variant:Nn \vbox_set_top_to_ht:Nnn { c }
+\cs_generate_variant:Nn \vbox_gset_top_to_ht:Nnn { c }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
 % \begin{macro}{\vbox_set_to_ht:Nnn, \vbox_set_to_ht:cnn}
 % \begin{macro}{\vbox_gset_to_ht:Nnn, \vbox_gset_to_ht:cnn}
 %  \testfile*
@@ -1572,9 +1610,12 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}{\vbox_set:Nw, \vbox_set:cw}
-% \begin{macro}{\vbox_gset:Nw, \vbox_gset:cw}
-% \begin{macro}{\vbox_set_end:, \vbox_gset_end:}
+% \begin{macro}
+%   {
+%     \vbox_set:Nw, \vbox_set:cw, \vbox_gset:Nw, \vbox_gset:cw,
+%     \vbox_set_top:Nw, \vbox_set_top:cw, \vbox_gset_top:Nw, \vbox_gset_top:cw,
+%     \vbox_set_end:, \vbox_gset_end:
+%   }
 % \testfile*
 %   Storing material in a vertical box. This type is useful in
 %   environment definitions.
@@ -1593,6 +1634,20 @@
   }
 \cs_generate_variant:Nn \vbox_set:Nw  { c }
 \cs_generate_variant:Nn \vbox_gset:Nw { c }
+\cs_new_protected:Npn \vbox_set_top:Nw #1
+  {
+    \tex_setbox:D #1 \tex_vtop:D
+      \c_group_begin_token
+        \color_group_begin:
+  }
+\cs_new_protected:Npn \vbox_gset_top:Nw #1
+  {
+    \tex_global:D \tex_setbox:D #1 \tex_vtop:D
+      \c_group_begin_token
+        \color_group_begin:
+  }
+\cs_generate_variant:Nn \vbox_set_top:Nw  { c }
+\cs_generate_variant:Nn \vbox_gset_top:Nw { c }
 \cs_new_protected:Npn \vbox_set_end:
   {
         \par
@@ -1602,11 +1657,14 @@
 \cs_new_eq:NN \vbox_gset_end: \vbox_set_end:
 %    \end{macrocode}
 % \end{macro}
-% \end{macro}
-% \end{macro}
 %
-% \begin{macro}{\vbox_set_to_ht:Nnw, \vbox_set_to_ht:cnw}
-% \begin{macro}{\vbox_gset_to_ht:Nnw, \vbox_gset_to_ht:cnw}
+% \begin{macro}
+%   {
+%     \vbox_set_to_ht:Nnw, \vbox_set_to_ht:cnw,
+%     \vbox_gset_to_ht:Nnw, \vbox_gset_to_ht:cnw,
+%     \vbox_set_top_to_ht:Nnw, \vbox_set_top_to_ht:cnw,
+%     \vbox_gset_top_to_ht:Nnw, \vbox_gset_top_to_ht:cnw
+%   }
 %   A combination of the above ideas.
 %    \begin{macrocode}
 \cs_new_protected:Npn \vbox_set_to_ht:Nnw #1#2
@@ -1623,6 +1681,20 @@
   }
 \cs_generate_variant:Nn \vbox_set_to_ht:Nnw  { c }
 \cs_generate_variant:Nn \vbox_gset_to_ht:Nnw { c }
+\cs_new_protected:Npn \vbox_set_top_to_ht:Nnw #1#2
+  {
+    \tex_setbox:D #1 \tex_vtop:D to \@@_dim_eval:n {#2}
+      \c_group_begin_token
+        \color_group_begin:
+  }
+\cs_new_protected:Npn \vbox_gset_top_to_ht:Nnw #1#2
+  {
+    \tex_global:D \tex_setbox:D #1 \tex_vtop:D to \@@_dim_eval:n {#2}
+      \c_group_begin_token
+        \color_group_begin:
+  }
+\cs_generate_variant:Nn \vbox_set_top_to_ht:Nnw  { c }
+\cs_generate_variant:Nn \vbox_gset_top_to_ht:Nnw { c }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -851,10 +851,13 @@
       \tl_build_put_right:Nx
       \tl_build_put_left:Nn
       \vbox_set:Nn
-      \vbox_set_top:Nn
       \vbox_set_to_ht:Nnn
+      \vbox_set_top:Nn
+      \vbox_set_top_to_ht:Nnn
       \vbox_set:Nw
       \vbox_set_to_ht:Nnw
+      \vbox_set_top:Nw
+      \vbox_set_top_to_ht:Nnw
       \vbox_set_split_to_ht:NNn
     }
   \__kernel_patch:nnn
@@ -913,10 +916,13 @@
       \tl_build_gput_right:Nx
       \tl_build_gput_left:Nn
       \vbox_gset:Nn
-      \vbox_gset_top:Nn
       \vbox_gset_to_ht:Nnn
+      \vbox_gset_top:Nn
+      \vbox_gset_top_to_ht:Nnn
       \vbox_gset:Nw
       \vbox_gset_to_ht:Nnw
+      \vbox_gset_top:Nw
+      \vbox_gset_top_to_ht:Nnw
       \vbox_gset_split_to_ht:NNn
     }
 %    \end{macrocode}

--- a/l3kernel/testfiles/m3box003.lvt
+++ b/l3kernel/testfiles/m3box003.lvt
@@ -102,4 +102,56 @@
   \box_show:N \g_tempa_box
   \box_show:N \g_tempb_box
 }
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\TEST{Set~top~boxes~to~a~height}{
+  \cs_set_protected:Npn \test:
+    {
+      \tex_par:D
+      \skip_vertical:n { 0pt plus .5cm }
+    }
+  \vbox_set_top_to_ht:cnn {l_tempa_box} {1cm} {q\test: (q)}
+  \vbox_gset_top_to_ht:cnn {g_tempb_box} {1cm} {B\test: B}
+  \box_show:N \l_tempa_box
+  \box_show:N \g_tempb_box
+}
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\TEST{All~inline~commands}{
+  \cs_set_protected:Npn \test:N #1
+    {
+      \iow_term:x
+        {
+          Box~#1:~ ( \dim_eval:n { \box_ht:N #1 }
+          + \dim_eval:n { \box_dp:N #1 } )
+          x \dim_eval:n { \box_wd:N #1 }
+        }
+    }
+  \cs_set_protected:Npn \test:
+    {
+      \test:N \l_tempa_box
+      \test:N \l_tempb_box
+      \test:N \g_tempa_box
+      \test:N \g_tempb_box
+    }
+  \box_clear:N \l_tempa_box
+  \box_clear:N \l_tempb_box
+  \box_gclear:N \g_tempa_box
+  \box_gclear:N \g_tempb_box
+  \skip_set:Nn \tex_parskip:D { 0pt plus 1fil }
+  {
+    \vbox_set:cw { l_tempa_box } a \\ a \vbox_set_end:
+    \vbox_set_top:cw { l_tempb_box } a \\ a \vbox_set_end:
+    \vbox_gset:cw { g_tempa_box } A \\ A \vbox_gset_end:
+    \vbox_gset_top:cw { g_tempb_box } A \\ A \vbox_gset_end:
+    \test:
+  }
+  \test:
+  {
+    \vbox_set_to_ht:cnw { l_tempa_box } { 30pt } a \par a \vbox_set_end:
+    \vbox_set_top_to_ht:cnw { l_tempb_box } { 30pt } a \par a \vbox_set_end:
+    \vbox_gset_to_ht:cnw { g_tempa_box } { 30pt } A \par A \vbox_gset_end:
+    \vbox_gset_top_to_ht:cnw { g_tempb_box } { 30pt } A \par A \vbox_gset_end:
+    \test:
+  }
+  \test:
+}
 \END

--- a/l3kernel/testfiles/m3box003.tlg
+++ b/l3kernel/testfiles/m3box003.tlg
@@ -305,3 +305,71 @@ l. ...}
 <argument> \g_tempb_box 
 l. ...}
 ============================================================
+============================================================
+TEST 10: Set top boxes to a height
+============================================================
+> \box...=
+\vbox(4.30554+26.6472)x469.75499, glue set 0.79778
+.\hbox(4.30554+1.94444)x469.75499, glue set 444.4772fil
+..\hbox(0.0+0.0)x20.0
+..\OT1/cmr/m/n/10 q
+..\penalty 10000
+..\glue(\parfillskip) 0.0 plus 1.0fil
+..\glue(\rightskip) 0.0
+.\glue 0.0 plus 14.22636
+.\glue(\parskip) 0.0 plus 1.0
+.\glue(\parskip) 0.0
+.\glue(\baselineskip) 2.55556
+.\hbox(7.5+2.5)x469.75499, glue set 436.6994fil
+..\hbox(0.0+0.0)x20.0
+..\OT1/cmr/m/n/10 (
+..\OT1/cmr/m/n/10 q
+..\OT1/cmr/m/n/10 )
+..\penalty 10000
+..\glue(\parfillskip) 0.0 plus 1.0fil
+..\glue(\rightskip) 0.0
+! OK.
+<argument> \l_tempa_box 
+l. ...}
+> \box...=
+\vbox(6.83331+21.61943)x469.75499, glue set 0.63176
+.\hbox(6.83331+0.0)x469.75499, glue set 442.67163fil
+..\hbox(0.0+0.0)x20.0
+..\OT1/cmr/m/n/10 B
+..\penalty 10000
+..\glue(\parfillskip) 0.0 plus 1.0fil
+..\glue(\rightskip) 0.0
+.\glue 0.0 plus 14.22636
+.\glue(\parskip) 0.0 plus 1.0
+.\glue(\parskip) 0.0
+.\glue(\baselineskip) 5.16669
+.\hbox(6.83331+0.0)x469.75499, glue set 442.67163fil
+..\hbox(0.0+0.0)x20.0
+..\OT1/cmr/m/n/10 B
+..\penalty 10000
+..\glue(\parfillskip) 0.0 plus 1.0fil
+..\glue(\rightskip) 0.0
+! OK.
+<argument> \g_tempb_box 
+l. ...}
+============================================================
+============================================================
+TEST 11: All inline commands
+============================================================
+Box \l_tempa_box : (16.30554pt+0.0pt)x469.75499pt
+Box \l_tempb_box : (4.30554pt+12.0pt)x469.75499pt
+Box \g_tempa_box : (18.83331pt+0.0pt)x469.75499pt
+Box \g_tempb_box : (6.83331pt+12.0pt)x469.75499pt
+Box \l_tempa_box : (0.0pt+0.0pt)x0.0pt
+Box \l_tempb_box : (0.0pt+0.0pt)x0.0pt
+Box \g_tempa_box : (18.83331pt+0.0pt)x469.75499pt
+Box \g_tempb_box : (6.83331pt+12.0pt)x469.75499pt
+Box \l_tempa_box : (30.0pt+0.0pt)x469.75499pt
+Box \l_tempb_box : (4.30554pt+25.69446pt)x469.75499pt
+Box \g_tempa_box : (30.0pt+0.0pt)x469.75499pt
+Box \g_tempb_box : (6.83331pt+23.16669pt)x469.75499pt
+Box \l_tempa_box : (0.0pt+0.0pt)x0.0pt
+Box \l_tempb_box : (0.0pt+0.0pt)x0.0pt
+Box \g_tempa_box : (30.0pt+0.0pt)x469.75499pt
+Box \g_tempb_box : (6.83331pt+23.16669pt)x469.75499pt
+============================================================


### PR DESCRIPTION
Upon request at #922 and #552, I implemented here `\vbox_set_top_to_ht:Nnn` (and some `w` versions that don't need discussion).  This is a wrapper around `\setbox #1 = \vtop to #2 {#3}`.  However, this primitive does very weird things: it first sets the material with a certain distance `#2` between the top of the box and the last baseline (just like `\vbox to`), then it shifts the baseline to be that of the first line.  At the end of the day `#2` is neither the height nor the depth of the resulting box.

Actually, the height of the `\vtop` should always be the height of the first line, otherwise the baselines wouldn't coincide.  So perhaps by symmetry with the `\vbox` case we should provide `\vbox_set_top_to_dp:Nnn` (and not `to_ht`) which sets the depth (namely the distance between the first baseline and the bottom).  For this I need to know: **is it safe to do `\setbox0\vtop{\unvbox0}` or will I lose whatsits or inserts etc?**  I'm thinking of doing the following:
- Set the material to its natural size with `\setbox0\vbox{#3}` to determine the natural total size, and the height of the first line.
- Reset the material in a vtop with `\setbox2\vtop{\unvbox0}` to determine the depth of the last line.
- Then do `\setbox #1=\vtop to \dimexpr #2 + \ht0 - \dp2 {\unvbox2}` (well, actually I need to have saved `\ht0` but you get the gist).
