### PR TITLE
Speed up string comparison by using \if

### DIFF
--- a/l3kernel/l3fp-expo.dtx
+++ b/l3kernel/l3fp-expo.dtx
@@ -1000,8 +1000,7 @@
 \cs_new:Npn \@@_pow_normal_o:ww
     \s_@@ \@@_chk:w 1 #1#2#3; \s_@@ \@@_chk:w #4#5
   {
-    \if_int_compare:w \@@_str_if_eq:nn { #2 #3 }
-              { 1 {1000} {0000} {0000} {0000} } = \c_zero_int
+    \if:w 0 \@@_str_if_eq:nn { #2 #3 } { 1 {1000} {0000} {0000} {0000} }
       \if_int_compare:w #4 #1 = 32 \exp_stop_f:
         \exp_after:wN \@@_case_return_ii_o:ww
       \fi:

--- a/l3kernel/l3fp-parse.dtx
+++ b/l3kernel/l3fp-parse.dtx
@@ -1755,9 +1755,7 @@
   {
     \if_catcode:w \scan_stop: \exp_not:N #1
       \if_meaning:w \scan_stop: #1
-        \if_int_compare:w
-            \@@_str_if_eq:nn { \s_@@ } { \exp_not:N #1 }
-            = \c_zero_int
+        \if:w 0 \@@_str_if_eq:nn { \s_@@ } { \exp_not:N #1 }
           0
           \__kernel_msg_expandable_error:nnn
             { fp } { after-e } { floating~point~ }
@@ -1769,9 +1767,7 @@
           \prg_return_false:
         \fi:
       \else:
-        \if_int_compare:w
-            \@@_str_if_eq:nn { \int_value:w #1 } { \tex_the:D #1 }
-            = \c_zero_int
+        \if:w 0 \@@_str_if_eq:nn { \int_value:w #1 } { \tex_the:D #1 }
           \int_value:w #1
         \else:
           0
@@ -2263,9 +2259,7 @@
 \cs_new:Npn \@@_parse_infix:NN #1 #2
   {
     \if_catcode:w \scan_stop: \exp_not:N #2
-      \if_int_compare:w
-          \@@_str_if_eq:nn { \s_@@_expr_mark } { \exp_not:N #2 }
-          = \c_zero_int
+      \if:w 0 \@@_str_if_eq:nn { \s_@@_expr_mark } { \exp_not:N #2 }
         \exp_after:wN \exp_after:wN
         \exp_after:wN \@@_parse_infix_mark:NNN
       \else:
@@ -2315,9 +2309,7 @@
 \cs_new:Npn \@@_parse_infix_after_paren:NN #1 #2
   {
     \if_catcode:w \scan_stop: \exp_not:N #2
-      \if_int_compare:w
-          \@@_str_if_eq:nn { \s_@@_expr_mark } { \exp_not:N #2 }
-          = \c_zero_int
+      \if:w 0 \@@_str_if_eq:nn { \s_@@_expr_mark } { \exp_not:N #2 }
         \exp_after:wN \exp_after:wN
         \exp_after:wN \@@_parse_infix_mark:NNN
       \else:

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -1163,9 +1163,12 @@
 %     \str_if_eq:ee
 %   }
 %   Modern engines provide a direct way of comparing two token lists,
-%   but returning a number. This set of conditionals therefore make life
-%   a bit clearer. The \texttt{nn} and \texttt{xx} versions are created
-%   directly as this is most efficient.
+%   but returning a number. This set of conditionals therefore makes life
+%   a bit clearer. The \texttt{nn} and \texttt{ee} versions are created
+%   directly as this is most efficient. Since \cs{@@_if_eq:nn} will expand to
+%   |0| as an explicit character with category 12 if the two lists match (and
+%   either |-1| or |1| if they don't) we can use \cs{if:w} here which is faster
+%   than using \cs{if_int_compare:w}.
 %    \begin{macrocode}
 \prg_new_conditional:Npnn \str_if_eq:nn #1#2 { p , T , F , TF }
   {

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -1169,16 +1169,14 @@
 %    \begin{macrocode}
 \prg_new_conditional:Npnn \str_if_eq:nn #1#2 { p , T , F , TF }
   {
-    \if_int_compare:w
-      \@@_if_eq:nn { \exp_not:n {#1} } { \exp_not:n {#2} }
-      = \c_zero_int
+    \if:w 0 \@@_if_eq:nn { \exp_not:n {#1} } { \exp_not:n {#2} }
       \prg_return_true: \else: \prg_return_false: \fi:
   }
 \prg_generate_conditional_variant:Nnn \str_if_eq:nn
   { V , v , o , nV , no , VV , nv } { p , T , F , TF }
 \prg_new_conditional:Npnn \str_if_eq:ee #1#2 { p , T , F , TF }
   {
-    \if_int_compare:w \@@_if_eq:nn {#1} {#2} = \c_zero_int
+    \if:w 0 \@@_if_eq:nn {#1} {#2}
       \prg_return_true: \else: \prg_return_false: \fi:
   }
 %    \end{macrocode}
@@ -1191,9 +1189,8 @@
 %    \begin{macrocode}
 \prg_new_conditional:Npnn \str_if_eq:NN #1#2 { p , TF , T , F }
   {
-    \if_int_compare:w
-      \@@_if_eq:nn { \tl_to_str:N #1 } { \tl_to_str:N #2 }
-      = \c_zero_int \prg_return_true: \else: \prg_return_false: \fi:
+    \if:w 0 \@@_if_eq:nn { \tl_to_str:N #1 } { \tl_to_str:N #2 }
+      \prg_return_true: \else: \prg_return_false: \fi:
   }
 \prg_generate_conditional_variant:Nnn \str_if_eq:NN
   { c , Nc , cc } { T , F , TF , p }


### PR DESCRIPTION
The `\pdfstrcmp` primitive (and equivalent implementations, including the current Lua code used by `expl3` in LuaTeX) doesn't return its result as a count register or similar, but as a tokens of category 12. It is therefore faster to check whether the result is equal to `0` by using the `\if` primitive instead of `\ifnum` (my benchmarks indicate 10% speed difference for the check in pdfTeX).

This changes those usages of `\pdfstrcmp` in which the result is only tested to be equal to zero to use `\if`.