### PR TITLE
Tools to match/replace multiple regex concurrently (fixes #433)

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,6 +10,8 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - `\prop_to_keyval:N`
 - Support for validity scope for keys
+- `\regex_match_case:nn(TF)`, `\regex_replace_case_once:nN(TF)`,
+  `\regex_replace_case_all:nN(TF)`
 
 ### Changed
 - Allow indirect conversions between colorspaces though fallback models

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -105,6 +105,10 @@ this project uses date-based 'snapshot' version identifiers.
   `\ior_show:N`, `\ior_log:N`, `\iow_show:N`, `\iow_log:N`,
   `\tl_log_analysis:N`, `\tl_log_analysis:n`
 - `\legacy_if_set_true:n`, `\legacy_if_set_false:n`, `\legacy_if_set:nn`
+- Matching multiple regex at the same time (issue #433):
+  `\regex_case_match:nn(TF)`,
+  `\regex_case_replace_once:nN(TF)`,
+  `\regex_case_replace_all:nN(TF)`
 
 ### Fixed
 - Checking brace balance in all regex functions (issue #377)

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -794,6 +794,46 @@
 %   then performing the replacement with \cs{regex_replace_once:nnN}.
 % \end{function}
 %
+% \begin{function}[noTF, added = 2021-05-15]{\regex_case_replace_all:nN}
+%   \begin{syntax}
+%     \cs{regex_case_replace_all:nNTF}
+%     ~~|{| \\
+%     ~~~~\Arg{regex_1} \Arg{replacement_1} \\
+%     ~~~~\Arg{regex_2} \Arg{replacement_2} \\
+%     ~~~~\ldots \\
+%     ~~~~\Arg{regex_n} \Arg{replacement_n} \\
+%     ~~|}| \meta{tl~var}
+%     ~~\Arg{true code} \Arg{false code}
+%   \end{syntax}
+%   Replaces all occurrences of all \meta{regex} in the \meta{token
+%   list} by the corresponding \meta{replacement}.  Every match is
+%   treated independently, and matches cannot overlap.  The result is
+%   assigned locally to \meta{tl~var}, and the \meta{true code} or
+%   \meta{false code} is left in the input stream depending on whether
+%   any replacement was made or not.
+%
+%   In detail, for each starting position in the \meta{token list}, each
+%   of the \meta{regex} is searched in turn.  If one of them matches
+%   then it is replaced by the corresponding \meta{replacement}, and the
+%   search resumes at the position that follows this match (and
+%   replacement).  For instance
+% \begin{verbatim}
+% \tl_set:Nn \l_tmpa_tl { Hello,~world! }
+% \regex_case_replace_all:nN
+%   {
+%     { [A-Za-z]+ } { ``\0'' }
+%     { \b } { --- }
+%     { . } { [\0] }
+%   } \l_tmpa_tl
+% \end{verbatim}
+%   results in \cs{l_tmpa_tl} having the contents
+%   \verb*|``Hello''---[,][ ]``world''---[!]|.  Note in particular that
+%   the word-boundary assertion |\b| did not match at the start of words
+%   because the case |[A-Za-z]+| matched at these positions.  To change
+%   this, one could simply swap the order of the two cases in the
+%   argument of \cs{regex_case_replace_all:nN}.
+% \end{function}
+%
 % \section{Scratch regular expressions}
 %
 % \begin{variable}[added = 2017-12-11]{\l_tmpa_regex, \l_tmpb_regex}
@@ -1160,21 +1200,22 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_tl_odd_items:n, \@@_tl_odd_items_loop:nn}
-%   Map through a token list one pair at a time, leaving the odd items
-%   (including the last one if the token list has an odd number of
-%   items).
+% \begin{macro}{\@@_tl_odd_items:n, \@@_tl_even_items:n, \@@_tl_even_items_loop:nn}
+%   Map through a token list one pair at a time, leaving the
+%   odd-numbered or even-numbered items (the first item is
+%   numbered~$1$).
 %    \begin{macrocode}
-\cs_new:Npn \@@_tl_odd_items:n #1
+\cs_new:Npn \@@_tl_odd_items:n #1 { \@@_tl_even_items:n { ? #1 } }
+\cs_new:Npn \@@_tl_even_items:n #1
   {
-    \@@_tl_odd_items_loop:nn #1 \q_@@_nil \q_@@_nil \q_@@_nil
+    \@@_tl_even_items_loop:nn #1 \q_@@_nil \q_@@_nil
     \prg_break_point:
   }
-\cs_new:Npn \@@_tl_odd_items_loop:nn #1#2
+\cs_new:Npn \@@_tl_even_items_loop:nn #1#2
   {
-    \@@_use_none_delimit_by_q_nil:w #1 \prg_break: \q_@@_nil
-    { \exp_not:n {#1} }
-    \@@_tl_odd_items_loop:nn
+    \@@_use_none_delimit_by_q_nil:w #2 \prg_break: \q_@@_nil
+    { \exp_not:n {#2} }
+    \@@_tl_even_items_loop:nn
   }
 %    \end{macrocode}
 % \end{macro}
@@ -5747,7 +5788,7 @@
 % \subsubsection{Framework}
 %
 % \begin{macro}{\@@_replacement:n, \@@_replacement:x}
-% \begin{macro}{\@@_replacement_aux:n}
+% \begin{macro}{\@@_replacement_apply:Nn, \@@_replacement_set:n}
 %   The replacement text is built incrementally. We keep track in
 %   \cs{l_@@_balance_int} of the balance of explicit begin- and
 %   end-group tokens and we store in \cs{l_@@_balance_tl} some
@@ -5758,7 +5799,9 @@
 %   parsed, make sure that there is no open csname. Finally, define the
 %   \texttt{balance_one_match} and \texttt{do_one_match} functions.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_replacement:n #1
+\cs_new_protected:Npn \@@_replacement:n
+  { \@@_replacement_apply:Nn \@@_replacement_set:n }
+\cs_new_protected:Npn \@@_replacement_apply:Nn #1#2
   {
     \group_begin:
       \tl_build_begin:N \l_@@_build_tl
@@ -5779,7 +5822,7 @@
         }
         { \@@_replacement_escaped:N ##1 }
         { \@@_replacement_normal:n ##1 }
-        {#1}
+        {#2}
       \prg_do_nothing: \prg_do_nothing:
       \if_int_compare:w \l_@@_replacement_csnames_int > \c_zero_int
         \msg_error:nnx { regex } { replacement-missing-rbrace }
@@ -5802,10 +5845,10 @@
       \tl_build_end:N \l_@@_build_tl
       \exp_args:NNo
     \group_end:
-    \@@_replacement_aux:n \l_@@_build_tl
+    #1 \l_@@_build_tl
   }
 \cs_generate_variant:Nn \@@_replacement:n { x }
-\cs_new_protected:Npn \@@_replacement_aux:n #1
+\cs_new_protected:Npn \@@_replacement_set:n #1
   {
     \cs_set:Npn \@@_replacement_do_one_match:n ##1
       {
@@ -5823,6 +5866,28 @@
   }
 %    \end{macrocode}
 % \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\@@_case_replacement:n, \@@_case_replacement:x}
+%    \begin{macrocode}
+\tl_new:N \g_@@_case_replacement_tl
+\cs_new_protected:Npn \@@_case_replacement:n #1
+  {
+    \tl_gset:Nn \g_@@_case_replacement_tl
+      {
+        \if_case:w
+          \__kernel_intarray_item:Nn
+            \g_@@_submatch_case_intarray {##1}
+      }
+    \tl_map_tokens:nn {#1}
+      { \@@_replacement_apply:Nn \@@_case_replacement_aux:n }
+    \exp_args:No \@@_replacement_set:n
+      { \g_@@_case_replacement_tl \fi: }
+  }
+\cs_generate_variant:Nn \@@_case_replacement:n { x }
+\cs_new_protected:Npn \@@_case_replacement_aux:n #1
+  { \tl_gput_right:Nn \g_@@_case_replacement_tl { \or: #1 } }
+%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{\@@_replacement_put:n}
@@ -6537,6 +6602,38 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}[noTF]{\regex_case_replace_all:nN}
+%   If the input is bad (odd number of items) then take the false
+%   branch.  Otherwise, use the same auxiliary as
+%   \cs{regex_replace_all:nnN}, but with more complicated code to build
+%   the automaton, and to find what replacement text to use.
+%    \begin{macrocode}
+\cs_new_protected:Npn \regex_case_replace_all:nNTF #1#2
+  {
+    \int_if_odd:nTF { \tl_count:n {#1} }
+      {
+        \__kernel_msg_error:nnxxxx { regex } { case-odd }
+          { \token_to_str:N \regex_case_replace_all:nN(TF) } { code }
+          { \tl_count:n {#1} } { \tl_to_str:n {#1} }
+        \use_ii:nn
+      }
+      {
+        \@@_replace_all_aux:nnN
+          { \@@_case_build:x { \@@_tl_odd_items:n {#1} } }
+          { \@@_case_replacement:x { \@@_tl_even_items:n {#1} } }
+          #2
+        \bool_if:NTF \g_@@_success_bool
+      }
+  }
+\cs_new_protected:Npn \regex_case_replace_all:nN #1#2
+  { \regex_case_replace_all:nNTF {#1} {#2} { } { } }
+\cs_new_protected:Npn \regex_case_replace_all:nNT #1#2#3
+  { \regex_case_replace_all:nNTF {#1} {#2} {#3} { } }
+\cs_new_protected:Npn \regex_case_replace_all:nNF #1#2
+  { \regex_case_replace_all:nNTF {#1} {#2} { } }
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsubsection{Variables and helpers for user functions}
 %
 % \begin{variable}{\l_@@_match_count_int}
@@ -6574,12 +6671,14 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\g_@@_submatch_prev_intarray, \g_@@_submatch_begin_intarray, \g_@@_submatch_end_intarray}
-%   Hold the place where the match attempt begun and the end-points of each submatch.
+% \begin{variable}{\g_@@_submatch_prev_intarray, \g_@@_submatch_begin_intarray, \g_@@_submatch_end_intarray, \g_@@_submatch_case_intarray}
+%   Hold the place where the match attempt begun, the end-points of each
+%   submatch, and which regex case the match corresponds to, respectively.
 %    \begin{macrocode}
 \intarray_new:Nn \g_@@_submatch_prev_intarray { 65536 }
 \intarray_new:Nn \g_@@_submatch_begin_intarray { 65536 }
 \intarray_new:Nn \g_@@_submatch_end_intarray { 65536 }
+\intarray_new:Nn \g_@@_submatch_case_intarray { 65536 }
 %    \end{macrocode}
 % \end{variable}
 %
@@ -6998,10 +7097,14 @@
         {
           \__kernel_intarray_gset:Nnn \g_@@_submatch_prev_intarray
             { \l_@@_submatch_int } { 0 }
+          \__kernel_intarray_gset:Nnn \g_@@_submatch_case_intarray
+            { \l_@@_submatch_int } { 0 }
           \int_incr:N \l_@@_submatch_int
         }
       \__kernel_intarray_gset:Nnn \g_@@_submatch_prev_intarray
         { \l_@@_zeroth_submatch_int } { \l_@@_start_pos_int }
+      \__kernel_intarray_gset:Nnn \g_@@_submatch_case_intarray
+        { \l_@@_zeroth_submatch_int } { \g_@@_case_int }
       \int_zero:N \l_@@_internal_a_int
       \exp_after:wN \@@_extract_aux:w \l_@@_success_submatches_tl
         \prg_break_point: \@@_use_none_delimit_by_q_recursion_stop:w ,
@@ -7088,14 +7191,16 @@
 %   match. Join together the replacement texts for each match (including
 %   the part of the query before the match), and the end of the query.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_replace_all:nnN #1#2#3
+\cs_new_protected:Npn \@@_replace_all:nnN #1#2
+  { \@@_replace_all_aux:nnN {#1} { \@@_replacement:n {#2} } }
+\cs_new_protected:Npn \@@_replace_all_aux:nnN #1#2#3
   {
     \group_begin:
       \@@_multi_match:n { \@@_extract: }
       #1
       \exp_args:No \@@_match:n {#3}
       \exp_args:No \@@_query_set:n {#3}
-      \@@_replacement:n {#2}
+      #2
       \int_set:Nn \l_@@_balance_int
         {
           0

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -99,7 +99,7 @@
 %
 % \section{Syntax of regular expressions}
 %
-% \subsection{Regex examples}
+% \subsection{Regular expression examples}
 %
 % We start with a few examples, and encourage the reader to apply
 % \cs{regex_show:n} to these regular expressions.
@@ -620,6 +620,43 @@
 %   results in \cs[no-index]{l_foo_int} taking the value $5$.
 % \end{function}
 %
+% \begin{function}[noTF, added = 2021-05-15]{\regex_case_match:nn}
+%   \begin{syntax}
+%     \cs{regex_case_match:nnTF}
+%     ~~|{| \\
+%     ~~~~\Arg{regex_1} \Arg{code case_1} \\
+%     ~~~~\Arg{regex_2} \Arg{code case_2} \\
+%     ~~~~\ldots \\
+%     ~~~~\Arg{regex_n} \Arg{code case_n} \\
+%     ~~|}| \Arg{token list}
+%     ~~\Arg{true code} \Arg{false code}
+%   \end{syntax}
+%   Determines which of the \meta{regular expressions} matches at the
+%   earliest point in the \meta{token list}, and leaves the
+%   corresponding \meta{code_i} followed by the \meta{true code} in the
+%   input stream.  If several \meta{regex} match starting at the same
+%   point, then the first one in the list is selected and the others are
+%   discarded.  If none of the \meta{regex} match, the \meta{false code}
+%   is left in the input stream.
+%
+%   In detail, for each starting position in the \meta{token list}, each
+%   of the \meta{regex} is searched in turn.  If one of them matches
+%   then the corresponding \meta{code} is used and everything else is
+%   discarded, while if none of the \meta{regex} match at a given
+%   position then the next starting position is attempted.  If none of
+%   the \meta{regex} match anywhere in the \meta{token list} then
+%   nothing is left in the input stream.  Note that this differs from
+%   nested \cs{regex_match:nnTF} statements since all \meta{regex} are
+%   attempted at each position rather than attempting to match
+%   \meta{regex_1} at every position before moving on to \meta{regex_2}.
+%
+%   Each \meta{regex} can either be given as a regex variable or as an
+%   explicit regular expression.  It may be useful to include as the
+%   last case \meta{regex_n} the regex |{\Z}|, which always matches at
+%   the very end of the \meta{token list}, so as to include fall-back
+%   code \meta{code case_n} used when no other case matches.
+% \end{function}
+%
 % \section{Submatch extraction}
 %
 % \begin{function}[noTF, added = 2017-05-26]
@@ -1100,6 +1137,27 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\@@_tl_pairs_map:nNF, \@@_tl_pairs_map:Nnn}
+%   Map through a token list one pair at a time, with a two-argument
+%   function.
+%    \begin{macrocode}
+\cs_new:Npn \@@_tl_pairs_map:nNF #1#2
+  {
+    \@@_tl_pairs_map:Nnn #2 #1 \q_@@_nil \q_@@_nil
+    \prg_break_point:
+  }
+\cs_new:Npn \@@_tl_pairs_map:Nnn #1#2#3
+  {
+    \@@_use_none_delimit_by_q_nil:w
+      #2 \prg_break:n \use_none:n
+      #3 \prg_break:n \use:n
+    \q_@@_nil
+    #1 {#2} {#3}
+    \@@_tl_pairs_map:Nnn #1
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsubsection{Constants and variables}
 %
 % \begin{macro}{\@@_tmp:w}
@@ -1186,9 +1244,17 @@
 %    \end{macrocode}
 % \end{variable}
 %
+% \begin{variable}{\q_@@_nil}
+%   Internal quarks.
+%    \begin{macrocode}
+\quark_new:N \q_@@_nil
+%    \end{macrocode}
+% \end{variable}
+%
 % \begin{macro}[EXP]{
 %     \@@_use_none_delimit_by_q_recursion_stop:w,
-%     \@@_use_i_delimit_by_q_recursion_stop:nw
+%     \@@_use_i_delimit_by_q_recursion_stop:nw,
+%     \@@_use_none_delimit_by_q_nil:w,
 %   }
 %   Functions to gobble up to a quark.
 %    \begin{macrocode}
@@ -1196,15 +1262,9 @@
   #1 \q_@@_recursion_stop { }
 \cs_new:Npn \@@_use_i_delimit_by_q_recursion_stop:nw
   #1 #2 \q_@@_recursion_stop {#1}
+\cs_new:Npn \@@_use_none_delimit_by_q_nil:w #1 \q_@@_nil { }
 %    \end{macrocode}
 % \end{macro}
-%
-% \begin{variable}{\q_@@_nil}
-%   Internal quarks.
-%    \begin{macrocode}
-\quark_new:N \q_@@_nil
-%    \end{macrocode}
-% \end{variable}
 %
 % \begin{macro}[pTF]{\@@_quark_if_nil:n}
 %   Branching quark conditional.
@@ -2339,6 +2399,24 @@
           \prg_do_nothing: \prg_do_nothing:
         }
     \@@_compile_end:
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_compile_use:n}
+%   Use a regex, regardless of whether it is given as a string (in which
+%   case we need to compile) or as a regex variable.  This is used for
+%   \cs{regex_case_match:nn} and related functions to allow a mixture of
+%   explicit regex and regex variables.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_compile_use:n #1
+  {
+    \tl_if_single_token:nT {#1}
+      {
+        \exp_args:No \tl_if_head_eq_meaning:nNT #1 \@@_branch:n
+          { \use_ii:nnn }
+      }
+    \@@_compile:n {#1} \l_@@_internal_regex
   }
 %    \end{macrocode}
 % \end{macro}
@@ -4154,6 +4232,76 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{variable}{\g_@@_case_int}
+%   Case number that was successfully matched in
+%   \cs{regex_case_match:nn} and related functions.
+%    \begin{macrocode}
+\int_new:N \g_@@_case_int
+%    \end{macrocode}
+% \end{variable}
+%
+% \begin{variable}{\l_@@_case_max_group_int}
+%   The largest group number appearing in any of the \meta{regex} in the
+%   argument of \cs{regex_case_match:nn} and related functions.
+%    \begin{macrocode}
+\int_new:N \l_@@_case_max_group_int
+%    \end{macrocode}
+% \end{variable}
+%
+% \begin{macro}{\@@_case_build:n, \@@_case_build_aux:Nn, \@@_case_build_loop:n}
+%   See \cs{@@_build:n}, but with a loop.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_case_build:n
+  { \@@_case_build_aux:Nn \c_true_bool }
+\cs_new_protected:Npn \@@_case_build_aux:Nn #1#2
+  {
+    \@@_standard_escapechar:
+    \int_set_eq:NN \l_@@_max_state_int \l_@@_min_state_int
+    \@@_build_new_state:
+    \@@_build_new_state:
+    \@@_toks_put_right:Nn \l_@@_left_state_int
+      { \@@_action_start_wildcard:N #1 }
+    %
+    \@@_build_new_state:
+    \@@_toks_put_left:Nx \l_@@_left_state_int
+      { \@@_action_submatch:nN { 0 } < }
+    \@@_push_lr_states:
+    \int_zero:N \l_@@_case_max_group_int
+    \int_gzero:N \g_@@_case_int
+    \tl_map_inline:nn {#2}
+      {
+        \int_gincr:N \g_@@_case_int
+        \@@_case_build_loop:n {##1}
+      }
+    \int_set_eq:NN \l_@@_capturing_group_int \l_@@_case_max_group_int
+    \@@_pop_lr_states:
+  }
+\cs_new_protected:Npn \@@_case_build_loop:n #1
+  {
+    \int_set:Nn \l_@@_capturing_group_int { 1 }
+    \@@_compile_use:n {#1}
+    \int_set:Nn \l_@@_case_max_group_int
+      {
+        \int_max:nn { \l_@@_case_max_group_int }
+          { \l_@@_capturing_group_int }
+      }
+    \seq_pop:NN \l_@@_right_state_seq \l_@@_internal_a_tl
+    \int_set:Nn \l_@@_right_state_int \l_@@_internal_a_tl
+    \@@_toks_put_left:Nx \l_@@_right_state_int
+      {
+        \@@_action_submatch:nN { 0 } >
+        \int_gset:Nn \g_@@_case_int
+          { \int_use:N \g_@@_case_int }
+        \@@_action_success:
+      }
+    \@@_toks_clear:N \l_@@_max_state_int
+    \seq_push:No \l_@@_right_state_seq
+      { \int_use:N \l_@@_max_state_int }
+    \int_incr:N \l_@@_max_state_int
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{\@@_build_for_cs:n}
 %   The matching code relies on some global intarray variables, but only
 %   uses a range of their entries.  Specifically,
@@ -4495,7 +4643,7 @@
 %   the group, and leaves \texttt{internal_a} pointing to the left end
 %   of the last repetition. We only record the submatch information at
 %   the last repetition. Finally, add a state at the end (the transition
-%   to it has been taken care of by the replicating auxiliary.
+%   to it has been taken care of by the replicating auxiliary).
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_group_repeat:nn #1#2
   {
@@ -6269,6 +6417,34 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}[noTF]{\regex_case_match:nn}
+%   The auxiliary errors if |#1| has an odd number of items, and
+%   otherwise it sets \cs{g_@@_case_int} according to which case was
+%   found (zero if not found).  Overall, the \texttt{false} branch is
+%   taken either if the cases |#1| were nonsense (odd number of items)
+%   or if there was no match.  The \texttt{true} branch is taken
+%   otherwise, and we leave the corresponding code in the input stream.
+%    \begin{macrocode}
+\cs_new_protected:Npn \regex_case_match:nnTF #1#2#3#4
+  {
+    \int_gzero:N \g_@@_case_int
+    \@@_case_match:nn {#1} {#2}
+    \int_compare:nNnTF \g_@@_case_int = 0
+      {#4}
+      {
+        \tl_item:nn {#1} { 2 * \g_@@_case_int }
+        #3
+      }
+  }
+\cs_new_protected:Npn \regex_case_match:nn #1#2
+  { \regex_case_match:nnTF {#1} {#2} { } { } }
+\cs_new_protected:Npn \regex_case_match:nnT #1#2#3
+  { \regex_case_match:nnTF {#1} {#2} {#3} { } }
+\cs_new_protected:Npn \regex_case_match:nnF #1#2#3
+  { \regex_case_match:nnTF {#1} {#2} { } {#3} }
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}[noTF]
 %   {
 %     \regex_extract_once:nnN, \regex_extract_once:NnN,
@@ -6431,6 +6607,37 @@
     \group_end:
   }
 %    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_case_match:nn}
+% \begin{macro}[EXP]{\@@_case_match_aux:nn}
+%   The code would get badly messed up if the number of items in |#1|
+%   were not even, so we catch this case, then follow the same code as
+%   \cs{regex_match:nnTF} but using \cs{@@_case_build:n} and without
+%   returning a result.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_case_match:nn #1#2
+  {
+    \int_if_odd:nTF { \tl_count:n {#1} }
+      {
+        \__kernel_msg_error:nnxxxx { regex } { case-odd }
+          { \token_to_str:N \regex_case_match:nn } { code }
+          { \tl_count:n {#1} } { \tl_to_str:n {#1} }
+      }
+      {
+        \group_begin:
+          \@@_disable_submatches:
+          \@@_single_match:
+          \exp_args:Nx \@@_case_build:n
+            { \@@_tl_pairs_map:nNF {#1} \@@_case_match_aux:nn { } }
+          \int_gzero:N \g_@@_case_int
+          \@@_match:n {#2}
+        \group_end:
+      }
+  }
+\cs_new:Npn \@@_case_match_aux:nn #1#2 { \exp_not:n { {#1} } }
+%    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 % \begin{macro}{\@@_count:nnN}
@@ -7617,8 +7824,15 @@
   { The~values~given~in~a~quantifier~must~be~in~order. }
 %    \end{macrocode}
 %
-% Used when showing a regex.
+% Used in user commands, and when showing a regex.
 %    \begin{macrocode}
+\msg_new:nnnn { regex } { case-odd }
+  { #1~with~odd~number~of~items }
+  {
+    There~must~be~a~#2~part~for~each~regex:~
+    found~odd~number~of~items~(#3)~in\\
+    \iow_indent:n {#4}
+  }
 \msg_new:nnn { regex } { show }
   {
     >~Compiled~regex~

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -620,9 +620,9 @@
 %   results in \cs[no-index]{l_foo_int} taking the value $5$.
 % \end{function}
 %
-% \begin{function}[noTF, added = 2021-05-15]{\regex_case_match:nn}
+% \begin{function}[noTF, added = 2022-01-10]{\regex_match_case:nn}
 %   \begin{syntax}
-%     \cs{regex_case_match:nnTF}
+%     \cs{regex_match_case:nnTF}
 %     ~~|{| \\
 %     ~~~~\Arg{regex_1} \Arg{code case_1} \\
 %     ~~~~\Arg{regex_2} \Arg{code case_2} \\
@@ -766,9 +766,9 @@
 %   locally to \meta{tl~var}.
 % \end{function}
 %
-% \begin{function}[noTF, added = 2021-05-15]{\regex_case_replace_once:nN}
+% \begin{function}[noTF, added = 2022-01-10]{\regex_replace_case_once:nN}
 %   \begin{syntax}
-%     \cs{regex_case_replace_once:nNTF}
+%     \cs{regex_replace_case_once:nNTF}
 %     ~~|{| \\
 %     ~~~~\Arg{regex_1} \Arg{replacement_1} \\
 %     ~~~~\Arg{regex_2} \Arg{replacement_2} \\
@@ -790,13 +790,13 @@
 %   of the \meta{regex} is searched in turn.  If one of them matches
 %   then it is replaced by the corresponding \meta{replacement} as
 %   described for \cs{regex_replace_once:nnN}.  This is equivalent to
-%   checking with \cs{regex_case_match:nn} which \meta{regex} matches,
+%   checking with \cs{regex_match_case:nn} which \meta{regex} matches,
 %   then performing the replacement with \cs{regex_replace_once:nnN}.
 % \end{function}
 %
-% \begin{function}[noTF, added = 2021-05-15]{\regex_case_replace_all:nN}
+% \begin{function}[noTF, added = 2022-01-10]{\regex_replace_case_all:nN}
 %   \begin{syntax}
-%     \cs{regex_case_replace_all:nNTF}
+%     \cs{regex_replace_case_all:nNTF}
 %     ~~|{| \\
 %     ~~~~\Arg{regex_1} \Arg{replacement_1} \\
 %     ~~~~\Arg{regex_2} \Arg{replacement_2} \\
@@ -819,7 +819,7 @@
 %   replacement).  For instance
 % \begin{verbatim}
 % \tl_set:Nn \l_tmpa_tl { Hello,~world! }
-% \regex_case_replace_all:nN
+% \regex_replace_case_all:nN
 %   {
 %     { [A-Za-z]+ } { ``\0'' }
 %     { \b } { --- }
@@ -831,7 +831,7 @@
 %   the word-boundary assertion |\b| did not match at the start of words
 %   because the case |[A-Za-z]+| matched at these positions.  To change
 %   this, one could simply swap the order of the two cases in the
-%   argument of \cs{regex_case_replace_all:nN}.
+%   argument of \cs{regex_replace_case_all:nN}.
 % \end{function}
 %
 % \section{Scratch regular expressions}
@@ -2468,7 +2468,7 @@
 % \begin{macro}{\@@_compile_use:n}
 %   Use a regex, regardless of whether it is given as a string (in which
 %   case we need to compile) or as a regex variable.  This is used for
-%   \cs{regex_case_match:nn} and related functions to allow a mixture of
+%   \cs{regex_match_case:nn} and related functions to allow a mixture of
 %   explicit regex and regex variables.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_compile_use:n #1
@@ -4301,7 +4301,7 @@
 %
 % \begin{variable}{\g_@@_case_int}
 %   Case number that was successfully matched in
-%   \cs{regex_case_match:nn} and related functions.
+%   \cs{regex_match_case:nn} and related functions.
 %    \begin{macrocode}
 \int_new:N \g_@@_case_int
 %    \end{macrocode}
@@ -4309,7 +4309,7 @@
 %
 % \begin{variable}{\l_@@_case_max_group_int}
 %   The largest group number appearing in any of the \meta{regex} in the
-%   argument of \cs{regex_case_match:nn} and related functions.
+%   argument of \cs{regex_match_case:nn} and related functions.
 %    \begin{macrocode}
 \int_new:N \l_@@_case_max_group_int
 %    \end{macrocode}
@@ -6520,26 +6520,26 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}[noTF]{\regex_case_match:nn}
+% \begin{macro}[noTF]{\regex_match_case:nn}
 %   The auxiliary errors if |#1| has an odd number of items, and
 %   otherwise it sets \cs{g_@@_case_int} according to which case was
 %   found (zero if not found).  The \texttt{true} branch leaves the
 %   corresponding code in the input stream.
 %    \begin{macrocode}
-\cs_new_protected:Npn \regex_case_match:nnTF #1#2#3
+\cs_new_protected:Npn \regex_match_case:nnTF #1#2#3
   {
-    \@@_case_match:nnTF {#1} {#2}
+    \@@_match_case:nnTF {#1} {#2}
       {
         \tl_item:nn {#1} { 2 * \g_@@_case_int }
         #3
       }
   }
-\cs_new_protected:Npn \regex_case_match:nn #1#2
-  { \regex_case_match:nnTF {#1} {#2} { } { } }
-\cs_new_protected:Npn \regex_case_match:nnT #1#2#3
-  { \regex_case_match:nnTF {#1} {#2} {#3} { } }
-\cs_new_protected:Npn \regex_case_match:nnF #1#2
-  { \regex_case_match:nnTF {#1} {#2} { } }
+\cs_new_protected:Npn \regex_match_case:nn #1#2
+  { \regex_match_case:nnTF {#1} {#2} { } { } }
+\cs_new_protected:Npn \regex_match_case:nnT #1#2#3
+  { \regex_match_case:nnTF {#1} {#2} {#3} { } }
+\cs_new_protected:Npn \regex_match_case:nnF #1#2
+  { \regex_match_case:nnTF {#1} {#2} { } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -6580,7 +6580,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}[noTF]{\regex_case_replace_once:nN}
+% \begin{macro}[noTF]{\regex_replace_case_once:nN}
 %   If the input is bad (odd number of items) then take the false
 %   branch.  Otherwise, use the same auxiliary as
 %   \cs{regex_replace_once:nnN}, but with more complicated code to build
@@ -6588,12 +6588,12 @@
 %   \cs{tl_item:nn} is only expanded once we know the value of
 %   \cs{g_@@_case_int}, namely which case matched.
 %    \begin{macrocode}
-\cs_new_protected:Npn \regex_case_replace_once:nNTF #1#2
+\cs_new_protected:Npn \regex_replace_case_once:nNTF #1#2
   {
     \int_if_odd:nTF { \tl_count:n {#1} }
       {
         \msg_error:nnxxxx { regex } { case-odd }
-          { \token_to_str:N \regex_case_replace_once:nN(TF) } { code }
+          { \token_to_str:N \regex_replace_case_once:nN(TF) } { code }
           { \tl_count:n {#1} } { \tl_to_str:n {#1} }
         \use_ii:nn
       }
@@ -6605,12 +6605,12 @@
         \bool_if:NTF \g_@@_success_bool
       }
   }
-\cs_new_protected:Npn \regex_case_replace_once:nN #1#2
-  { \regex_case_replace_once:nNTF {#1} {#2} { } { } }
-\cs_new_protected:Npn \regex_case_replace_once:nNT #1#2#3
-  { \regex_case_replace_once:nNTF {#1} {#2} {#3} { } }
-\cs_new_protected:Npn \regex_case_replace_once:nNF #1#2
-  { \regex_case_replace_once:nNTF {#1} {#2} { } }
+\cs_new_protected:Npn \regex_replace_case_once:nN #1#2
+  { \regex_replace_case_once:nNTF {#1} {#2} { } { } }
+\cs_new_protected:Npn \regex_replace_case_once:nNT #1#2#3
+  { \regex_replace_case_once:nNTF {#1} {#2} {#3} { } }
+\cs_new_protected:Npn \regex_replace_case_once:nNF #1#2
+  { \regex_replace_case_once:nNTF {#1} {#2} { } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -6620,12 +6620,12 @@
 %   \cs{regex_replace_all:nnN}, but with more complicated code to build
 %   the automaton, and to find what replacement text to use.
 %    \begin{macrocode}
-\cs_new_protected:Npn \regex_case_replace_all:nNTF #1#2
+\cs_new_protected:Npn \regex_replace_case_all:nNTF #1#2
   {
     \int_if_odd:nTF { \tl_count:n {#1} }
       {
         \msg_error:nnxxxx { regex } { case-odd }
-          { \token_to_str:N \regex_case_replace_all:nN(TF) } { code }
+          { \token_to_str:N \regex_replace_case_all:nN(TF) } { code }
           { \tl_count:n {#1} } { \tl_to_str:n {#1} }
         \use_ii:nn
       }
@@ -6637,12 +6637,12 @@
         \bool_if:NTF \g_@@_success_bool
       }
   }
-\cs_new_protected:Npn \regex_case_replace_all:nN #1#2
-  { \regex_case_replace_all:nNTF {#1} {#2} { } { } }
-\cs_new_protected:Npn \regex_case_replace_all:nNT #1#2#3
-  { \regex_case_replace_all:nNTF {#1} {#2} {#3} { } }
-\cs_new_protected:Npn \regex_case_replace_all:nNF #1#2
-  { \regex_case_replace_all:nNTF {#1} {#2} { } }
+\cs_new_protected:Npn \regex_replace_case_all:nN #1#2
+  { \regex_replace_case_all:nNTF {#1} {#2} { } { } }
+\cs_new_protected:Npn \regex_replace_case_all:nNT #1#2#3
+  { \regex_replace_case_all:nNTF {#1} {#2} {#3} { } }
+\cs_new_protected:Npn \regex_replace_case_all:nNF #1#2
+  { \regex_replace_case_all:nNTF {#1} {#2} { } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -6775,19 +6775,19 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_case_match:nnTF}
-% \begin{macro}[EXP]{\@@_case_match_aux:nn}
+% \begin{macro}{\@@_match_case:nnTF}
+% \begin{macro}[EXP]{\@@_match_case_aux:nn}
 %   The code would get badly messed up if the number of items in |#1|
 %   were not even, so we catch this case, then follow the same code as
 %   \cs{regex_match:nnTF} but using \cs{@@_case_build:n} and without
 %   returning a result.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_case_match:nnTF #1#2
+\cs_new_protected:Npn \@@_match_case:nnTF #1#2
   {
     \int_if_odd:nTF { \tl_count:n {#1} }
       {
         \msg_error:nnxxxx { regex } { case-odd }
-          { \token_to_str:N \regex_case_match:nn(TF) } { code }
+          { \token_to_str:N \regex_match_case:nn(TF) } { code }
           { \tl_count:n {#1} } { \tl_to_str:n {#1} }
         \use_ii:nn
       }
@@ -6798,7 +6798,7 @@
         \bool_if:NTF \g_@@_success_bool
       }
   }
-\cs_new:Npn \@@_case_match_aux:nn #1#2 { \exp_not:n { {#1} } }
+\cs_new:Npn \@@_match_case_aux:nn #1#2 { \exp_not:n { {#1} } }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -2475,10 +2475,15 @@
   {
     \tl_if_single_token:nT {#1}
       {
-        \exp_args:No \tl_if_head_eq_meaning:nNT #1 \@@_branch:n
-          { \use_ii:nnn }
+        \exp_after:wN \@@_compile_use_aux:w
+        \token_to_meaning:N #1 ~ \q_@@_nil
       }
     \@@_compile:n {#1} \l_@@_internal_regex
+  }
+\cs_new_protected:Npn \@@_compile_use_aux:w #1 ~ #2 \q_@@_nil
+  {
+    \str_if_eq:nnT { #1 ~ } { macro:->\@@_branch:n }
+      { \use_ii:nnn }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -6592,7 +6592,7 @@
   {
     \int_if_odd:nTF { \tl_count:n {#1} }
       {
-        \__kernel_msg_error:nnxxxx { regex } { case-odd }
+        \msg_error:nnxxxx { regex } { case-odd }
           { \token_to_str:N \regex_case_replace_once:nN(TF) } { code }
           { \tl_count:n {#1} } { \tl_to_str:n {#1} }
         \use_ii:nn
@@ -6624,7 +6624,7 @@
   {
     \int_if_odd:nTF { \tl_count:n {#1} }
       {
-        \__kernel_msg_error:nnxxxx { regex } { case-odd }
+        \msg_error:nnxxxx { regex } { case-odd }
           { \token_to_str:N \regex_case_replace_all:nN(TF) } { code }
           { \tl_count:n {#1} } { \tl_to_str:n {#1} }
         \use_ii:nn
@@ -6786,7 +6786,7 @@
   {
     \int_if_odd:nTF { \tl_count:n {#1} }
       {
-        \__kernel_msg_error:nnxxxx { regex } { case-odd }
+        \msg_error:nnxxxx { regex } { case-odd }
           { \token_to_str:N \regex_case_match:nn(TF) } { code }
           { \tl_count:n {#1} } { \tl_to_str:n {#1} }
         \use_ii:nn

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -637,7 +637,8 @@
 %   input stream.  If several \meta{regex} match starting at the same
 %   point, then the first one in the list is selected and the others are
 %   discarded.  If none of the \meta{regex} match, the \meta{false code}
-%   is left in the input stream.
+%   is left in the input stream.  Each \meta{regex} can either be given
+%   as a regex variable or as an explicit regular expression.
 %
 %   In detail, for each starting position in the \meta{token list}, each
 %   of the \meta{regex} is searched in turn.  If one of them matches
@@ -649,12 +650,6 @@
 %   nested \cs{regex_match:nnTF} statements since all \meta{regex} are
 %   attempted at each position rather than attempting to match
 %   \meta{regex_1} at every position before moving on to \meta{regex_2}.
-%
-%   Each \meta{regex} can either be given as a regex variable or as an
-%   explicit regular expression.  It may be useful to include as the
-%   last case \meta{regex_n} the regex |{\Z}|, which always matches at
-%   the very end of the \meta{token list}, so as to include fall-back
-%   code \meta{code case_n} used when no other case matches.
 % \end{function}
 %
 % \section{Submatch extraction}
@@ -1137,23 +1132,21 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_tl_pairs_map:nNF, \@@_tl_pairs_map:Nnn}
-%   Map through a token list one pair at a time, with a two-argument
-%   function.
+% \begin{macro}{\@@_tl_odd_items:n, \@@_tl_odd_items_loop:nn}
+%   Map through a token list one pair at a time, leaving the odd items
+%   (including the last one if the token list has an odd number of
+%   items).
 %    \begin{macrocode}
-\cs_new:Npn \@@_tl_pairs_map:nNF #1#2
+\cs_new:Npn \@@_tl_odd_items:n #1
   {
-    \@@_tl_pairs_map:Nnn #2 #1 \q_@@_nil \q_@@_nil
+    \@@_tl_odd_items_loop:nn #1 \q_@@_nil \q_@@_nil \q_@@_nil
     \prg_break_point:
   }
-\cs_new:Npn \@@_tl_pairs_map:Nnn #1#2#3
+\cs_new:Npn \@@_tl_odd_items_loop:nn #1#2
   {
-    \@@_use_none_delimit_by_q_nil:w
-      #2 \prg_break:n \use_none:n
-      #3 \prg_break:n \use:n
-    \q_@@_nil
-    #1 {#2} {#3}
-    \@@_tl_pairs_map:Nnn #1
+    \@@_use_none_delimit_by_q_nil:w #1 \prg_break: \q_@@_nil
+    { \exp_not:n {#1} }
+    \@@_tl_odd_items_loop:nn
   }
 %    \end{macrocode}
 % \end{macro}
@@ -4248,11 +4241,15 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{macro}{\@@_case_build:n, \@@_case_build_aux:Nn, \@@_case_build_loop:n}
+% \begin{macro}{\@@_case_build:n, \@@_case_build:x, \@@_case_build_aux:Nn, \@@_case_build_loop:n}
 %   See \cs{@@_build:n}, but with a loop.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_case_build:n
-  { \@@_case_build_aux:Nn \c_true_bool }
+\cs_new_protected:Npn \@@_case_build:n #1
+  {
+    \@@_case_build_aux:Nn \c_true_bool {#1}
+    \int_gzero:N \g_@@_case_int
+  }
+\cs_generate_variant:Nn \@@_case_build:n { x }
 \cs_new_protected:Npn \@@_case_build_aux:Nn #1#2
   {
     \@@_standard_escapechar:
@@ -6420,17 +6417,12 @@
 % \begin{macro}[noTF]{\regex_case_match:nn}
 %   The auxiliary errors if |#1| has an odd number of items, and
 %   otherwise it sets \cs{g_@@_case_int} according to which case was
-%   found (zero if not found).  Overall, the \texttt{false} branch is
-%   taken either if the cases |#1| were nonsense (odd number of items)
-%   or if there was no match.  The \texttt{true} branch is taken
-%   otherwise, and we leave the corresponding code in the input stream.
+%   found (zero if not found).  The \texttt{true} branch leaves the
+%   corresponding code in the input stream.
 %    \begin{macrocode}
-\cs_new_protected:Npn \regex_case_match:nnTF #1#2#3#4
+\cs_new_protected:Npn \regex_case_match:nnTF #1#2#3
   {
-    \int_gzero:N \g_@@_case_int
-    \@@_case_match:nn {#1} {#2}
-    \int_compare:nNnTF \g_@@_case_int = 0
-      {#4}
+    \@@_case_match:nnTF {#1} {#2}
       {
         \tl_item:nn {#1} { 2 * \g_@@_case_int }
         #3
@@ -6440,8 +6432,8 @@
   { \regex_case_match:nnTF {#1} {#2} { } { } }
 \cs_new_protected:Npn \regex_case_match:nnT #1#2#3
   { \regex_case_match:nnTF {#1} {#2} {#3} { } }
-\cs_new_protected:Npn \regex_case_match:nnF #1#2#3
-  { \regex_case_match:nnTF {#1} {#2} { } {#3} }
+\cs_new_protected:Npn \regex_case_match:nnF #1#2
+  { \regex_case_match:nnTF {#1} {#2} { } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -6609,30 +6601,27 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_case_match:nn}
+% \begin{macro}{\@@_case_match:nnTF}
 % \begin{macro}[EXP]{\@@_case_match_aux:nn}
 %   The code would get badly messed up if the number of items in |#1|
 %   were not even, so we catch this case, then follow the same code as
 %   \cs{regex_match:nnTF} but using \cs{@@_case_build:n} and without
 %   returning a result.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_case_match:nn #1#2
+\cs_new_protected:Npn \@@_case_match:nnTF #1#2
   {
     \int_if_odd:nTF { \tl_count:n {#1} }
       {
         \__kernel_msg_error:nnxxxx { regex } { case-odd }
-          { \token_to_str:N \regex_case_match:nn } { code }
+          { \token_to_str:N \regex_case_match:nn(TF) } { code }
           { \tl_count:n {#1} } { \tl_to_str:n {#1} }
+        \use_ii:nn
       }
       {
-        \group_begin:
-          \@@_disable_submatches:
-          \@@_single_match:
-          \exp_args:Nx \@@_case_build:n
-            { \@@_tl_pairs_map:nNF {#1} \@@_case_match_aux:nn { } }
-          \int_gzero:N \g_@@_case_int
-          \@@_match:n {#2}
-        \group_end:
+        \@@_if_match:nn
+          { \@@_case_build:x { \@@_tl_odd_items:n {#1} } }
+          {#2}
+        \bool_if:NTF \g_@@_success_bool
       }
   }
 \cs_new:Npn \@@_case_match_aux:nn #1#2 { \exp_not:n { {#1} } }

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -766,6 +766,34 @@
 %   locally to \meta{tl~var}.
 % \end{function}
 %
+% \begin{function}[noTF, added = 2021-05-15]{\regex_case_replace_once:nN}
+%   \begin{syntax}
+%     \cs{regex_case_replace_once:nNTF}
+%     ~~|{| \\
+%     ~~~~\Arg{regex_1} \Arg{replacement_1} \\
+%     ~~~~\Arg{regex_2} \Arg{replacement_2} \\
+%     ~~~~\ldots \\
+%     ~~~~\Arg{regex_n} \Arg{replacement_n} \\
+%     ~~|}| \meta{tl~var}
+%     ~~\Arg{true code} \Arg{false code}
+%   \end{syntax}
+%   Replaces the earliest match of the regular expression
+%   "(?|"\meta{regex_1}"|"\dots"|"\meta{regex_n}")" in the \meta{token
+%   list variable} by the \meta{replacement} corresponding to which
+%   \meta{regex_i} matched, then leaves the \meta{true code} in the
+%   input stream.  If none of the \meta{regex} match, then the
+%   \meta{tl~var} is not modified, and the \meta{false code} is left in
+%   the input stream.  Each \meta{regex} can either be given as a regex
+%   variable or as an explicit regular expression.
+%
+%   In detail, for each starting position in the \meta{token list}, each
+%   of the \meta{regex} is searched in turn.  If one of them matches
+%   then it is replaced by the corresponding \meta{replacement} as
+%   described for \cs{regex_replace_once:nnN}.  This is equivalent to
+%   checking with \cs{regex_case_match:nn} which \meta{regex} matches,
+%   then performing the replacement with \cs{regex_replace_once:nnN}.
+% \end{function}
+%
 % \section{Scratch regular expressions}
 %
 % \begin{variable}[added = 2017-12-11]{\l_tmpa_regex, \l_tmpb_regex}
@@ -5718,7 +5746,7 @@
 %
 % \subsubsection{Framework}
 %
-% \begin{macro}{\@@_replacement:n}
+% \begin{macro}{\@@_replacement:n, \@@_replacement:x}
 % \begin{macro}{\@@_replacement_aux:n}
 %   The replacement text is built incrementally. We keep track in
 %   \cs{l_@@_balance_int} of the balance of explicit begin- and
@@ -5776,6 +5804,7 @@
     \group_end:
     \@@_replacement_aux:n \l_@@_build_tl
   }
+\cs_generate_variant:Nn \@@_replacement:n { x }
 \cs_new_protected:Npn \@@_replacement_aux:n #1
   {
     \cs_set:Npn \@@_replacement_do_one_match:n ##1
@@ -6474,6 +6503,40 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}[noTF]{\regex_case_replace_once:nN}
+%   If the input is bad (odd number of items) then take the false
+%   branch.  Otherwise, use the same auxiliary as
+%   \cs{regex_replace_once:nnN}, but with more complicated code to build
+%   the automaton, and to find what replacement text to use.  The
+%   \cs{tl_item:nn} is only expanded once we know the value of
+%   \cs{g_@@_case_int}, namely which case matched.
+%    \begin{macrocode}
+\cs_new_protected:Npn \regex_case_replace_once:nNTF #1#2
+  {
+    \int_if_odd:nTF { \tl_count:n {#1} }
+      {
+        \__kernel_msg_error:nnxxxx { regex } { case-odd }
+          { \token_to_str:N \regex_case_replace_once:nN(TF) } { code }
+          { \tl_count:n {#1} } { \tl_to_str:n {#1} }
+        \use_ii:nn
+      }
+      {
+        \@@_replace_once_aux:nnN
+          { \@@_case_build:x { \@@_tl_odd_items:n {#1} } }
+          { \@@_replacement:x { \tl_item:nn {#1} { 2 * \g_@@_case_int } } }
+          #2
+        \bool_if:NTF \g_@@_success_bool
+      }
+  }
+\cs_new_protected:Npn \regex_case_replace_once:nN #1#2
+  { \regex_case_replace_once:nNTF {#1} {#2} { } { } }
+\cs_new_protected:Npn \regex_case_replace_once:nNT #1#2#3
+  { \regex_case_replace_once:nNTF {#1} {#2} {#3} { } }
+\cs_new_protected:Npn \regex_case_replace_once:nNF #1#2
+  { \regex_case_replace_once:nNTF {#1} {#2} { } }
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsubsection{Variables and helpers for user functions}
 %
 % \begin{variable}{\l_@@_match_count_int}
@@ -6963,7 +7026,7 @@
 %
 % \subsubsection{Replacement}
 %
-% \begin{macro}{\@@_replace_once:nnN}
+% \begin{macro}{\@@_replace_once:nnN, \@@_replace_once_aux:nnN}
 %   Build the \textsc{nfa} and the replacement functions, then find a
 %   single match.  If the match failed, simply exit the
 %   group. Otherwise, we do the replacement. Extract submatches. Compute
@@ -6977,18 +7040,19 @@
 %   \texttt{x}-expansion, and checks that braces are balanced in the
 %   final result.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_replace_once:nnN #1#2#3
+\cs_new_protected:Npn \@@_replace_once:nnN #1#2
+  { \@@_replace_once_aux:nnN {#1} { \@@_replacement:n {#2} } }
+\cs_new_protected:Npn \@@_replace_once_aux:nnN #1#2#3
   {
     \group_begin:
       \@@_single_match:
       #1
       \exp_args:No \@@_match:n {#3}
-      \if_meaning:w \c_false_bool \g_@@_success_bool
-        \group_end:
-      \else:
+    \bool_if:NTF \g_@@_success_bool
+      {
         \@@_extract:
         \exp_args:No \@@_query_set:n {#3}
-        \@@_replacement:n {#2}
+        #2
         \int_set:Nn \l_@@_balance_int
           {
             \@@_replacement_balance_one_match:n
@@ -7006,7 +7070,8 @@
               { \l_@@_max_pos_int }
           }
         \@@_group_end_replace:N #3
-      \fi:
+      }
+      { \group_end: }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -886,7 +886,7 @@
 %     \texttt{curr_state} and \texttt{curr_submatches}.
 %   \item If possible, when a state is reused by the same thread, kill
 %     other subthreads.
-%   \item Use an array rather than \cs[no-index]{l__regex_balance_tl}
+%   \item Use an array rather than \cs[no-index]{g__regex_balance_tl}
 %     to build the function \cs[no-index]{__regex_replacement_balance_one_match:n}.
 %   \item Reduce the number of epsilon-transitions in alternatives.
 %   \item Optimize simple strings: use less states (|abcade| should give
@@ -5639,12 +5639,12 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\l_@@_balance_tl}
+% \begin{variable}{\g_@@_balance_tl}
 %   This token list holds the replacement text for
 %   \cs{@@_replacement_balance_one_match:n} while it is being built
 %   incrementally.
 %    \begin{macrocode}
-\tl_new:N \l_@@_balance_tl
+\tl_new:N \g_@@_balance_tl
 %    \end{macrocode}
 % \end{variable}
 %
@@ -5791,7 +5791,7 @@
 % \begin{macro}{\@@_replacement_apply:Nn, \@@_replacement_set:n}
 %   The replacement text is built incrementally. We keep track in
 %   \cs{l_@@_balance_int} of the balance of explicit begin- and
-%   end-group tokens and we store in \cs{l_@@_balance_tl} some
+%   end-group tokens and we store in \cs{g_@@_balance_tl} some
 %   code to compute the brace balance from submatches (see its
 %   description). Detect unescaped right braces, and escaped characters,
 %   with trailing \cs{prg_do_nothing:} because some of the later
@@ -5806,7 +5806,7 @@
     \group_begin:
       \tl_build_begin:N \l_@@_build_tl
       \int_zero:N \l_@@_balance_int
-      \tl_clear:N \l_@@_balance_tl
+      \tl_gclear:N \g_@@_balance_tl
       \@@_escape_use:nnnn
         {
           \if_charcode:w \c_right_brace_str ##1
@@ -5836,12 +5836,8 @@
             { \seq_count:N \l_@@_replacement_category_seq }
           \seq_clear:N \l_@@_replacement_category_seq
         }
-      \cs_gset:Npx \@@_replacement_balance_one_match:n ##1
-        {
-          + \int_use:N \l_@@_balance_int
-          \l_@@_balance_tl
-          - \@@_submatch_balance:n {##1}
-        }
+      \tl_gput_right:Nx \g_@@_balance_tl
+        { + \int_use:N \l_@@_balance_int }
       \tl_build_end:N \l_@@_build_tl
       \exp_args:NNo
     \group_end:
@@ -5863,6 +5859,12 @@
           }
         #1
       }
+    \exp_args:Nno \use:n
+      { \cs_gset:Npn \@@_replacement_balance_one_match:n ##1 }
+      {
+        \g_@@_balance_tl
+        - \@@_submatch_balance:n {##1}
+      }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -5871,22 +5873,30 @@
 % \begin{macro}{\@@_case_replacement:n, \@@_case_replacement:x}
 %    \begin{macrocode}
 \tl_new:N \g_@@_case_replacement_tl
+\tl_new:N \g_@@_case_balance_tl
 \cs_new_protected:Npn \@@_case_replacement:n #1
   {
-    \tl_gset:Nn \g_@@_case_replacement_tl
+    \tl_gset:Nn \g_@@_case_balance_tl
       {
         \if_case:w
           \__kernel_intarray_item:Nn
             \g_@@_submatch_case_intarray {##1}
       }
+    \tl_gset_eq:NN \g_@@_case_replacement_tl \g_@@_case_balance_tl
     \tl_map_tokens:nn {#1}
       { \@@_replacement_apply:Nn \@@_case_replacement_aux:n }
+    \tl_gset:No \g_@@_balance_tl
+      { \g_@@_case_balance_tl \fi: }
     \exp_args:No \@@_replacement_set:n
       { \g_@@_case_replacement_tl \fi: }
   }
 \cs_generate_variant:Nn \@@_case_replacement:n { x }
 \cs_new_protected:Npn \@@_case_replacement_aux:n #1
-  { \tl_gput_right:Nn \g_@@_case_replacement_tl { \or: #1 } }
+  {
+    \tl_gput_right:Nn \g_@@_case_replacement_tl { \or: #1 }
+    \tl_gput_right:No \g_@@_case_balance_tl
+      { \exp_after:wN \or: \g_@@_balance_tl }
+  }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -5990,7 +6000,7 @@
 %   construction, it must be taken into account in the brace balance.
 %   Later on, |##1| will be replaced by a pointer to the $0$-th submatch for a
 %   given match.  There is an \cs{exp_not:N} here as at the point-of-use
-%   of \cs{l_@@_balance_tl} there is an \texttt{x}-type expansion which is needed
+%   of \cs{g_@@_balance_tl} there is an \texttt{x}-type expansion which is needed
 %   to get |##1| in correctly.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_replacement_put_submatch:n #1
@@ -6007,11 +6017,8 @@
     \tl_build_put_right:Nn \l_@@_build_tl
       { \@@_query_submatch:n { \int_eval:n { #1 + ##1 } } }
     \if_int_compare:w \l_@@_replacement_csnames_int = \c_zero_int
-      \tl_put_right:Nn \l_@@_balance_tl
-        {
-          + \@@_submatch_balance:n
-            { \exp_not:N \int_eval:n { #1 + ##1 } }
-        }
+      \tl_gput_right:Nn \g_@@_balance_tl
+        { + \@@_submatch_balance:n { \int_eval:n { #1 + ##1 } } }
     \fi:
   }
 %    \end{macrocode}

--- a/l3kernel/testfiles/m3intarray001.luatex.tlg
+++ b/l3kernel/testfiles/m3intarray001.luatex.tlg
@@ -22,7 +22,7 @@ This is a coding error.
 LaTeX has been asked to create a new control sequence '\g_testa_intarray' but
 this name has already been used elsewhere.
 The current meaning is:
-  macro:->\__intarray:w 9 
+  macro:->\__intarray:w 10 
 Defining \g_testa_intarray on line ...
 ! LaTeX3 Error: Access to an entry beyond an array's bounds.
 For immediate help type H <return>.

--- a/l3kernel/testfiles/m3intarray001.tlg
+++ b/l3kernel/testfiles/m3intarray001.tlg
@@ -22,7 +22,7 @@ This is a coding error.
 LaTeX has been asked to create a new control sequence '\g_testa_intarray' but
 this name has already been used elsewhere.
 The current meaning is:
-  select font cmr10 at 0.00021pt
+  select font cmr10 at 0.00023pt
 Defining \g_testa_intarray on line ...
 ! LaTeX3 Error: Access to an entry beyond an array's bounds.
 For immediate help type H <return>.

--- a/l3kernel/testfiles/m3regex012.lvt
+++ b/l3kernel/testfiles/m3regex012.lvt
@@ -41,10 +41,39 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { regex_case_match:nn ~ error }
+\TEST { regex_case_replace_once:nN }
+  {
+    \regex_set:Nn \l_tmpa_regex { [a-z]bc }
+    \cs_set_protected:Npn \test:n #1
+      {
+        \tl_set:Nn \l_tmpa_tl {#1}
+        \regex_case_replace_once:nNTF
+          {
+            \l_tmpa_regex { (abc,\0,\1) } % should complain about \1 but doesn't
+            { (?i) Y (\w) } { [Y,\0,\1] }
+            { (z) \Z } { <\0,\1 Z> }
+          }
+          \l_tmpa_tl
+          { \TYPE{#1~=>~\l_tmpa_tl} }
+          { \TYPE{#1:~FALSE} }
+      }
+    \test:n { }
+    \test:n { abc }
+    \test:n { Y abc }
+    \test:n { y abc }
+    \test:n { y bc }
+    \test:n { y ; bc }
+    \test:n { y ; bc z }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { regex_case ~ errors }
   {
     \regex_case_match:nnTF { Something ~ odd. } { .. } { \ERROR } { \FALSE }
     \regex_case_match:nn { * } { .. }
+    \regex_case_replace_once:nNTF { Something ~ odd. } \l_tmpa_tl { \ERROR } { \FALSE }
+    \regex_case_replace_once:nN { * } { .. }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3regex012.lvt
+++ b/l3kernel/testfiles/m3regex012.lvt
@@ -1,0 +1,50 @@
+%
+% Copyright (C) 2021 The LaTeX Project
+\documentclass{minimal}
+\input{regression-test}
+
+\RequirePackage[enable-debug]{expl3}
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation , log-functions }
+\ExplSyntaxOff
+
+% \begin{document}
+
+\START
+\AUTHOR{Bruno Le Floch}
+\ExplSyntaxOn
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { regex_case_match:nn }
+  {
+    \regex_set:Nn \l_tmpa_regex { [a-z]bc }
+    \cs_set_protected:Npn \test:n #1
+      {
+        \TYPE{#1:}
+        \regex_case_match:nnTF
+          {
+            \l_tmpa_regex { \TYPE{abc} }
+            { (?i) Y \w } { \TYPE{Y} }
+            { z \Z } { \TYPE{Z} }
+          }
+          {#1} { \TRUE } { \FALSE }
+      }
+    \test:n { }
+    \test:n { abc }
+    \test:n { Y abc }
+    \test:n { y abc }
+    \test:n { y bc }
+    \test:n { y ; bc }
+    \test:n { y ; bc z }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { regex_case_match:nn ~ error }
+  {
+    \regex_case_match:nn { * } { .. }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\END

--- a/l3kernel/testfiles/m3regex012.lvt
+++ b/l3kernel/testfiles/m3regex012.lvt
@@ -16,13 +16,13 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { regex_case_match:nn }
+\TEST { regex_match_case:nn }
   {
     \regex_set:Nn \l_tmpa_regex { [a-z]bc }
     \cs_set_protected:Npn \test:n #1
       {
         \TYPE{#1:}
-        \regex_case_match:nnTF
+        \regex_match_case:nnTF
           {
             \l_tmpa_regex { \TYPE{abc} }
             { (?i) Y \w } { \TYPE{Y} }
@@ -41,13 +41,13 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { regex_case_replace_once:nN }
+\TEST { regex_replace_case_once:nN }
   {
     \regex_set:Nn \l_tmpa_regex { [a-z]bc }
     \cs_set_protected:Npn \test:n #1
       {
         \tl_set:Nn \l_tmpa_tl {#1}
-        \regex_case_replace_once:nNTF
+        \regex_replace_case_once:nNTF
           {
             \l_tmpa_regex { (abc,\0,\1) } % should complain about \1 but doesn't
             { (?i) Y (\w) } { [Y,\0,\1] }
@@ -68,13 +68,13 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { regex_case_replace_all:nN }
+\TEST { regex_replace_case_all:nN }
   {
     \regex_set:Nn \l_tmpa_regex { [a-z]bc }
     \cs_set_protected:Npn \test:n #1
       {
         \tl_set:Nn \l_tmpa_tl {#1}
-        \regex_case_replace_all:nNTF
+        \regex_replace_case_all:nNTF
           {
             \l_tmpa_regex { (abc,\0,\1) }
             { (?i) Y (\w) } { [Y,\0,\1] }
@@ -92,7 +92,7 @@
     \test:n { Y abc YYYz }
     \test:n { y abcbc }
     \tl_set:Nn \l_tmpa_tl { Hello,~world! }
-    \regex_case_replace_all:nNTF
+    \regex_replace_case_all:nNTF
       {
         { [A-Za-z]+ } { ``\0'' }
         { \b } { --- }
@@ -100,7 +100,7 @@
       } \l_tmpa_tl
       { \TYPE { \l_tmpa_tl } } { \ERROR }
     \tl_set:Nn \l_tmpa_tl { Hello,~world! }
-    \regex_case_replace_all:nNTF
+    \regex_replace_case_all:nNTF
       {
         { \b } { --- }
         { [A-Za-z]+ } { ``\0'' }
@@ -108,7 +108,7 @@
       } \l_tmpa_tl
       { \TYPE { \l_tmpa_tl } } { \ERROR }
     \tl_set:Nn \l_tmpa_tl { a ( b ( c ) d ( ) ) e }
-    \regex_case_replace_all:nN
+    \regex_replace_case_all:nN
       {
         { \( } { \{ }
         { \) } { \} }
@@ -116,7 +116,7 @@
       \l_tmpa_tl
     \tl_analysis_log:N \l_tmpa_tl
     \tl_set:Nn \l_tmpa_tl { a { } b | { | | } | | e }
-    \regex_case_replace_all:nN
+    \regex_replace_case_all:nN
       {
         { \| } { \} }
         { . (.) } { \0\1 }
@@ -124,7 +124,7 @@
       \l_tmpa_tl
     \tl_analysis_log:N \l_tmpa_tl
     \tl_clear:N \l_tmpa_tl
-    \regex_case_replace_all:nN
+    \regex_replace_case_all:nN
       {
         { \A } { A }
         \Z { Z }
@@ -137,12 +137,12 @@
 
 \TEST { regex_case ~ errors }
   {
-    \regex_case_match:nnTF { Something ~ odd. } { .. } { \ERROR } { \FALSE }
-    \regex_case_match:nn { * } { .. }
-    \regex_case_replace_once:nNTF { Something ~ odd. } \l_tmpa_tl { \ERROR } { \FALSE }
-    \regex_case_replace_once:nN { * } { .. }
-    \regex_case_replace_all:nNTF { Something ~ odd. } \l_tmpa_tl { \ERROR } { \FALSE }
-    \regex_case_replace_all:nN { * } { .. }
+    \regex_match_case:nnTF { Something ~ odd. } { .. } { \ERROR } { \FALSE }
+    \regex_match_case:nn { * } { .. }
+    \regex_replace_case_once:nNTF { Something ~ odd. } \l_tmpa_tl { \ERROR } { \FALSE }
+    \regex_replace_case_once:nN { * } { .. }
+    \regex_replace_case_all:nNTF { Something ~ odd. } \l_tmpa_tl { \ERROR } { \FALSE }
+    \regex_replace_case_all:nN { * } { .. }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3regex012.lvt
+++ b/l3kernel/testfiles/m3regex012.lvt
@@ -123,6 +123,14 @@
       }
       \l_tmpa_tl
     \tl_analysis_log:N \l_tmpa_tl
+    \tl_clear:N \l_tmpa_tl
+    \regex_case_replace_all:nN
+      {
+        { \A } { A }
+        \Z { Z }
+      }
+      \l_tmpa_tl
+    \TYPE { \l_tmpa_tl }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3regex012.lvt
+++ b/l3kernel/testfiles/m3regex012.lvt
@@ -43,6 +43,7 @@
 
 \TEST { regex_case_match:nn ~ error }
   {
+    \regex_case_match:nnTF { Something ~ odd. } { .. } { \ERROR } { \FALSE }
     \regex_case_match:nn { * } { .. }
   }
 

--- a/l3kernel/testfiles/m3regex012.lvt
+++ b/l3kernel/testfiles/m3regex012.lvt
@@ -107,6 +107,22 @@
         { . } { [\0] }
       } \l_tmpa_tl
       { \TYPE { \l_tmpa_tl } } { \ERROR }
+    \tl_set:Nn \l_tmpa_tl { a ( b ( c ) d ( ) ) e }
+    \regex_case_replace_all:nN
+      {
+        { \( } { \{ }
+        { \) } { \} }
+      }
+      \l_tmpa_tl
+    \tl_analysis_log:N \l_tmpa_tl
+    \tl_set:Nn \l_tmpa_tl { a { } b | { | | } | | e }
+    \regex_case_replace_all:nN
+      {
+        { \| } { \} }
+        { . (.) } { \0\1 }
+      }
+      \l_tmpa_tl
+    \tl_analysis_log:N \l_tmpa_tl
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3regex012.lvt
+++ b/l3kernel/testfiles/m3regex012.lvt
@@ -68,12 +68,57 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+\TEST { regex_case_replace_all:nN }
+  {
+    \regex_set:Nn \l_tmpa_regex { [a-z]bc }
+    \cs_set_protected:Npn \test:n #1
+      {
+        \tl_set:Nn \l_tmpa_tl {#1}
+        \regex_case_replace_all:nNTF
+          {
+            \l_tmpa_regex { (abc,\0,\1) }
+            { (?i) Y (\w) } { [Y,\0,\1] }
+            { (z) \Z } { <\0,\1 Z> }
+          }
+          \l_tmpa_tl
+          { \TYPE{#1~=>~\l_tmpa_tl} }
+          { \TYPE{#1:~FALSE} }
+      }
+    \test:n { }
+    \test:n { y bc }
+    \test:n { y ; bc }
+    \test:n { y ; bc z }
+    \test:n { abc bc ybc yabc }
+    \test:n { Y abc YYYz }
+    \test:n { y abcbc }
+    \tl_set:Nn \l_tmpa_tl { Hello,~world! }
+    \regex_case_replace_all:nNTF
+      {
+        { [A-Za-z]+ } { ``\0'' }
+        { \b } { --- }
+        { . } { [\0] }
+      } \l_tmpa_tl
+      { \TYPE { \l_tmpa_tl } } { \ERROR }
+    \tl_set:Nn \l_tmpa_tl { Hello,~world! }
+    \regex_case_replace_all:nNTF
+      {
+        { \b } { --- }
+        { [A-Za-z]+ } { ``\0'' }
+        { . } { [\0] }
+      } \l_tmpa_tl
+      { \TYPE { \l_tmpa_tl } } { \ERROR }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \TEST { regex_case ~ errors }
   {
     \regex_case_match:nnTF { Something ~ odd. } { .. } { \ERROR } { \FALSE }
     \regex_case_match:nn { * } { .. }
     \regex_case_replace_once:nNTF { Something ~ odd. } \l_tmpa_tl { \ERROR } { \FALSE }
     \regex_case_replace_once:nN { * } { .. }
+    \regex_case_replace_all:nNTF { Something ~ odd. } \l_tmpa_tl { \ERROR } { \FALSE }
+    \regex_case_replace_all:nN { * } { .. }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3regex012.tlg
+++ b/l3kernel/testfiles/m3regex012.tlg
@@ -47,6 +47,44 @@ YabcYYYz => [Y,Ya,a]bc[Y,YY,Y][Y,Yz,z]
 yabcbc => [Y,ya,a]b(abc,cbc,)
 ``Hello''---[,][ ]``world''---[!]
 ---``Hello''---[,][ ]---``world''---[!]
+The token list \l_tmpa_tl contains the tokens:
+>  a (the letter a)
+>  { (begin-group character {)
+>  b (the letter b)
+>  { (begin-group character {)
+>  c (the letter c)
+>  } (end-group character })
+>  d (the letter d)
+>  { (begin-group character {)
+>  } (end-group character })
+>  } (end-group character })
+>  e (the letter e)
+! LaTeX3 Error: Missing brace inserted when replacing.
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+LaTeX was asked to do some regular expression operation, and the resulting
+token list would not have the same number of begin-group and end-group tokens.
+Braces were inserted: 2 left, 0 right.
+The token list \l_tmpa_tl contains the tokens:
+>  { (begin-group character {)
+>  { (begin-group character {)
+>  a (the letter a)
+>  { (begin-group character {)
+>  { (begin-group character {)
+>  } (end-group character })
+>  b (the letter b)
+>  b (the letter b)
+>  } (end-group character })
+>  { (begin-group character {)
+>  | (the character |)
+>  | (the character |)
+>  } (end-group character })
+>  } (end-group character })
+>  | (the character |)
+>  | (the character |)
+>  } (end-group character })
+>  e (the letter e)
 ============================================================
 ============================================================
 TEST 4: regex_case errors

--- a/l3kernel/testfiles/m3regex012.tlg
+++ b/l3kernel/testfiles/m3regex012.tlg
@@ -36,7 +36,20 @@ y;bc: FALSE
 y;bcz => y;bc<z,zZ>
 ============================================================
 ============================================================
-TEST 3: regex_case errors
+TEST 3: regex_case_replace_all:nN
+============================================================
+: FALSE
+ybc => (abc,ybc,)
+y;bc: FALSE
+y;bcz => y;bc<z,zZ>
+abcbcybcyabc => (abc,abc,)bc(abc,ybc,)[Y,ya,a]bc
+YabcYYYz => [Y,Ya,a]bc[Y,YY,Y][Y,Yz,z]
+yabcbc => [Y,ya,a]b(abc,cbc,)
+``Hello''---[,][ ]``world''---[!]
+---``Hello''---[,][ ]---``world''---[!]
+============================================================
+============================================================
+TEST 4: regex_case errors
 ============================================================
 ! LaTeX3 Error: \regex_case_match:nn(TF) with odd number of items
 For immediate help type H <return>.
@@ -59,6 +72,19 @@ There must be a code part for each regex: found odd number of items (13) in
     Something odd.
 FALSE
 ! LaTeX3 Error: \regex_case_replace_once:nN(TF) with odd number of items
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+There must be a code part for each regex: found odd number of items (1) in
+    *
+! LaTeX3 Error: \regex_case_replace_all:nN(TF) with odd number of items
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+There must be a code part for each regex: found odd number of items (13) in
+    Something odd.
+FALSE
+! LaTeX3 Error: \regex_case_replace_all:nN(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }

--- a/l3kernel/testfiles/m3regex012.tlg
+++ b/l3kernel/testfiles/m3regex012.tlg
@@ -1,0 +1,36 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Bruno Le Floch
+============================================================
+TEST 1: regex_case_match:nn
+============================================================
+:
+FALSE
+abc:
+abc
+TRUE
+Yabc:
+Y
+TRUE
+yabc:
+Y
+TRUE
+ybc:
+abc
+TRUE
+y;bc:
+FALSE
+y;bcz:
+Z
+TRUE
+============================================================
+============================================================
+TEST 2: regex_case_match:nn error
+============================================================
+! LaTeX3 Error: \regex_case_match:nn with odd number of items
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+There must be a code part for each regex: found odd number of items (1) in
+    *
+============================================================

--- a/l3kernel/testfiles/m3regex012.tlg
+++ b/l3kernel/testfiles/m3regex012.tlg
@@ -85,6 +85,7 @@ The token list \l_tmpa_tl contains the tokens:
 >  | (the character |)
 >  } (end-group character })
 >  e (the letter e)
+A
 ============================================================
 ============================================================
 TEST 4: regex_case errors

--- a/l3kernel/testfiles/m3regex012.tlg
+++ b/l3kernel/testfiles/m3regex012.tlg
@@ -27,7 +27,14 @@ TRUE
 ============================================================
 TEST 2: regex_case_match:nn error
 ============================================================
-! LaTeX3 Error: \regex_case_match:nn with odd number of items
+! LaTeX3 Error: \regex_case_match:nn(TF) with odd number of items
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+There must be a code part for each regex: found odd number of items (13) in
+    Something odd.
+FALSE
+! LaTeX3 Error: \regex_case_match:nn(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }

--- a/l3kernel/testfiles/m3regex012.tlg
+++ b/l3kernel/testfiles/m3regex012.tlg
@@ -2,7 +2,7 @@ This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
 Author: Bruno Le Floch
 ============================================================
-TEST 1: regex_case_match:nn
+TEST 1: regex_match_case:nn
 ============================================================
 :
 FALSE
@@ -25,7 +25,7 @@ Z
 TRUE
 ============================================================
 ============================================================
-TEST 2: regex_case_replace_once:nN
+TEST 2: regex_replace_case_once:nN
 ============================================================
 : FALSE
 abc => (abc,abc,)
@@ -36,7 +36,7 @@ y;bc: FALSE
 y;bcz => y;bc<z,zZ>
 ============================================================
 ============================================================
-TEST 3: regex_case_replace_all:nN
+TEST 3: regex_replace_case_all:nN
 ============================================================
 : FALSE
 ybc => (abc,ybc,)
@@ -90,40 +90,40 @@ A
 ============================================================
 TEST 4: regex_case errors
 ============================================================
-! LaTeX3 Error: \regex_case_match:nn(TF) with odd number of items
+! LaTeX3 Error: \regex_match_case:nn(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }
 There must be a code part for each regex: found odd number of items (13) in
     Something odd.
 FALSE
-! LaTeX3 Error: \regex_case_match:nn(TF) with odd number of items
+! LaTeX3 Error: \regex_match_case:nn(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }
 There must be a code part for each regex: found odd number of items (1) in
     *
-! LaTeX3 Error: \regex_case_replace_once:nN(TF) with odd number of items
+! LaTeX3 Error: \regex_replace_case_once:nN(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }
 There must be a code part for each regex: found odd number of items (13) in
     Something odd.
 FALSE
-! LaTeX3 Error: \regex_case_replace_once:nN(TF) with odd number of items
+! LaTeX3 Error: \regex_replace_case_once:nN(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }
 There must be a code part for each regex: found odd number of items (1) in
     *
-! LaTeX3 Error: \regex_case_replace_all:nN(TF) with odd number of items
+! LaTeX3 Error: \regex_replace_case_all:nN(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }
 There must be a code part for each regex: found odd number of items (13) in
     Something odd.
 FALSE
-! LaTeX3 Error: \regex_case_replace_all:nN(TF) with odd number of items
+! LaTeX3 Error: \regex_replace_case_all:nN(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }

--- a/l3kernel/testfiles/m3regex012.tlg
+++ b/l3kernel/testfiles/m3regex012.tlg
@@ -25,7 +25,18 @@ Z
 TRUE
 ============================================================
 ============================================================
-TEST 2: regex_case_match:nn error
+TEST 2: regex_case_replace_once:nN
+============================================================
+: FALSE
+abc => (abc,abc,)
+Yabc => [Y,Ya,a]bc
+yabc => [Y,ya,a]bc
+ybc => (abc,ybc,)
+y;bc: FALSE
+y;bcz => y;bc<z,zZ>
+============================================================
+============================================================
+TEST 3: regex_case errors
 ============================================================
 ! LaTeX3 Error: \regex_case_match:nn(TF) with odd number of items
 For immediate help type H <return>.
@@ -35,6 +46,19 @@ There must be a code part for each regex: found odd number of items (13) in
     Something odd.
 FALSE
 ! LaTeX3 Error: \regex_case_match:nn(TF) with odd number of items
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+There must be a code part for each regex: found odd number of items (1) in
+    *
+! LaTeX3 Error: \regex_case_replace_once:nN(TF) with odd number of items
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+There must be a code part for each regex: found odd number of items (13) in
+    Something odd.
+FALSE
+! LaTeX3 Error: \regex_case_replace_once:nN(TF) with odd number of items
 For immediate help type H <return>.
  ...                                              
 l. ...  }


### PR DESCRIPTION
This implements `\regex_case_match:nn(TF)`, `\regex_case_replace_once:nN(TF)`, `\regex_case_replace_all:nN(TF)` which can do different code/replacements depending on which of several regex match.  See the documentation in l3regex and issue #433 for details.

I don't expect the code to be reviewed in detail as it's pretty complicated and connects to many parts of l3regex, but if someone else can test beyond the existing test files that would be great.