### PR TITLE
trial update for #968

### DIFF
--- a/l3kernel/doc/interface3.tex
+++ b/l3kernel/doc/interface3.tex
@@ -41,6 +41,14 @@ for those people who are interested.
 
 
 \documentclass[kernel]{l3doc}
+
+% fix for l3doc class
+\ExplSyntaxOn
+\DeclareDocumentCommand \meta { m }
+  { \texttt{ \__codedoc_meta:n {#1} } }
+\ExplSyntaxOff
+
+
 \listfiles
 
 \begin{document}

--- a/l3kernel/l3box.dtx
+++ b/l3kernel/l3box.dtx
@@ -142,12 +142,12 @@
 %
 % \begin{function}{\box_move_right:nn, \box_move_left:nn}
 %   \begin{syntax}
-%     \cs{box_move_right:nn} \Arg{dimexpr} \Arg{box function}
+%     \cs{box_move_right:nn} \Arg{dim expr} \Arg{box function}
 %   \end{syntax}
 %   This function operates in vertical mode, and inserts the
 %   material specified by the \meta{box function}
 %   such that its reference point is displaced horizontally by the given
-%   \meta{dimexpr} from the reference point for typesetting, to the right
+%   \meta{dim expr} from the reference point for typesetting, to the right
 %   or left as appropriate. The \meta{box function} should be
 %   a box operation such as \cs{box_use:N} |\<box>| or a \enquote{raw}
 %   box specification such as \cs{vbox:n} |{ xyz }|.
@@ -155,12 +155,12 @@
 %
 % \begin{function}{\box_move_up:nn, \box_move_down:nn}
 %   \begin{syntax}
-%     \cs{box_move_up:nn} \Arg{dimexpr} \Arg{box function}
+%     \cs{box_move_up:nn} \Arg{dim expr} \Arg{box function}
 %   \end{syntax}
 %   This function operates in horizontal mode, and inserts the
 %   material specified by the \meta{box function}
 %   such that its reference point is displaced vertically by the given
-%   \meta{dimexpr} from the reference point for typesetting, up
+%   \meta{dim expr} from the reference point for typesetting, up
 %   or down as appropriate. The \meta{box function} should be
 %   a box operation such as \cs{box_use:N} |\<box>| or a \enquote{raw}
 %   box specification such as \cs{vbox:n} |{ xyz }|.
@@ -173,7 +173,7 @@
 %     \cs{box_dp:N} \meta{box}
 %   \end{syntax}
 %   Calculates the depth (below the baseline) of the \meta{box}
-%   in a form suitable for use in a \meta{dimension expression}.
+%   in a form suitable for use in a \meta{dim expr}.
 %   \begin{texnote}
 %     This is the \TeX{} primitive \tn{dp}.
 %   \end{texnote}
@@ -184,7 +184,7 @@
 %     \cs{box_ht:N} \meta{box}
 %   \end{syntax}
 %   Calculates the height (above the baseline) of the \meta{box}
-%   in a form suitable for use in a \meta{dimension expression}.
+%   in a form suitable for use in a \meta{dim expr}.
 %   \begin{texnote}
 %     This is the \TeX{} primitive \tn{ht}.
 %   \end{texnote}
@@ -195,7 +195,7 @@
 %     \cs{box_wd:N} \meta{box}
 %   \end{syntax}
 %   Calculates the width of the \meta{box} in a form
-%   suitable for use in a \meta{dimension expression}.
+%   suitable for use in a \meta{dim expr}.
 %   \begin{texnote}
 %     This is the \TeX{} primitive \tn{wd}.
 %   \end{texnote}
@@ -206,7 +206,7 @@
 %     \cs{box_ht_plus_dp:N} \meta{box}
 %   \end{syntax}
 %   Calculates the total vertical size (height plus depth) of the \meta{box}
-%   in a form suitable for use in a \meta{dimension expression}.
+%   in a form suitable for use in a \meta{dim expr}.
 % \end{function}
 %
 % \begin{function}[updated = 2019-01-22]
@@ -215,10 +215,10 @@
 %     \box_gset_dp:Nn, \box_gset_dp:cn
 %   }
 %   \begin{syntax}
-%     \cs{box_set_dp:Nn} \meta{box} \Arg{dimension expression}
+%     \cs{box_set_dp:Nn} \meta{box} \Arg{dim expr}
 %   \end{syntax}
 %   Set the depth (below the baseline) of the \meta{box} to the value of
-%   the \Arg{dimension expression}.
+%   the \Arg{dim expr}.
 % \end{function}
 %
 % \begin{function}[updated = 2019-01-22]
@@ -227,10 +227,10 @@
 %     \box_gset_ht:Nn, \box_gset_ht:cn
 %   }
 %   \begin{syntax}
-%     \cs{box_set_ht:Nn} \meta{box} \Arg{dimension expression}
+%     \cs{box_set_ht:Nn} \meta{box} \Arg{dim expr}
 %   \end{syntax}
 %   Set the height (above the baseline) of the \meta{box} to the value of
-%   the \Arg{dimension expression}.
+%   the \Arg{dim expr}.
 % \end{function}
 %
 % \begin{function}[updated = 2019-01-22]
@@ -239,10 +239,10 @@
 %     \box_gset_wd:Nn, \box_gset_wd:cn
 %   }
 %   \begin{syntax}
-%     \cs{box_set_wd:Nn} \meta{box} \Arg{dimension expression}
+%     \cs{box_set_wd:Nn} \meta{box} \Arg{dim expr}
 %   \end{syntax}
 %   Set the width of the \meta{box} to the value of the
-%   \Arg{dimension expression}.
+%   \Arg{dim expr}.
 % \end{function}
 %
 % \section{Box conditionals}
@@ -324,10 +324,10 @@
 %
 % \begin{function}[added = 2012-05-11]{\box_show:Nnn, \box_show:cnn}
 %   \begin{syntax}
-%      \cs{box_show:Nnn} \meta{box} \Arg{intexpr_1} \Arg{intexpr_2}
+%      \cs{box_show:Nnn} \meta{box} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
 %   Display the contents of \meta{box} in the terminal, showing the first
-%   \meta{intexpr_1} items of the box, and descending into \meta{intexpr_2}
+%   \meta{int expr_1} items of the box, and descending into \meta{int expr_2}
 %   group levels.
 % \end{function}
 %
@@ -340,10 +340,10 @@
 %
 % \begin{function}[added = 2012-05-11]{\box_log:Nnn, \box_log:cnn}
 %   \begin{syntax}
-%      \cs{box_log:Nnn} \meta{box} \Arg{intexpr_1} \Arg{intexpr_2}
+%      \cs{box_log:Nnn} \meta{box} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
 %   Writes the contents of \meta{box} to the log, showing the first
-%   \meta{intexpr_1} items of the box, and descending into \meta{intexpr_2}
+%   \meta{int expr_1} items of the box, and descending into \meta{int expr_2}
 %   group levels.
 % \end{function}
 %
@@ -364,10 +364,10 @@
 %
 % \begin{function}[updated = 2017-04-05]{\hbox_to_wd:nn}
 %   \begin{syntax}
-%     \cs{hbox_to_wd:nn} \Arg{dimexpr} \Arg{contents}
+%     \cs{hbox_to_wd:nn} \Arg{dim expr} \Arg{contents}
 %   \end{syntax}
 %   Typesets the \meta{contents} into a horizontal box of width
-%   \meta{dimexpr} and then includes this box in the current list for
+%   \meta{dim expr} and then includes this box in the current list for
 %   typesetting.
 % \end{function}
 %
@@ -394,9 +394,9 @@
 %     \hbox_gset_to_wd:Nnn, \hbox_gset_to_wd:cnn
 %   }
 %   \begin{syntax}
-%     \cs{hbox_set_to_wd:Nnn} \meta{box} \Arg{dimexpr} \Arg{contents}
+%     \cs{hbox_set_to_wd:Nnn} \meta{box} \Arg{dim expr} \Arg{contents}
 %   \end{syntax}
-%   Typesets the \meta{contents} to the width given by the \meta{dimexpr}
+%   Typesets the \meta{contents} to the width given by the \meta{dim expr}
 %   and then stores the result inside the \meta{box}.
 % \end{function}
 %
@@ -447,9 +447,9 @@
 %     \hbox_gset_to_wd:Nnw, \hbox_gset_to_wd:cnw
 %   }
 %   \begin{syntax}
-%     \cs{hbox_set_to_wd:Nnw} \meta{box} \Arg{dimexpr} \meta{contents} \cs{hbox_set_end:}
+%     \cs{hbox_set_to_wd:Nnw} \meta{box} \Arg{dim expr} \meta{contents} \cs{hbox_set_end:}
 %   \end{syntax}
-%   Typesets the \meta{contents} to the width given by the \meta{dimexpr}
+%   Typesets the \meta{contents} to the width given by the \meta{dim expr}
 %   and then stores the result inside the \meta{box}. In contrast
 %   to \cs{hbox_set_to_wd:Nnn} this function does not absorb the argument
 %   when finding the \meta{content}, and so can be used in circumstances
@@ -498,10 +498,10 @@
 %
 % \begin{function}[updated = 2017-04-05]{\vbox_to_ht:nn}
 %   \begin{syntax}
-%     \cs{vbox_to_ht:nn} \Arg{dimexpr} \Arg{contents}
+%     \cs{vbox_to_ht:nn} \Arg{dim expr} \Arg{contents}
 %   \end{syntax}
 %   Typesets the \meta{contents} into a vertical box of height
-%   \meta{dimexpr} and then includes this box in the current list for
+%   \meta{dim expr} and then includes this box in the current list for
 %   typesetting.
 % \end{function}
 %
@@ -538,10 +538,10 @@
 %     \vbox_gset_to_ht:Nnn, \vbox_gset_to_ht:cnn
 %   }
 %   \begin{syntax}
-%     \cs{vbox_set_to_ht:Nnn} \meta{box} \Arg{dimexpr} \Arg{contents}
+%     \cs{vbox_set_to_ht:Nnn} \meta{box} \Arg{dim expr} \Arg{contents}
 %   \end{syntax}
 %   Typesets the \meta{contents} to the height given by the
-%   \meta{dimexpr} and then stores the result inside the \meta{box}.
+%   \meta{dim expr} and then stores the result inside the \meta{box}.
 % \end{function}
 %
 % \begin{function}[updated = 2017-04-05]
@@ -567,9 +567,9 @@
 %     \vbox_gset_to_ht:Nnw, \vbox_gset_to_ht:cnw
 %   }
 %   \begin{syntax}
-%     \cs{vbox_set_to_ht:Nnw} \meta{box} \Arg{dimexpr} \meta{contents} \cs{vbox_set_end:}
+%     \cs{vbox_set_to_ht:Nnw} \meta{box} \Arg{dim expr} \meta{contents} \cs{vbox_set_end:}
 %   \end{syntax}
-%   Typesets the \meta{contents} to the height given by the \meta{dimexpr}
+%   Typesets the \meta{contents} to the height given by the \meta{dim expr}
 %   and then stores the result inside the \meta{box}. In contrast
 %   to \cs{vbox_set_to_ht:Nnn} this function does not absorb the argument
 %   when finding the \meta{content}, and so can be used in circumstances
@@ -585,10 +585,10 @@
 %     \vbox_gset_split_to_ht:Ncn, \vbox_gset_split_to_ht:ccn
 %   }
 %   \begin{syntax}
-%      \cs{vbox_set_split_to_ht:NNn} \meta{box_1} \meta{box_2} \Arg{dimexpr}
+%      \cs{vbox_set_split_to_ht:NNn} \meta{box_1} \meta{box_2} \Arg{dim expr}
 %   \end{syntax}
 %   Sets \meta{box_1} to contain material to the height given by the
-%   \meta{dimexpr} by removing content from the top of \meta{box_2}
+%   \meta{dim expr} by removing content from the top of \meta{box_2}
 %   (which must be a vertical box).
 % \end{function}
 %

--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -117,7 +117,7 @@
 %   \end{syntax}
 %   Adjusts the bounding box of the \meta{box} \meta{left} is removed from
 %   the left-hand edge of the bounding box, \meta{right} from the right-hand
-%   edge and so fourth. All adjustments are \meta{dimension expressions}.
+%   edge and so fourth. All adjustments are \meta{dim exprs}.
 %   Material outside of the bounding box is still displayed in the output
 %   unless \cs{box_clip:N} is subsequently applied.
 %   The updated \meta{box} is an
@@ -138,7 +138,7 @@
 %   Adjusts the bounding box of the \meta{box} such that it has lower-left
 %   co-ordinates (\meta{llx}, \meta{lly}) and upper-right co-ordinates
 %   (\meta{urx}, \meta{ury}). All four co-ordinate positions are
-%   \meta{dimension expressions}. Material outside of the bounding box is
+%   \meta{dim exprs}. Material outside of the bounding box is
 %   still displayed in the output unless \cs{box_clip:N} is
 %   subsequently applied.
 %   The updated \meta{box} is an
@@ -166,9 +166,9 @@
 %
 % \begin{function}[pTF, added = 2019-08-25]{\fp_if_nan:n}
 %   \begin{syntax}
-%     \cs{fp_if_nan:n} \Arg{fpexpr}
+%     \cs{fp_if_nan:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{fpexpr} and tests whether the result is exactly
+%   Evaluates the \meta{fp expr} and tests whether the result is exactly
 %   \nan{}.  The test returns \texttt{false} for any other result, even
 %   a tuple containing \nan{}.
 % \end{function}
@@ -437,14 +437,14 @@
 % \begin{function}[added = 2021-04-29, noTF]
 %   {\seq_set_item:Nnn, \seq_set_item:cnn, \seq_gset_item:Nnn, \seq_gset_item:cnn}
 %   \begin{syntax}
-%     \cs{seq_set_item:Nnn} \meta{seq~var} \Arg{intexpr} \Arg{item}
-%     \cs{seq_set_item:NnnTF} \meta{seq~var} \Arg{intexpr} \Arg{item} \Arg{true code} \Arg{false code}
+%     \cs{seq_set_item:Nnn} \meta{seq~var} \Arg{int expr} \Arg{item}
+%     \cs{seq_set_item:NnnTF} \meta{seq~var} \Arg{int expr} \Arg{item} \Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   Removes the item of \meta{sequence} at the position given by
-%   evaluating the \meta{integer expression} and replaces it by
+%   evaluating the \meta{int expr} and replaces it by
 %   \meta{item}.  Items are indexed from $1$ on the left/top of the
 %   \meta{sequence}, or from $-1$ on the right/bottom.  If the
-%   \meta{integer expression} is zero or is larger (in absolute value)
+%   \meta{int expr} is zero or is larger (in absolute value)
 %   than the number of items in the sequence, the \meta{sequence} is not
 %   modified.  In these cases, \cs{seq_set_item:Nnn} raises an error
 %   while \cs{seq_set_item:NnnTF} runs the \meta{false code}.  In cases
@@ -455,10 +455,10 @@
 % \begin{function}[added = 2021-04-28, noTF]
 %   {\seq_pop_item:NnN, \seq_pop_item:cnN, \seq_gpop_item:NnN, \seq_gpop_item:cnN}
 %   \begin{syntax}
-%     \cs{seq_pop_item:NnN} \meta{seq~var} \Arg{intexpr} \Arg{tl~var}
-%     \cs{seq_pop_item:NnNTF} \meta{seq~var} \Arg{intexpr} \Arg{tl~var} \Arg{true code} \Arg{false code}
+%     \cs{seq_pop_item:NnN} \meta{seq~var} \Arg{int expr} \Arg{tl~var}
+%     \cs{seq_pop_item:NnNTF} \meta{seq~var} \Arg{int expr} \Arg{tl~var} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Removes the \meta{item} at position \meta{integer expression} in the
+%   Removes the \meta{item} at position \meta{int expr} in the
 %   \meta{sequence}, and places it in the \meta{token list variable}.
 %   Items are indexed from $1$ on the left/top of the \meta{sequence},
 %   or from $-1$ on the right/bottom.  If the position is zero or is

--- a/l3kernel/l3cctab.dtx
+++ b/l3kernel/l3cctab.dtx
@@ -122,10 +122,10 @@
 %
 % \begin{function}[EXP, added = 2021-05-10]{\cctab_item:Nn, \cctab_item:cn}
 %   \begin{syntax}
-%     \cs{cctab_item:Nn} \meta{category code table} \Arg{integer expression}
+%     \cs{cctab_item:Nn} \meta{category code table} \Arg{int expr}
 %   \end{syntax}
 %   Determines the \meta{character} with character code given by the
-%   \meta{integer expression} and expands to its category code specified
+%   \meta{int expr} and expands to its category code specified
 %   by the \meta{category code table}.
 % \end{function}
 %

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -716,13 +716,13 @@
 % \begin{function}[added = 2014-07-17, EXP]
 %   {\clist_item:Nn, \clist_item:cn, \clist_item:nn}
 %   \begin{syntax}
-%     \cs{clist_item:Nn} \meta{comma list} \Arg{integer expression}
+%     \cs{clist_item:Nn} \meta{comma list} \Arg{int expr}
 %   \end{syntax}
 %   Indexing items in the \meta{comma list} from~$1$ at the top (left), this
-%   function evaluates the \meta{integer expression} and leaves the
+%   function evaluates the \meta{int expr} and leaves the
 %   appropriate item from the comma list in the input stream. If the
-%   \meta{integer expression} is negative, indexing occurs from the
-%   bottom (right) of the comma list. When the \meta{integer expression}
+%   \meta{int expr} is negative, indexing occurs from the
+%   bottom (right) of the comma list. When the \meta{int expr}
 %   is larger than the number of items in the \meta{comma list} (as
 %   calculated by \cs{clist_count:N}) then the function expands to
 %   nothing.

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -305,7 +305,7 @@
 %     \cs{coffin_dp:N} \meta{coffin}
 %   \end{syntax}
 %   Calculates the depth (below the baseline) of the \meta{coffin}
-%   in a form suitable for use in a \meta{dimension expression}.
+%   in a form suitable for use in a \meta{dim expr}.
 % \end{function}
 %
 % \begin{function}{\coffin_ht:N, \coffin_ht:c}
@@ -313,7 +313,7 @@
 %     \cs{coffin_ht:N} \meta{coffin}
 %   \end{syntax}
 %   Calculates the height (above the baseline) of the \meta{coffin}
-%   in a form suitable for use in a \meta{dimension expression}.
+%   in a form suitable for use in a \meta{dim expr}.
 % \end{function}
 %
 % \begin{function}{\coffin_wd:N, \coffin_wd:c}
@@ -321,7 +321,7 @@
 %     \cs{coffin_wd:N} \meta{coffin}
 %   \end{syntax}
 %   Calculates the width of the \meta{coffin} in a form
-%   suitable for use in a \meta{dimension expression}.
+%   suitable for use in a \meta{dim expr}.
 % \end{function}
 %
 % \section{Coffin diagnostics}
@@ -396,12 +396,12 @@
 % \begin{function}[added = 2021-05-11]
 %   {\coffin_show:Nnn, \coffin_show:cnn, \coffin_log:Nnn, \coffin_log:cnn}
 %   \begin{syntax}
-%     \cs{coffin_show:Nnn} \meta{coffin} \Arg{intexpr_1} \Arg{intexpr_2}
-%     \cs{coffin_log:Nnn} \meta{coffin} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{coffin_show:Nnn} \meta{coffin} \Arg{int expr_1} \Arg{int expr_2}
+%     \cs{coffin_log:Nnn} \meta{coffin} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
 %   Shows poles and contents of the \meta{coffin} in the terminal or log
-%   file, showing the first \meta{intexpr_1} items in the coffin, and
-%   descending into \meta{intexpr_2} group levels.  See
+%   file, showing the first \meta{int expr_1} items in the coffin, and
+%   descending into \meta{int expr_2} group levels.  See
 %   \cs{coffin_show_structure:N} and \cs{box_show:Nnn} to show
 %   separately the pole structure and the contents.
 % \end{function}

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -2075,8 +2075,8 @@
 %     \@@_wrap_line_end:nw,
 %     \@@_wrap_end_chunk:w
 %   }
-%   This is followed by \Arg{string} \meta{intexpr} |;|.  It stores the
-%   \meta{string} and up to \meta{intexpr} characters from the current
+%   This is followed by \Arg{string} \meta{int expr} |;|.  It stores the
+%   \meta{string} and up to \meta{int expr} characters from the current
 %   chunk into \cs{l_@@_line_part_tl}.  Characters are grabbed 8~at a
 %   time and left in \cs{l_@@_line_part_tl} by the \texttt{line_loop}
 %   auxiliary.  When $k<8$ remain to be found, the \texttt{line_aux}

--- a/l3kernel/l3fp-parse.dtx
+++ b/l3kernel/l3fp-parse.dtx
@@ -74,9 +74,9 @@
 %
 % \begin{macro}[EXP]{\@@_parse:n}
 %   \begin{syntax}
-%     \cs{@@_parse:n} \Arg{fpexpr}
+%     \cs{@@_parse:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} and leaves the result
+%   Evaluates the \meta{fp expr} and leaves the result
 %   in the input stream as a floating point object.  This
 %   function forms the basis of almost all public \pkg{l3fp} functions.
 %   During evaluation, each token is fully \texttt{f}-expanded.

--- a/l3kernel/l3fp-round.dtx
+++ b/l3kernel/l3fp-round.dtx
@@ -298,7 +298,7 @@
 %
 % \begin{macro}[EXP]{\@@_round_digit:Nw}
 %   \begin{syntax}
-%     \cs{int_value:w} \cs{@@_round_digit:Nw} \meta{digit} \meta{intexpr} |;|
+%     \cs{int_value:w} \cs{@@_round_digit:Nw} \meta{digit} \meta{int expr} |;|
 %   \end{syntax}
 %   This function should always be called within an \cs{int_value:w}
 %   or \cs{@@_int_eval:w} expansion; it may add an extra

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -58,8 +58,8 @@
 % A decimal floating point number is one which is stored as a significand and a
 % separate exponent.  The module implements expandably a wide set of
 % arithmetic, trigonometric, and other operations on decimal floating point
-% numbers, to be used within floating point expressions.  Floating point
-% expressions support the following operations with their usual
+% numbers, to be used within floating point expressions.  \emph{Floating point
+% expressions} (\enquote{\meta{fp expr}}) support the following operations with their usual
 % precedence.
 % \begin{itemize}
 %   \item Basic arithmetic: addition $x+y$, subtraction $x-y$,
@@ -170,11 +170,11 @@
 % \begin{function}[updated = 2012-05-08, tested = m3fp001]
 %   {\fp_const:Nn, \fp_const:cn}
 %   \begin{syntax}
-%     \cs{fp_const:Nn} \meta{fp~var} \Arg{floating point expression}
+%     \cs{fp_const:Nn} \meta{fp~var} \Arg{fp expr}
 %   \end{syntax}
 %   Creates a new constant \meta{fp~var} or raises an error if the name
 %   is already taken. The \meta{fp~var} is set globally equal to
-%   the result of evaluating the \meta{floating point expression}.
+%   the result of evaluating the \meta{fp expr}.
 % \end{function}
 %
 % \begin{function}[updated = 2012-05-08, tested = m3fp001]
@@ -200,10 +200,10 @@
 % \begin{function}[updated = 2012-05-08, tested = m3fp002]
 %   {\fp_set:Nn, \fp_set:cn, \fp_gset:Nn, \fp_gset:cn}
 %   \begin{syntax}
-%     \cs{fp_set:Nn} \meta{fp~var} \Arg{floating point expression}
+%     \cs{fp_set:Nn} \meta{fp~var} \Arg{fp expr}
 %   \end{syntax}
 %   Sets \meta{fp~var} equal to the result of computing the
-%   \meta{floating point expression}.
+%   \meta{fp expr}.
 % \end{function}
 %
 % \begin{function}[updated = 2012-05-08, tested = m3fp002]
@@ -221,9 +221,9 @@
 % \begin{function}[updated = 2012-05-08, tested = m3fp002]
 %   {\fp_add:Nn, \fp_add:cn, \fp_gadd:Nn, \fp_gadd:cn}
 %   \begin{syntax}
-%     \cs{fp_add:Nn} \meta{fp~var} \Arg{floating point expression}
+%     \cs{fp_add:Nn} \meta{fp~var} \Arg{fp expr}
 %   \end{syntax}
-%   Adds the result of computing the \meta{floating point expression} to
+%   Adds the result of computing the \meta{fp expr} to
 %   the \meta{fp~var}.
 %   This also applies if \meta{fp~var} and \meta{floating point
 %     expression} evaluate to tuples of the same size.
@@ -232,7 +232,7 @@
 % \begin{function}[updated = 2012-05-08, tested = m3fp002]
 %   {\fp_sub:Nn, \fp_sub:cn, \fp_gsub:Nn, \fp_gsub:cn}
 %   \begin{syntax}
-%     \cs{fp_sub:Nn} \meta{fp~var} \Arg{floating point expression}
+%     \cs{fp_sub:Nn} \meta{fp~var} \Arg{fp expr}
 %   \end{syntax}
 %   Subtracts the result of computing the \meta{floating point
 %     expression} from the \meta{fp~var}.
@@ -245,9 +245,9 @@
 % \begin{function}[EXP, added = 2012-05-08, updated = 2012-07-08,
 %   tested = m3fp-convert003]{\fp_eval:n}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \Arg{floating point expression}
+%     \cs{fp_eval:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} and expresses the
+%   Evaluates the \meta{fp expr} and expresses the
 %   result as a decimal number with no
 %   exponent.  Leading or trailing zeros may be inserted to compensate
 %   for the exponent.  Non-significant trailing zeros are trimmed, and
@@ -262,9 +262,9 @@
 %
 % \begin{function}[EXP, added = 2018-11-03]{\fp_sign:n}
 %   \begin{syntax}
-%     \cs{fp_sign:n} \Arg{fpexpr}
+%     \cs{fp_sign:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{fpexpr} and leaves its sign in the input stream
+%   Evaluates the \meta{fp expr} and leaves its sign in the input stream
 %   using \cs{fp_eval:n} |{sign(|\meta{result}|)}|: $+1$ for positive
 %   numbers and for $+\infty$, $-1$ for negative numbers and for
 %   $-\infty$, $\pm 0$ for $\pm 0$.  If the operand is a tuple or is
@@ -276,9 +276,9 @@
 %   {\fp_to_decimal:N, \fp_to_decimal:c, \fp_to_decimal:n}
 %   \begin{syntax}
 %     \cs{fp_to_decimal:N} \meta{fp~var}
-%     \cs{fp_to_decimal:n} \Arg{floating point expression}
+%     \cs{fp_to_decimal:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} and expresses the
+%   Evaluates the \meta{fp expr} and expresses the
 %   result as a decimal number with no
 %   exponent.  Leading or trailing zeros may be inserted to compensate
 %   for the exponent.  Non-significant trailing zeros are trimmed, and
@@ -294,9 +294,9 @@
 %   {\fp_to_dim:N, \fp_to_dim:c, \fp_to_dim:n}
 %   \begin{syntax}
 %     \cs{fp_to_dim:N} \meta{fp~var}
-%     \cs{fp_to_dim:n} \Arg{floating point expression}
+%     \cs{fp_to_dim:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} and expresses the
+%   Evaluates the \meta{fp expr} and expresses the
 %   result as a dimension (in~\texttt{pt}) suitable for use in dimension
 %   expressions.  The output is identical to \cs{fp_to_decimal:n}, with
 %   an additional trailing~\texttt{pt} (both letter tokens).
@@ -311,9 +311,9 @@
 %   {\fp_to_int:N, \fp_to_int:c, \fp_to_int:n}
 %   \begin{syntax}
 %     \cs{fp_to_int:N} \meta{fp~var}
-%     \cs{fp_to_int:n} \Arg{floating point expression}
+%     \cs{fp_to_int:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression}, and rounds the
+%   Evaluates the \meta{fp expr}, and rounds the
 %   result to the closest integer, rounding exact ties to an even
 %   integer.
 %   The result may be outside the range $[- 2^{31} + 1, 2^{31} - 1]$ of
@@ -326,9 +326,9 @@
 %   {\fp_to_scientific:N, \fp_to_scientific:c, \fp_to_scientific:n}
 %   \begin{syntax}
 %     \cs{fp_to_scientific:N} \meta{fp~var}
-%     \cs{fp_to_scientific:n} \Arg{floating point expression}
+%     \cs{fp_to_scientific:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} and expresses the
+%   Evaluates the \meta{fp expr} and expresses the
 %   result in scientific notation:
 %   \begin{quote}
 %     \meta{optional \texttt{-}}\meta{digit}\texttt{.}\meta{15 digits}\texttt{e}\meta{optional sign}\meta{exponent}
@@ -346,9 +346,9 @@
 %   {\fp_to_tl:N, \fp_to_tl:c, \fp_to_tl:n}
 %   \begin{syntax}
 %     \cs{fp_to_tl:N} \meta{fp~var}
-%     \cs{fp_to_tl:n} \Arg{floating point expression}
+%     \cs{fp_to_tl:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} and expresses the
+%   Evaluates the \meta{fp expr} and expresses the
 %   result in (almost) the shortest possible form.  Numbers in the
 %   ranges $(0,10^{-3})$ and $[10^{16},\infty)$ are expressed in
 %   scientific notation with trailing zeros trimmed and no decimal
@@ -398,10 +398,10 @@
 % \begin{function}[EXP, pTF, updated = 2012-05-08,
 %   tested = m3fp-logic001]{\fp_compare:nNn}
 %   \begin{syntax}
-%     \cs{fp_compare_p:nNn} \Arg{fpexpr_1} \meta{relation} \Arg{fpexpr_2}
-%     \cs{fp_compare:nNnTF} \Arg{fpexpr_1} \meta{relation} \Arg{fpexpr_2} \Arg{true code} \Arg{false code}
+%     \cs{fp_compare_p:nNn} \Arg{fp expr_1} \meta{relation} \Arg{fp expr_2}
+%     \cs{fp_compare:nNnTF} \Arg{fp expr_1} \meta{relation} \Arg{fp expr_2} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Compares the \meta{fpexpr_1} and the \meta{fpexpr_2}, and returns
+%   Compares the \meta{fp expr_1} and the \meta{fp expr_2}, and returns
 %   \texttt{true} if the \meta{relation} is obeyed.  Two floating points
 %   $x$ and~$y$ may obey four mutually exclusive relations:
 %   $x<y$, $x=y$, $x>y$, or $x?y$ (\enquote{not ordered}).  The last
@@ -430,30 +430,30 @@
 %   \begin{syntax}
 %     \cs{fp_compare_p:n} \\
 %     ~~\{ \\
-%     ~~~~\meta{fpexpr_1} \meta{relation_1} \\
+%     ~~~~\meta{fp expr_1} \meta{relation_1} \\
 %     ~~~~\ldots{} \\
-%     ~~~~\meta{fpexpr_N} \meta{relation_N} \\
-%     ~~~~\meta{fpexpr_{N+1}} \\
+%     ~~~~\meta{fp expr_N} \meta{relation_N} \\
+%     ~~~~\meta{fp expr_{N+1}} \\
 %     ~~\} \\
 %     \cs{fp_compare:nTF}
 %     ~~\{ \\
-%     ~~~~\meta{fpexpr_1} \meta{relation_1} \\
+%     ~~~~\meta{fp expr_1} \meta{relation_1} \\
 %     ~~~~\ldots{} \\
-%     ~~~~\meta{fpexpr_N} \meta{relation_N} \\
-%     ~~~~\meta{fpexpr_{N+1}} \\
+%     ~~~~\meta{fp expr_N} \meta{relation_N} \\
+%     ~~~~\meta{fp expr_{N+1}} \\
 %     ~~\} \\
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expressions} as described for
+%   Evaluates the \meta{fp exprs} as described for
 %   \cs{fp_eval:n} and compares consecutive result using the
-%   corresponding \meta{relation}, namely it compares \meta{fpexpr_1}
-%   and \meta{fpexpr_2} using the \meta{relation_1}, then
-%   \meta{fpexpr_2} and \meta{fpexpr_3} using the \meta{relation_2},
-%   until finally comparing \meta{fpexpr_N} and \meta{fpexpr_{N+1}}
+%   corresponding \meta{relation}, namely it compares \meta{fp expr_1}
+%   and \meta{fp expr_2} using the \meta{relation_1}, then
+%   \meta{fp expr_2} and \meta{fp expr_3} using the \meta{relation_2},
+%   until finally comparing \meta{fp expr_N} and \meta{fp expr_{N+1}}
 %   using the \meta{relation_N}.  The test yields \texttt{true} if all
 %   comparisons are \texttt{true}.  Each \meta{floating point
 %     expression} is evaluated only once.  Contrarily to
-%   \cs{int_compare:nTF}, all \meta{floating point expressions} are
+%   \cs{int_compare:nTF}, all \meta{fp exprs} are
 %   computed, even if one comparison is \texttt{false}.  Two floating
 %   points $x$ and~$y$ may obey four mutually exclusive
 %   relations: $x<y$, $x=y$, $x>y$, or $x?y$ (\enquote{not ordered}).
@@ -481,7 +481,7 @@
 % \begin{function}[rEXP, added = 2012-08-16, tested = m3fp-logic003]
 %   {\fp_do_until:nNnn}
 %   \begin{syntax}
-%      \cs{fp_do_until:nNnn} \Arg{fpexpr_1} \meta{relation} \Arg{fpexpr_2} \Arg{code}
+%      \cs{fp_do_until:nNnn} \Arg{fp expr_1} \meta{relation} \Arg{fp expr_2} \Arg{code}
 %   \end{syntax}
 %   Places the \meta{code} in the input stream for \TeX{} to process,
 %   and then evaluates the relationship between the two \meta{floating
@@ -494,7 +494,7 @@
 % \begin{function}[rEXP, added = 2012-08-16, tested = m3fp-logic003]
 %   {\fp_do_while:nNnn}
 %   \begin{syntax}
-%      \cs{fp_do_while:nNnn} \Arg{fpexpr_1} \meta{relation} \Arg{fpexpr_2} \Arg{code}
+%      \cs{fp_do_while:nNnn} \Arg{fp expr_1} \meta{relation} \Arg{fp expr_2} \Arg{code}
 %   \end{syntax}
 %   Places the \meta{code} in the input stream for \TeX{} to process,
 %   and then evaluates the relationship between the two \meta{floating
@@ -507,7 +507,7 @@
 % \begin{function}[rEXP, added = 2012-08-16, tested = m3fp-logic003]
 %   {\fp_until_do:nNnn}
 %   \begin{syntax}
-%      \cs{fp_until_do:nNnn} \Arg{fpexpr_1} \meta{relation} \Arg{fpexpr_2} \Arg{code}
+%      \cs{fp_until_do:nNnn} \Arg{fp expr_1} \meta{relation} \Arg{fp expr_2} \Arg{code}
 %   \end{syntax}
 %   Evaluates the relationship between the two \meta{floating point
 %     expressions} as described for \cs{fp_compare:nNnTF}, and then
@@ -520,7 +520,7 @@
 % \begin{function}[rEXP, added = 2012-08-16, tested = m3fp-logic003]
 %   {\fp_while_do:nNnn}
 %   \begin{syntax}
-%      \cs{fp_while_do:nNnn} \Arg{fpexpr_1} \meta{relation} \Arg{fpexpr_2} \Arg{code}
+%      \cs{fp_while_do:nNnn} \Arg{fp expr_1} \meta{relation} \Arg{fp expr_2} \Arg{code}
 %   \end{syntax}
 %   Evaluates the relationship between the two \meta{floating point
 %     expressions} as described for \cs{fp_compare:nNnTF}, and then
@@ -533,7 +533,7 @@
 % \begin{function}[rEXP, added = 2012-08-16, updated = 2013-12-14, tested = m3fp-logic003]
 %   {\fp_do_until:nn}
 %   \begin{syntax}
-%      \cs{fp_do_until:nn} \{ \meta{fpexpr_1} \meta{relation} \meta{fpexpr_2} \} \Arg{code}
+%      \cs{fp_do_until:nn} \{ \meta{fp expr_1} \meta{relation} \meta{fp expr_2} \} \Arg{code}
 %   \end{syntax}
 %   Places the \meta{code} in the input stream for \TeX{} to process,
 %   and then evaluates the relationship between the two \meta{floating
@@ -546,7 +546,7 @@
 % \begin{function}[rEXP, added = 2012-08-16, updated = 2013-12-14, tested = m3fp-logic003]
 %   {\fp_do_while:nn}
 %   \begin{syntax}
-%      \cs{fp_do_while:nn} \{ \meta{fpexpr_1} \meta{relation} \meta{fpexpr_2} \} \Arg{code}
+%      \cs{fp_do_while:nn} \{ \meta{fp expr_1} \meta{relation} \meta{fp expr_2} \} \Arg{code}
 %   \end{syntax}
 %   Places the \meta{code} in the input stream for \TeX{} to process,
 %   and then evaluates the relationship between the two \meta{floating
@@ -559,7 +559,7 @@
 % \begin{function}[rEXP, added = 2012-08-16, updated = 2013-12-14, tested = m3fp-logic003]
 %   {\fp_until_do:nn}
 %   \begin{syntax}
-%      \cs{fp_until_do:nn} \{ \meta{fpexpr_1} \meta{relation} \meta{fpexpr_2} \} \Arg{code}
+%      \cs{fp_until_do:nn} \{ \meta{fp expr_1} \meta{relation} \meta{fp expr_2} \} \Arg{code}
 %   \end{syntax}
 %   Evaluates the relationship between the two \meta{floating point
 %     expressions} as described for \cs{fp_compare:nTF}, and then places
@@ -572,7 +572,7 @@
 % \begin{function}[rEXP, added = 2012-08-16, updated = 2013-12-14, tested = m3fp-logic003]
 %   {\fp_while_do:nn}
 %   \begin{syntax}
-%      \cs{fp_while_do:nn} \{ \meta{fpexpr_1} \meta{relation} \meta{fpexpr_2} \} \Arg{code}
+%      \cs{fp_while_do:nn} \{ \meta{fp expr_1} \meta{relation} \meta{fp expr_2} \} \Arg{code}
 %   \end{syntax}
 %   Evaluates the relationship between the two \meta{floating point
 %     expressions} as described for \cs{fp_compare:nTF}, and then places
@@ -773,9 +773,9 @@
 %   tested = m3fp002]{\fp_show:N, \fp_show:c, \fp_show:n}
 %   \begin{syntax}
 %     \cs{fp_show:N} \meta{fp~var}
-%     \cs{fp_show:n} \Arg{floating point expression}
+%     \cs{fp_show:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} and displays the
+%   Evaluates the \meta{fp expr} and displays the
 %   result in the terminal.
 % \end{function}
 %
@@ -783,9 +783,9 @@
 %   {\fp_log:N, \fp_log:c, \fp_log:n}
 %   \begin{syntax}
 %     \cs{fp_log:N} \meta{fp~var}
-%     \cs{fp_log:n} \Arg{floating point expression}
+%     \cs{fp_log:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} and writes the
+%   Evaluates the \meta{fp expr} and writes the
 %   result in the log file.
 % \end{function}
 %
@@ -1036,27 +1036,27 @@
 %
 % \begin{function}[tested = m3fp-basics004]{abs}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |abs(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |abs(| \meta{fp expr} |)| \}
 %   \end{syntax}
-%   Computes the absolute value of the \meta{fpexpr}.  If the operand is
+%   Computes the absolute value of the \meta{fp expr}.  If the operand is
 %   a tuple, \enquote{invalid operation} occurs.  This operation does
 %   not raise exceptions in other cases.  See also \cs{fp_abs:n}.
 % \end{function}
 %
 % \begin{function}[tested = m3fp-expo001]{exp}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |exp(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |exp(| \meta{fp expr} |)| \}
 %   \end{syntax}
-%   Computes the exponential of the \meta{fpexpr}.  \enquote{Underflow}
+%   Computes the exponential of the \meta{fp expr}.  \enquote{Underflow}
 %   and \enquote{overflow} occur when appropriate.
 %   If the operand is a tuple, \enquote{invalid operation} occurs.
 % \end{function}
 %
 % \begin{function}[tested = m3fp-expo001]{fact}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |fact(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |fact(| \meta{fp expr} |)| \}
 %   \end{syntax}
-%   Computes the factorial of the \meta{fpexpr}.  If the \meta{fpexpr}
+%   Computes the factorial of the \meta{fp expr}.  If the \meta{fp expr}
 %   is an integer between $-0$ and $3248$ included, the result is finite
 %   and correctly rounded.  Larger positive integers give $+\infty$ with
 %   \enquote{overflow}, while $|fact(|{+\infty}|)|=+\infty$ and
@@ -1066,9 +1066,9 @@
 %
 % \begin{function}[tested = m3fp-expo001]{ln}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |ln(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |ln(| \meta{fp expr} |)| \}
 %   \end{syntax}
-%   Computes the natural logarithm of the \meta{fpexpr}.  Negative
+%   Computes the natural logarithm of the \meta{fp expr}.  Negative
 %   numbers have no (real) logarithm, hence the \enquote{invalid
 %   operation} is raised in that case, including for $\ln(-0)$.
 %   \enquote{Division by zero} occurs when evaluating
@@ -1079,9 +1079,9 @@
 %
 % \begin{function}[EXP, added = 2018-11-03]{logb}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |logb(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |logb(| \meta{fp expr} |)| \}
 %   \end{syntax}
-%   Determines the exponent of the \meta{fpexpr}, namely the floor of
+%   Determines the exponent of the \meta{fp expr}, namely the floor of
 %   the base-$10$ logarithm of its absolute value.  \enquote{Division by
 %   zero} occurs when evaluating $\operatorname{logb}(\pm 0) = -\infty$.
 %   Other special values are $\operatorname{logb}(\pm\infty)=+\infty$
@@ -1092,11 +1092,11 @@
 %
 % \begin{function}[tested = m3fp-logic002]{max, min}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |max(| \meta{fpexpr_1} |,| \meta{fpexpr_2} |,| \ldots{} |)| \}
-%     \cs{fp_eval:n} \{ |min(| \meta{fpexpr_1} |,| \meta{fpexpr_2} |,| \ldots{} |)| \}
+%     \cs{fp_eval:n} \{ |max(| \meta{fp expr_1} |,| \meta{fp expr_2} |,| \ldots{} |)| \}
+%     \cs{fp_eval:n} \{ |min(| \meta{fp expr_1} |,| \meta{fp expr_2} |,| \ldots{} |)| \}
 %   \end{syntax}
-%   Evaluates each \meta{fpexpr} and computes the largest (smallest) of
-%   those.  If any of the \meta{fpexpr} is a \nan{} or tuple, the result
+%   Evaluates each \meta{fp expr} and computes the largest (smallest) of
+%   those.  If any of the \meta{fp expr} is a \nan{} or tuple, the result
 %   is \nan{}.  If any operand is a tuple, \enquote{invalid operation}
 %   occurs; these operations do not raise exceptions in other cases.
 % \end{function}
@@ -1105,19 +1105,19 @@
 %   [tested = {m3fp-round001, m3fp-round002}, added = 2013-12-14, updated = 2015-08-08]
 %   {round, trunc, ceil, floor}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |round| |(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |round| |(| \meta{fpexpr_1} , \meta{fpexpr_2} |)| \}
-%     \cs{fp_eval:n} \{ |round| |(| \meta{fpexpr_1} , \meta{fpexpr_2} , \meta{fpexpr_3} |)| \}
+%     \cs{fp_eval:n} \{ |round| |(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |round| |(| \meta{fp expr_1} , \meta{fp expr_2} |)| \}
+%     \cs{fp_eval:n} \{ |round| |(| \meta{fp expr_1} , \meta{fp expr_2} , \meta{fp expr_3} |)| \}
 %   \end{syntax}
 %   Only |round| accepts a third argument.
-%   Evaluates $\meta{fpexpr_1}=x$ and $\meta{fpexpr_2}=n$ and $\meta{fpexpr_3}=t$ then rounds
+%   Evaluates $\meta{fp expr_1}=x$ and $\meta{fp expr_2}=n$ and $\meta{fp expr_3}=t$ then rounds
 %   $x$~to $n$~places.  If $n$~is an integer, this rounds~$x$ to a
 %   multiple of~$10^{-n}$; if $n=+\infty$, this always yields~$x$; if
 %   $n=-\infty$, this yields one of $\pm 0$, $\pm\infty$, or~\nan{}; if
 %   $n=\nan{}$, this yields \nan{}; if
 %   $n$~is neither $\pm\infty$ nor an integer, then an \enquote{invalid
-%     operation} exception is raised.  When \meta{fpexpr_2} is omitted,
-%   $n=0$, \emph{i.e.}, \meta{fpexpr_1} is rounded to an integer.  The
+%     operation} exception is raised.  When \meta{fp expr_2} is omitted,
+%   $n=0$, \emph{i.e.}, \meta{fp expr_1} is rounded to an integer.  The
 %   rounding direction depends on the function.
 %   \begin{itemize}
 %     \item |round| yields the multiple of~$10^{-n}$ closest to~$x$,
@@ -1139,15 +1139,15 @@
 %         zero}).
 %   \end{itemize}
 %   \enquote{Overflow} occurs if $x$~is finite and the result is
-%   infinite (this can only happen if $\meta{fpexpr_2}\string<-9984$).
+%   infinite (this can only happen if $\meta{fp expr_2}\string<-9984$).
 %   If any operand is a tuple, \enquote{invalid operation} occurs.
 % \end{function}
 %
 % \begin{function}[tested = m3fp-logic002]{sign}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |sign(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |sign(| \meta{fp expr} |)| \}
 %   \end{syntax}
-%   Evaluates the \meta{fpexpr} and determines its sign: $+1$ for
+%   Evaluates the \meta{fp expr} and determines its sign: $+1$ for
 %   positive numbers and for $+\infty$, $-1$ for negative numbers and
 %   for $-\infty$, $\pm 0$ for $\pm 0$, and \nan{} for \nan{}.
 %   If the operand is a tuple, \enquote{invalid operation} occurs.
@@ -1157,15 +1157,15 @@
 % \begin{function}[updated = 2013-11-17, tested = m3fp-trig001]
 %   {sin, cos, tan, cot, csc, sec}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |sin(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |cos(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |tan(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |cot(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |csc(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |sec(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |sin(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |cos(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |tan(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |cot(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |csc(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |sec(| \meta{fp expr} |)| \}
 %   \end{syntax}
 %   Computes the sine, cosine, tangent, cotangent, cosecant, or secant
-%   of the \meta{fpexpr} given in radians.  For arguments given in
+%   of the \meta{fp expr} given in radians.  For arguments given in
 %   degrees, see \texttt{sind}, \texttt{cosd}, \emph{etc.}  Note that
 %   since $\pi$~is irrational, $\operatorname{sin}(8\mathrm{pi})$ is not quite
 %   zero, while its analogue $\operatorname{sind}(8\times 180)$ is exactly
@@ -1181,15 +1181,15 @@
 % \begin{function}[added = 2013-11-02, tested = m3fp-trig003]
 %   {sind, cosd, tand, cotd, cscd, secd}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |sind(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |cosd(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |tand(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |cotd(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |cscd(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |secd(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |sind(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |cosd(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |tand(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |cotd(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |cscd(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |secd(| \meta{fp expr} |)| \}
 %   \end{syntax}
 %   Computes the sine, cosine, tangent, cotangent, cosecant, or secant
-%   of the \meta{fpexpr} given in degrees.  For arguments given in
+%   of the \meta{fp expr} given in degrees.  For arguments given in
 %   radians, see \texttt{sin}, \texttt{cos}, \emph{etc.}  Note that
 %   since $\pi$~is irrational, $\operatorname{sin}(8\mathrm{pi})$ is not quite
 %   zero, while its analogue $\operatorname{sind}(8\times 180)$ is exactly
@@ -1205,13 +1205,13 @@
 % \begin{function}[added = 2013-11-02, tested = m3fp-trig002]
 %   {asin, acos, acsc, asec}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |asin(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |acos(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |acsc(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |asec(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |asin(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |acos(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |acsc(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |asec(| \meta{fp expr} |)| \}
 %   \end{syntax}
 %   Computes the arcsine, arccosine, arccosecant, or arcsecant of the
-%   \meta{fpexpr} and returns the result in radians, in the range
+%   \meta{fp expr} and returns the result in radians, in the range
 %   $[-\pi/2,\pi/2]$ for \texttt{asin} and \texttt{acsc} and $[0,\pi]$
 %   for \texttt{acos} and \texttt{asec}.  For a result in degrees, use
 %   \texttt{asind}, \emph{etc.}  If the argument of |asin| or |acos|
@@ -1225,13 +1225,13 @@
 % \begin{function}[added = 2013-11-02, tested = m3fp-trig004]
 %   {asind, acosd, acscd, asecd}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |asind(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |acosd(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |acscd(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |asecd(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |asind(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |acosd(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |acscd(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |asecd(| \meta{fp expr} |)| \}
 %   \end{syntax}
 %   Computes the arcsine, arccosine, arccosecant, or arcsecant of the
-%   \meta{fpexpr} and returns the result in degrees, in the range
+%   \meta{fp expr} and returns the result in degrees, in the range
 %   $[-90,90]$ for \texttt{asin} and \texttt{acsc} and $[0,180]$ for
 %   \texttt{acos} and \texttt{asec}.  For a result in radians, use
 %   \texttt{asin}, \emph{etc.}  If the argument of |asin| or |acos| lies
@@ -1245,26 +1245,26 @@
 % \begin{function}[added = 2013-11-02, tested = m3fp-trig002]
 %   {atan, acot}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |atan(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |atan(| \meta{fpexpr_1} , \meta{fpexpr_2} |)| \}
-%     \cs{fp_eval:n} \{ |acot(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |acot(| \meta{fpexpr_1} , \meta{fpexpr_2} |)| \}
+%     \cs{fp_eval:n} \{ |atan(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |atan(| \meta{fp expr_1} , \meta{fp expr_2} |)| \}
+%     \cs{fp_eval:n} \{ |acot(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |acot(| \meta{fp expr_1} , \meta{fp expr_2} |)| \}
 %   \end{syntax}
 %   Those functions yield an angle in radians: \texttt{atand} and
 %   \texttt{acotd} are their analogs in degrees.  The one-argument
 %   versions compute the arctangent or arccotangent of the
-%   \meta{fpexpr}: arctangent takes values in the range
+%   \meta{fp expr}: arctangent takes values in the range
 %   $[-\pi/2,\pi/2]$, and arccotangent in the range $[0,\pi]$.  The
 %   two-argument arctangent computes the angle in polar coordinates of
-%   the point with Cartesian coordinates $(\meta{fpexpr_2},
-%   \meta{fpexpr_1})$: this is the arctangent of
-%   $\meta{fpexpr_1}/\meta{fpexpr_2}$, possibly shifted by~$\pi$
-%   depending on the signs of \meta{fpexpr_1} and \meta{fpexpr_2}.  The
+%   the point with Cartesian coordinates $(\meta{fp expr_2},
+%   \meta{fp expr_1})$: this is the arctangent of
+%   $\meta{fp expr_1}/\meta{fp expr_2}$, possibly shifted by~$\pi$
+%   depending on the signs of \meta{fp expr_1} and \meta{fp expr_2}.  The
 %   two-argument arccotangent computes the angle in polar coordinates of
-%   the point $(\meta{fpexpr_1}, \meta{fpexpr_2})$, equal to the
-%   arccotangent of $\meta{fpexpr_1}/\meta{fpexpr_2}$, possibly shifted
+%   the point $(\meta{fp expr_1}, \meta{fp expr_2})$, equal to the
+%   arccotangent of $\meta{fp expr_1}/\meta{fp expr_2}$, possibly shifted
 %   by~$\pi$.  Both two-argument functions take values in the wider
-%   range $[-\pi,\pi]$.  The ratio $\meta{fpexpr_1}/\meta{fpexpr_2}$
+%   range $[-\pi,\pi]$.  The ratio $\meta{fp expr_1}/\meta{fp expr_2}$
 %   need not be defined for the two-argument arctangent: when both
 %   expressions yield~$\pm 0$, or when both yield~$\pm\infty$, the
 %   resulting angle is one of $\{\pm\pi/4,\pm 3\pi/4\}$ depending on
@@ -1275,26 +1275,26 @@
 % \begin{function}[added = 2013-11-02, tested = m3fp-trig004]
 %   {atand, acotd}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |atand(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |atand(| \meta{fpexpr_1} , \meta{fpexpr_2} |)| \}
-%     \cs{fp_eval:n} \{ |acotd(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |acotd(| \meta{fpexpr_1} , \meta{fpexpr_2} |)| \}
+%     \cs{fp_eval:n} \{ |atand(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |atand(| \meta{fp expr_1} , \meta{fp expr_2} |)| \}
+%     \cs{fp_eval:n} \{ |acotd(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |acotd(| \meta{fp expr_1} , \meta{fp expr_2} |)| \}
 %   \end{syntax}
 %   Those functions yield an angle in degrees: \texttt{atand} and
 %   \texttt{acotd} are their analogs in radians.  The one-argument
 %   versions compute the arctangent or arccotangent of the
-%   \meta{fpexpr}: arctangent takes values in the range $[-90,90]$, and
+%   \meta{fp expr}: arctangent takes values in the range $[-90,90]$, and
 %   arccotangent in the range $[0,180]$.  The two-argument arctangent
 %   computes the angle in polar coordinates of the point with Cartesian
-%   coordinates $(\meta{fpexpr_2}, \meta{fpexpr_1})$: this is the
-%   arctangent of $\meta{fpexpr_1}/\meta{fpexpr_2}$, possibly shifted
-%   by~$180$ depending on the signs of \meta{fpexpr_1} and
-%   \meta{fpexpr_2}.  The two-argument arccotangent computes the angle
-%   in polar coordinates of the point $(\meta{fpexpr_1},
-%   \meta{fpexpr_2})$, equal to the arccotangent of
-%   $\meta{fpexpr_1}/\meta{fpexpr_2}$, possibly shifted by~$180$.  Both
+%   coordinates $(\meta{fp expr_2}, \meta{fp expr_1})$: this is the
+%   arctangent of $\meta{fp expr_1}/\meta{fp expr_2}$, possibly shifted
+%   by~$180$ depending on the signs of \meta{fp expr_1} and
+%   \meta{fp expr_2}.  The two-argument arccotangent computes the angle
+%   in polar coordinates of the point $(\meta{fp expr_1},
+%   \meta{fp expr_2})$, equal to the arccotangent of
+%   $\meta{fp expr_1}/\meta{fp expr_2}$, possibly shifted by~$180$.  Both
 %   two-argument functions take values in the wider range $[-180,180]$.
-%   The ratio $\meta{fpexpr_1}/\meta{fpexpr_2}$ need not be defined for
+%   The ratio $\meta{fp expr_1}/\meta{fp expr_2}$ need not be defined for
 %   the two-argument arctangent: when both expressions yield~$\pm 0$, or
 %   when both yield~$\pm\infty$, the resulting angle is one of $\{\pm
 %   45,\pm 135\}$ depending on signs.  The \enquote{underflow}
@@ -1304,10 +1304,10 @@
 %
 % \begin{function}[added = 2013-12-14, tested = m3fp-basics005]{sqrt}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |sqrt(| \meta{fpexpr} |)| \}
+%     \cs{fp_eval:n} \{ |sqrt(| \meta{fp expr} |)| \}
 %   \end{syntax}
-%   Computes the square root of the \meta{fpexpr}.  The \enquote{invalid
-%     operation} is raised when the \meta{fpexpr} is negative or is a tuple; no other
+%   Computes the square root of the \meta{fp expr}.  The \enquote{invalid
+%     operation} is raised when the \meta{fp expr} is negative or is a tuple; no other
 %   exception can occur.  Special values yield $\sqrt{-0} = -0$,
 %   $\sqrt{+0} = +0$, $\sqrt{+\infty} = +\infty$ and
 %   $\sqrt{\text{\nan{}}}=\text{\nan{}}$.
@@ -1338,11 +1338,11 @@
 %
 % \begin{function}[added = 2016-12-05]{randint}
 %   \begin{syntax}
-%     \cs{fp_eval:n} \{ |randint(| \meta{fpexpr} |)| \}
-%     \cs{fp_eval:n} \{ |randint(| \meta{fpexpr_1} , \meta{fpexpr_2} |)| \}
+%     \cs{fp_eval:n} \{ |randint(| \meta{fp expr} |)| \}
+%     \cs{fp_eval:n} \{ |randint(| \meta{fp expr_1} , \meta{fp expr_2} |)| \}
 %   \end{syntax}
-%   Produces a pseudo-random integer between $1$~and \meta{fpexpr} or
-%   between \meta{fpexpr_1} and \meta{fpexpr_2} inclusive.  The bounds
+%   Produces a pseudo-random integer between $1$~and \meta{fp expr} or
+%   between \meta{fp expr_1} and \meta{fp expr_2} inclusive.  The bounds
 %   must be integers in the range $(-10^{16},10^{16})$ and the first
 %   must be smaller or equal to the second.  See \texttt{rand} for
 %   important comments on how these pseudo-random numbers are generated.
@@ -1392,9 +1392,9 @@
 % \begin{function}[EXP, added = 2012-05-14, updated = 2012-07-08,
 %   tested = m3fp-convert003]{\fp_abs:n}
 %   \begin{syntax}
-%     \cs{fp_abs:n} \Arg{floating point expression}
+%     \cs{fp_abs:n} \Arg{fp expr}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expression} as described for
+%   Evaluates the \meta{fp expr} as described for
 %   \cs{fp_eval:n} and leaves the absolute value of the result in the
 %   input stream.  If the argument is $\pm\infty$, \nan{} or a tuple,
 %   \enquote{invalid operation} occurs.  Within floating point
@@ -1407,7 +1407,7 @@
 %   \begin{syntax}
 %     \cs{fp_max:nn} \Arg{fp expression 1} \Arg{fp expression 2}
 %   \end{syntax}
-%   Evaluates the \meta{floating point expressions} as described for
+%   Evaluates the \meta{fp exprs} as described for
 %   \cs{fp_eval:n} and leaves the resulting larger (\texttt{max}) or
 %   smaller (\texttt{min}) value in the input stream.  If the argument
 %   is a tuple, \enquote{invalid operation} occurs, but no other case
@@ -1427,7 +1427,7 @@
 %   \item Decide what exponent range to consider.
 %   \item Support signalling \texttt{nan}.
 %   \item Modulo and remainder, and rounding function |quantize| (and its friends analogous to |trunc|, |ceil|, |floor|).
-%   \item \cs{fp_format:nn} \Arg{fpexpr} \Arg{format}, but what should
+%   \item \cs{fp_format:nn} \Arg{fp expr} \Arg{format}, but what should
 %     \meta{format} be?  More general pretty printing?
 %   \item Add |and|, |or|, |xor|?  Perhaps under the names \texttt{all},
 %     \texttt{any}, and \texttt{xor}?

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -55,7 +55,7 @@
 % \texttt{+}, \texttt{-}, \texttt{/} and \texttt{*} and
 % parentheses can be used within such expressions to carry
 % arithmetic operations. This module carries out these functions
-% on \emph{integer expressions} (\enquote{\texttt{intexpr}}).
+% on \emph{integer expressions} (\enquote{\meta{int expr}}).
 %
 % \section{Integer expressions}
 %
@@ -118,20 +118,70 @@
 % 
 % \begin{function}[EXP]{\int_eval:n}
 %   \begin{syntax}
-%     \cs{int_eval:n} \Arg{integer expression}
+%     \cs{int_eval:n} \Arg{int expr}
 %   \end{syntax}
-%   Evaluates the \meta{integer expression} and leaves the result in the
+%   Evaluates the \meta{int expr} and leaves the result in the
 %   input stream as an integer denotation: for positive results an
 %   explicit sequence of decimal digits not starting with~\texttt{0},
 %   for negative results \texttt{-}~followed by such a sequence, and
-%   \texttt{0}~for zero.
+%   \texttt{0}~for zero.  The \meta{int expr} should consist,
+%   after expansion, of \texttt{+}, \texttt{-}, \texttt{*}, \texttt{/},
+%   \texttt{(}, \texttt{)} and of course integer operands.  The result
+%   is calculated by applying standard mathematical rules with the
+%   following peculiarities:
+%   \begin{itemize}
+%   \item \texttt{/} denotes division rounded to the closest integer with
+%     ties rounded away from zero;
+%   \item there is an error and the overall expression evaluates to zero
+%     whenever the absolute value of any intermediate result exceeds
+%     $2^{31}-1$, except in the case of scaling operations
+%     $a$\texttt{*}$b$\texttt{/}$c$, for which $a$\texttt{*}$b$ may be
+%     arbitrarily large;
+%   \item parentheses may not appear after unary \texttt{+} or
+%     \texttt{-}, namely placing \texttt{+(} or \texttt{-(} at the start
+%     of an expression or after \texttt{+}, \texttt{-}, \texttt{*},
+%     \texttt{/} or~\texttt{(} leads to an error.
+%   \end{itemize}
+%   Each integer operand can be either an integer variable (with no need
+%   for \cs{int_use:N}) or an integer denotation.  For example both
+%   \begin{verbatim}
+%     \int_eval:n { 5 +  4 * 3 - ( 3 + 4 * 5 ) }
+%   \end{verbatim}
+%   and
+%   \begin{verbatim}
+%     \tl_new:N  \l_my_tl
+%     \tl_set:Nn \l_my_tl { 5 }
+%     \int_new:N  \l_my_int
+%     \int_set:Nn \l_my_int { 4 }
+%     \int_eval:n { \l_my_tl +  \l_my_int * 3 - ( 3 + 4 * 5 ) }
+%   \end{verbatim}
+%   evaluate to $-6$ because \cs[no-index]{l_my_tl} expands to the
+%   integer denotation~|5|.  As the \meta{int expr} is fully
+%   expanded from left to right during evaluation, fully expandable and
+%   restricted-expandable functions can both be used, and \cs{exp_not:n}
+%   and its variants have no effect while \cs{exp_not:N} may incorrectly
+%   interrupt the expression.
+%   \begin{texnote}
+%     Exactly two expansions are needed to evaluate \cs{int_eval:n}.
+%     The result is \emph{not} an \meta{internal integer}, and therefore
+%     requires suitable termination if used in a \TeX{}-style integer
+%     assignment.
+%
+%     As all \TeX{} integers, integer operands can also be dimension or
+%     skip variables, converted to integers in~\texttt{sp}, or octal
+%     numbers given as \texttt{'} followed by digits other than
+%     \texttt{8} and \texttt{9}, or hexadecimal numbers given as
+%     |"| followed by digits or upper case letters from
+%     \texttt{A} to~\texttt{F}, or the character code of some character
+%     or one-character control sequence, given as \texttt{`}\meta{char}.
+%   \end{texnote}
 % \end{function}
 %
 % \begin{function}[EXP, added = 2018-03-30]{\int_eval:w}
 %   \begin{syntax}
-%     \cs{int_eval:w} \meta{integer expression}
+%     \cs{int_eval:w} \meta{int expr}
 %   \end{syntax}
-%   Evaluates the \meta{integer expression} as described for
+%   Evaluates the \meta{int expr} as described for
 %   \cs{int_eval:n}. The end of the expression is the first token
 %   encountered that cannot form part of such an expression.  If that
 %   token is \cs{scan_stop:} it is removed, otherwise not.  Spaces do
@@ -144,17 +194,17 @@
 %
 % \begin{function}[EXP, added = 2018-11-03]{\int_sign:n}
 %   \begin{syntax}
-%     \cs{int_sign:n} \Arg{intexpr}
+%     \cs{int_sign:n} \Arg{int expr}
 %   \end{syntax}
-%   Evaluates the \meta{integer expression} then leaves $1$ or $0$ or
+%   Evaluates the \meta{int expr} then leaves $1$ or $0$ or
 %   $-1$ in the input stream according to the sign of the result.
 % \end{function}
 %
 % \begin{function}[EXP, updated = 2012-09-26]{\int_abs:n}
 %   \begin{syntax}
-%     \cs{int_abs:n} \Arg{integer expression}
+%     \cs{int_abs:n} \Arg{int expr}
 %   \end{syntax}
-%   Evaluates the \meta{integer expression} as described for
+%   Evaluates the \meta{int expr} as described for
 %   \cs{int_eval:n} and leaves the absolute value of the result in
 %   the input stream as an \meta{integer denotation} after two
 %   expansions.
@@ -162,21 +212,21 @@
 %
 % \begin{function}[EXP, updated = 2012-09-26]{\int_div_round:nn}
 %   \begin{syntax}
-%     \cs{int_div_round:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{int_div_round:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
-%   Evaluates the two \meta{integer expressions} as described earlier,
+%   Evaluates the two \meta{int expr}s as described earlier,
 %   then divides the first value by the second, and rounds the result
 %   to the closest integer.  Ties are rounded away from zero.
 %   Note that this is identical to using
-%   |/| directly in an \meta{integer expression}. The result is left in
+%   |/| directly in an \meta{int expr}. The result is left in
 %   the input stream as an \meta{integer denotation} after two expansions.
 % \end{function}
 %
 % \begin{function}[EXP, updated = 2012-02-09]{\int_div_truncate:nn}
 %   \begin{syntax}
-%     \cs{int_div_truncate:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{int_div_truncate:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
-%   Evaluates the two \meta{integer expressions} as described earlier,
+%   Evaluates the two \meta{int expr}s as described earlier,
 %   then divides the first value by the second, and rounds the result
 %   towards zero.  Note that division using |/|
 %   rounds to the closest integer instead.
@@ -186,10 +236,10 @@
 %
 % \begin{function}[EXP, updated = 2012-09-26]{\int_max:nn, \int_min:nn}
 %   \begin{syntax}
-%     \cs{int_max:nn} \Arg{intexpr_1} \Arg{intexpr_2}
-%     \cs{int_min:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{int_max:nn} \Arg{int expr_1} \Arg{int expr_2}
+%     \cs{int_min:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
-%   Evaluates the \meta{integer expressions} as described for
+%   Evaluates the \meta{int expr}s as described for
 %   \cs{int_eval:n} and leaves either the larger or smaller value
 %   in the input stream as an \meta{integer denotation} after two
 %   expansions.
@@ -197,15 +247,15 @@
 %
 % \begin{function}[EXP, updated = 2012-09-26]{\int_mod:nn}
 %   \begin{syntax}
-%     \cs{int_mod:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{int_mod:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
-%   Evaluates the two \meta{integer expressions} as described earlier,
+%   Evaluates the two \meta{int expr}s as described earlier,
 %   then calculates the integer remainder of dividing the first
 %   expression by the second.  This is obtained by subtracting
-%   \cs{int_div_truncate:nn} \Arg{intexpr_1} \Arg{intexpr_2} times
-%   \meta{intexpr_2} from \meta{intexpr_1}.  Thus, the result has the
-%   same sign as \meta{intexpr_1} and its absolute value is strictly
-%   less than that of \meta{intexpr_2}.  The result is left in the input
+%   \cs{int_div_truncate:nn} \Arg{int expr_1} \Arg{int expr_2} times
+%   \meta{int expr_2} from \meta{int expr_1}.  Thus, the result has the
+%   same sign as \meta{int expr_1} and its absolute value is strictly
+%   less than that of \meta{int expr_2}.  The result is left in the input
 %   stream as an \meta{integer denotation} after two expansions.
 % \end{function}
 %
@@ -222,11 +272,11 @@
 %
 % \begin{function}[updated = 2011-10-22]{\int_const:Nn, \int_const:cn}
 %   \begin{syntax}
-%     \cs{int_const:Nn} \meta{integer} \Arg{integer expression}
+%     \cs{int_const:Nn} \meta{integer} \Arg{int expr}
 %   \end{syntax}
 %   Creates a new constant \meta{integer} or raises an error if the name
 %   is already taken. The value of the \meta{integer} is set
-%   globally to the \meta{integer expression}.
+%   globally to the \meta{int expr}.
 % \end{function}
 %
 % \begin{function}{\int_zero:N, \int_zero:c, \int_gzero:N, \int_gzero:c}
@@ -274,9 +324,9 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\int_add:Nn, \int_add:cn, \int_gadd:Nn, \int_gadd:cn}
 %   \begin{syntax}
-%     \cs{int_add:Nn} \meta{integer} \Arg{integer expression}
+%     \cs{int_add:Nn} \meta{integer} \Arg{int expr}
 %   \end{syntax}
-%   Adds the result of the \meta{integer expression} to the current
+%   Adds the result of the \meta{int expr} to the current
 %   content of the \meta{integer}.
 % \end{function}
 %
@@ -297,9 +347,9 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\int_set:Nn, \int_set:cn, \int_gset:Nn, \int_gset:cn}
 %   \begin{syntax}
-%     \cs{int_set:Nn} \meta{integer} \Arg{integer expression}
+%     \cs{int_set:Nn} \meta{integer} \Arg{int expr}
 %   \end{syntax}
-%   Sets \meta{integer} to the value of \meta{integer expression},
+%   Sets \meta{integer} to the value of \meta{int expr},
 %   which must evaluate to an integer (as described for
 %   \cs{int_eval:n}).
 % \end{function}
@@ -307,9 +357,9 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\int_sub:Nn, \int_sub:cn, \int_gsub:Nn, \int_gsub:cn}
 %   \begin{syntax}
-%     \cs{int_sub:Nn} \meta{integer} \Arg{integer expression}
+%     \cs{int_sub:Nn} \meta{integer} \Arg{int expr}
 %   \end{syntax}
-%   Subtracts the result of the \meta{integer expression} from the
+%   Subtracts the result of the \meta{int expr} from the
 %   current content of the \meta{integer}.
 % \end{function}
 %
@@ -334,12 +384,12 @@
 %
 % \begin{function}[EXP,pTF]{\int_compare:nNn}
 %   \begin{syntax}
-%     \cs{int_compare_p:nNn} \Arg{intexpr_1} \meta{relation} \Arg{intexpr_2} \\
+%     \cs{int_compare_p:nNn} \Arg{int expr_1} \meta{relation} \Arg{int expr_2} \\
 %     \cs{int_compare:nNnTF}
-%     ~~\Arg{intexpr_1} \meta{relation} \Arg{intexpr_2}
+%     ~~\Arg{int expr_1} \meta{relation} \Arg{int expr_2}
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   This function first evaluates each of the \meta{integer expressions}
+%   This function first evaluates each of the \meta{int expr}s
 %   as described for \cs{int_eval:n}. The two results are then
 %   compared using the \meta{relation}:
 %   \begin{center}
@@ -357,28 +407,28 @@
 %   \begin{syntax}
 %     \cs{int_compare_p:n} \\
 %     ~~\{ \\
-%     ~~~~\meta{intexpr_1} \meta{relation_1} \\
+%     ~~~~\meta{int expr_1} \meta{relation_1} \\
 %     ~~~~\ldots{} \\
-%     ~~~~\meta{intexpr_N} \meta{relation_N} \\
-%     ~~~~\meta{intexpr_{N+1}} \\
+%     ~~~~\meta{int expr_N} \meta{relation_N} \\
+%     ~~~~\meta{int expr_{N+1}} \\
 %     ~~\} \\
 %     \cs{int_compare:nTF}
 %     ~~\{ \\
-%     ~~~~\meta{intexpr_1} \meta{relation_1} \\
+%     ~~~~\meta{int expr_1} \meta{relation_1} \\
 %     ~~~~\ldots{} \\
-%     ~~~~\meta{intexpr_N} \meta{relation_N} \\
-%     ~~~~\meta{intexpr_{N+1}} \\
+%     ~~~~\meta{int expr_N} \meta{relation_N} \\
+%     ~~~~\meta{int expr_{N+1}} \\
 %     ~~\} \\
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   This function evaluates the \meta{integer expressions} as described
+%   This function evaluates the \meta{int expr}s as described
 %   for \cs{int_eval:n} and compares consecutive result using the
-%   corresponding \meta{relation}, namely it compares \meta{intexpr_1}
-%   and \meta{intexpr_2} using the \meta{relation_1}, then
-%   \meta{intexpr_2} and \meta{intexpr_3} using the \meta{relation_2},
-%   until finally comparing \meta{intexpr_N} and \meta{intexpr_{N+1}}
+%   corresponding \meta{relation}, namely it compares \meta{int expr_1}
+%   and \meta{int expr_2} using the \meta{relation_1}, then
+%   \meta{int expr_2} and \meta{int expr_3} using the \meta{relation_2},
+%   until finally comparing \meta{int expr_N} and \meta{int expr_{N+1}}
 %   using the \meta{relation_N}.  The test yields \texttt{true} if all
-%   comparisons are \texttt{true}.  Each \meta{integer expression} is
+%   comparisons are \texttt{true}.  Each \meta{int expr} is
 %   evaluated only once, and the evaluation is lazy, in the sense that
 %   if one comparison is \texttt{false}, then no other \meta{integer
 %     expression} is evaluated and no other comparison is performed.
@@ -399,19 +449,19 @@
 %
 % \begin{function}[added = 2013-07-24, EXP, noTF]{\int_case:nn}
 %   \begin{syntax}
-%     \cs{int_case:nnTF} \Arg{test integer expression} \\
+%     \cs{int_case:nnTF} \Arg{test int expr} \\
 %     ~~|{| \\
-%     ~~~~\Arg{intexpr case_1} \Arg{code case_1} \\
-%     ~~~~\Arg{intexpr case_2} \Arg{code case_2} \\
+%     ~~~~\Arg{int expr case_1} \Arg{code case_1} \\
+%     ~~~~\Arg{int expr case_2} \Arg{code case_2} \\
 %     ~~~~\ldots \\
-%     ~~~~\Arg{intexpr case_n} \Arg{code case_n} \\
+%     ~~~~\Arg{int expr case_n} \Arg{code case_n} \\
 %     ~~|}| \\
 %     ~~\Arg{true code}
 %     ~~\Arg{false code}
 %   \end{syntax}
-%   This function evaluates the \meta{test integer expression} and
+%   This function evaluates the \meta{test int expr} and
 %   compares this in turn to each of the
-%   \meta{integer expression cases}. If the two are equal then the
+%   \meta{int expr cases}. If the two are equal then the
 %   associated \meta{code} is left in the input stream
 %   and other cases are discarded. If any of the
 %   cases are matched, the \meta{true code} is also inserted into the
@@ -434,11 +484,11 @@
 %
 % \begin{function}[EXP,pTF]{\int_if_even:n, \int_if_odd:n}
 %   \begin{syntax}
-%     \cs{int_if_odd_p:n} \Arg{integer expression}
-%     \cs{int_if_odd:nTF} \Arg{integer expression}
+%     \cs{int_if_odd_p:n} \Arg{int expr}
+%     \cs{int_if_odd:nTF} \Arg{int expr}
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   This function first evaluates the \meta{integer expression}
+%   This function first evaluates the \meta{int expr}
 %   as described for \cs{int_eval:n}. It then evaluates if this
 %   is odd or even, as appropriate.
 % \end{function}
@@ -447,11 +497,11 @@
 %
 % \begin{function}[rEXP]{\int_do_until:nNnn}
 %   \begin{syntax}
-%      \cs{int_do_until:nNnn} \Arg{intexpr_1} \meta{relation} \Arg{intexpr_2} \Arg{code}
+%      \cs{int_do_until:nNnn} \Arg{int expr_1} \meta{relation} \Arg{int expr_2} \Arg{code}
 %   \end{syntax}
 %   Places the \meta{code} in the input stream for \TeX{} to process, and
 %   then evaluates the relationship between the two
-%   \meta{integer expressions} as described for \cs{int_compare:nNnTF}.
+%   \meta{int expr}s as described for \cs{int_compare:nNnTF}.
 %   If the test is \texttt{false} then the \meta{code} is inserted
 %   into the input stream again and a loop occurs until the
 %   \meta{relation} is \texttt{true}.
@@ -459,11 +509,11 @@
 %
 % \begin{function}[rEXP]{\int_do_while:nNnn}
 %   \begin{syntax}
-%      \cs{int_do_while:nNnn} \Arg{intexpr_1} \meta{relation} \Arg{intexpr_2} \Arg{code}
+%      \cs{int_do_while:nNnn} \Arg{int expr_1} \meta{relation} \Arg{int expr_2} \Arg{code}
 %   \end{syntax}
 %   Places the \meta{code} in the input stream for \TeX{} to process, and
 %   then evaluates the relationship between the two
-%   \meta{integer expressions} as described for \cs{int_compare:nNnTF}.
+%   \meta{int expr}s as described for \cs{int_compare:nNnTF}.
 %   If the test is \texttt{true} then the \meta{code} is inserted
 %   into the input stream again and a loop occurs until the
 %   \meta{relation} is \texttt{false}.
@@ -471,9 +521,9 @@
 %
 % \begin{function}[rEXP]{\int_until_do:nNnn}
 %   \begin{syntax}
-%      \cs{int_until_do:nNnn} \Arg{intexpr_1} \meta{relation} \Arg{intexpr_2} \Arg{code}
+%      \cs{int_until_do:nNnn} \Arg{int expr_1} \meta{relation} \Arg{int expr_2} \Arg{code}
 %   \end{syntax}
-%   Evaluates the relationship between the two \meta{integer expressions}
+%   Evaluates the relationship between the two \meta{int expr}s
 %   as described for \cs{int_compare:nNnTF}, and then places the
 %   \meta{code} in the input stream if the \meta{relation} is
 %   \texttt{false}. After the \meta{code} has been processed by \TeX{} the
@@ -483,9 +533,9 @@
 %
 % \begin{function}[rEXP]{\int_while_do:nNnn}
 %   \begin{syntax}
-%      \cs{int_while_do:nNnn} \Arg{intexpr_1} \meta{relation} \Arg{intexpr_2} \Arg{code}
+%      \cs{int_while_do:nNnn} \Arg{int expr_1} \meta{relation} \Arg{int expr_2} \Arg{code}
 %   \end{syntax}
-%   Evaluates the relationship between the two \meta{integer expressions}
+%   Evaluates the relationship between the two \meta{int expr}s
 %   as described for \cs{int_compare:nNnTF}, and then places the
 %   \meta{code} in the input stream if the \meta{relation} is
 %   \texttt{true}. After the \meta{code} has been processed by \TeX{} the
@@ -628,17 +678,17 @@
 %
 % \begin{function}[updated = 2011-10-22, EXP]{\int_to_arabic:n}
 %   \begin{syntax}
-%     \cs{int_to_arabic:n} \Arg{integer expression}
+%     \cs{int_to_arabic:n} \Arg{int expr}
 %   \end{syntax}
-%   Places the value of the \meta{integer expression} in the input
+%   Places the value of the \meta{int expr} in the input
 %   stream as digits, with category code $12$ (other).
 % \end{function}
 %
 % \begin{function}[updated = 2011-09-17, EXP]{\int_to_alph:n, \int_to_Alph:n}
 %   \begin{syntax}
-%     \cs{int_to_alph:n} \Arg{integer expression}
+%     \cs{int_to_alph:n} \Arg{int expr}
 %   \end{syntax}
-%   Evaluates the \meta{integer expression} and converts the result
+%   Evaluates the \meta{int expr} and converts the result
 %   into a series of letters, which are then left in the input stream.
 %   The conversion rule uses the $26$ letters of the English
 %   alphabet, in order, adding letters when necessary to increase the total
@@ -665,11 +715,11 @@
 % \begin{function}[updated = 2011-09-17, EXP]{\int_to_symbols:nnn}
 %   \begin{syntax}
 %     \cs{int_to_symbols:nnn}
-%     ~~\Arg{integer expression} \Arg{total symbols}
+%     ~~\Arg{int expr} \Arg{total symbols}
 %     ~~\Arg{value to symbol mapping}
 %   \end{syntax}
 %   This is the low-level function for conversion of an
-%   \meta{integer expression} into a symbolic form (often
+%   \meta{int expr} into a symbolic form (often
 %   letters). The \meta{total symbols} available should be given
 %   as an integer expression. Values are actually converted to symbols
 %   according to the \meta{value to symbol mapping}. This should be given
@@ -692,17 +742,17 @@
 %
 % \begin{function}[added = 2014-02-11, EXP]{\int_to_bin:n}
 %   \begin{syntax}
-%     \cs{int_to_bin:n} \Arg{integer expression}
+%     \cs{int_to_bin:n} \Arg{int expr}
 %   \end{syntax}
-%   Calculates the value of the \meta{integer expression} and places
+%   Calculates the value of the \meta{int expr} and places
 %   the binary representation of the result in the input stream.
 % \end{function}
 %
 % \begin{function}[added = 2014-02-11, EXP]{\int_to_hex:n, \int_to_Hex:n}
 %   \begin{syntax}
-%     \cs{int_to_hex:n} \Arg{integer expression}
+%     \cs{int_to_hex:n} \Arg{int expr}
 %   \end{syntax}
-%   Calculates the value of the \meta{integer expression} and places
+%   Calculates the value of the \meta{int expr} and places
 %   the hexadecimal (base~$16$) representation of the result in the
 %   input stream. Letters are used for digits beyond~$9$: lower
 %   case letters for \cs{int_to_hex:n} and upper case ones for
@@ -713,9 +763,9 @@
 %
 % \begin{function}[added = 2014-02-11, EXP]{\int_to_oct:n}
 %   \begin{syntax}
-%     \cs{int_to_oct:n} \Arg{integer expression}
+%     \cs{int_to_oct:n} \Arg{int expr}
 %   \end{syntax}
-%   Calculates the value of the \meta{integer expression} and places
+%   Calculates the value of the \meta{int expr} and places
 %   the octal (base~$8$) representation of the result in the input
 %   stream.
 %   The resulting tokens are digits with category code $12$ (other) and
@@ -725,9 +775,9 @@
 % \begin{function}[updated = 2014-02-11, EXP]
 %   {\int_to_base:nn, \int_to_Base:nn}
 %   \begin{syntax}
-%     \cs{int_to_base:nn} \Arg{integer expression} \Arg{base}
+%     \cs{int_to_base:nn} \Arg{int expr} \Arg{base}
 %   \end{syntax}
-%   Calculates the value of the \meta{integer expression} and
+%   Calculates the value of the \meta{int expr} and
 %   converts it into the appropriate representation in the \meta{base};
 %   the later may be given as an integer expression. For bases greater
 %   than $10$ the higher \enquote{digits} are represented by
@@ -744,9 +794,9 @@
 %
 % \begin{function}[updated = 2011-10-22, rEXP]{\int_to_roman:n, \int_to_Roman:n}
 %   \begin{syntax}
-%     \cs{int_to_roman:n} \Arg{integer expression}
+%     \cs{int_to_roman:n} \Arg{int expr}
 %   \end{syntax}
-%   Places the value of the \meta{integer expression} in the input
+%   Places the value of the \meta{int expr} in the input
 %   stream as Roman numerals, either lower case (\cs{int_to_roman:n}) or
 %   upper case (\cs{int_to_Roman:n}).  If the value is negative or zero,
 %   the output is empty.  The Roman numerals are letters with category
@@ -843,19 +893,19 @@
 %
 % \begin{function}[EXP, added = 2016-12-06, updated = 2018-04-27]{\int_rand:nn}
 %   \begin{syntax}
-%     \cs{int_rand:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{int_rand:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
-%   Evaluates the two \meta{integer expressions} and produces a
+%   Evaluates the two \meta{int expr}s and produces a
 %   pseudo-random number between the two (with bounds included).
 %   This is not available in older versions of \XeTeX{}.
 % \end{function}
 %
 % \begin{function}[EXP, added = 2018-05-05]{\int_rand:n}
 %   \begin{syntax}
-%     \cs{int_rand:n} \Arg{intexpr}
+%     \cs{int_rand:n} \Arg{int expr}
 %   \end{syntax}
-%   Evaluates the \meta{integer expression} then produces a
-%   pseudo-random number between $1$ and the \meta{intexpr} (included).
+%   Evaluates the \meta{int expr} then produces a
+%   pseudo-random number between $1$ and the \meta{int expr} (included).
 %   This is not available in older versions of \XeTeX{}.
 % \end{function}
 %
@@ -870,9 +920,9 @@
 %
 % \begin{function}[added = 2011-11-22, updated = 2015-08-07]{\int_show:n}
 %   \begin{syntax}
-%     \cs{int_show:n} \Arg{integer expression}
+%     \cs{int_show:n} \Arg{int expr}
 %   \end{syntax}
-%   Displays the result of evaluating the \meta{integer expression}
+%   Displays the result of evaluating the \meta{int expr}
 %   on the terminal.
 % \end{function}
 %
@@ -885,9 +935,9 @@
 %
 % \begin{function}[added = 2014-08-22, updated = 2015-08-07]{\int_log:n}
 %   \begin{syntax}
-%     \cs{int_log:n} \Arg{integer expression}
+%     \cs{int_log:n} \Arg{int expr}
 %   \end{syntax}
-%   Writes the result of evaluating the \meta{integer expression}
+%   Writes the result of evaluating the \meta{int expr}
 %   in the log file.
 % \end{function}
 %

--- a/l3kernel/l3intarray.dtx
+++ b/l3kernel/l3intarray.dtx
@@ -99,7 +99,7 @@
 % \begin{function}[added = 2018-05-04]
 %   {\intarray_const_from_clist:Nn, \intarray_const_from_clist:cn}
 %   \begin{syntax}
-%     \cs{intarray_const_from_clist:Nn} \meta{intarray~var} \meta{intexpr clist}
+%     \cs{intarray_const_from_clist:Nn} \meta{intarray~var} \meta{int expr clist}
 %   \end{syntax}
 %   Creates a new constant \meta{integer array variable} or raises an
 %   error if the name is already taken.  The \meta{integer array

--- a/l3kernel/l3skip.dtx
+++ b/l3kernel/l3skip.dtx
@@ -60,6 +60,11 @@
 % length variables, but for clarity the functions are grouped by variable
 % type.
 %
+% Many functions take
+% \emph{dimension expressions} (\enquote{\meta{dim expr}}) or
+% \emph{skip expressions} (\enquote{\meta{skip expr}}) as arguments.
+%
+%
 % \section{Creating and initialising \texttt{dim} variables}
 %
 % \begin{function}{\dim_new:N, \dim_new:c}
@@ -73,11 +78,11 @@
 %
 % \begin{function}[added = 2012-03-05]{\dim_const:Nn, \dim_const:cn}
 %   \begin{syntax}
-%     \cs{dim_const:Nn} \meta{dimension} \Arg{dimension expression}
+%     \cs{dim_const:Nn} \meta{dimension} \Arg{dim expr}
 %   \end{syntax}
 %   Creates a new constant \meta{dimension} or raises an error if the
 %   name is already taken. The value of the \meta{dimension} is set
-%   globally to the \meta{dimension expression}.
+%   globally to the \meta{dim expr}.
 % \end{function}
 %
 % \begin{function}{\dim_zero:N, \dim_zero:c, \dim_gzero:N, \dim_gzero:c}
@@ -112,18 +117,18 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\dim_add:Nn, \dim_add:cn, \dim_gadd:Nn, \dim_gadd:cn}
 %   \begin{syntax}
-%     \cs{dim_add:Nn} \meta{dimension} \Arg{dimension expression}
+%     \cs{dim_add:Nn} \meta{dimension} \Arg{dim expr}
 %   \end{syntax}
-%   Adds the result of the \meta{dimension expression} to the current
+%   Adds the result of the \meta{dim expr} to the current
 %   content of the \meta{dimension}.
 % \end{function}
 %
 % \begin{function}[updated = 2011-10-22]
 %   {\dim_set:Nn, \dim_set:cn, \dim_gset:Nn, \dim_gset:cn}
 %   \begin{syntax}
-%     \cs{dim_set:Nn} \meta{dimension} \Arg{dimension expression}
+%     \cs{dim_set:Nn} \meta{dimension} \Arg{dim expr}
 %   \end{syntax}
-%   Sets \meta{dimension} to the value of \meta{dimension expression}, which
+%   Sets \meta{dimension} to the value of \meta{dim expr}, which
 %   must evaluate to a length with units.
 % \end{function}
 %
@@ -142,9 +147,9 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\dim_sub:Nn, \dim_sub:cn, \dim_gsub:Nn, \dim_gsub:cn}
 %   \begin{syntax}
-%     \cs{dim_sub:Nn} \meta{dimension} \Arg{dimension expression}
+%     \cs{dim_sub:Nn} \meta{dimension} \Arg{dim expr}
 %   \end{syntax}
-%   Subtracts the result of the \meta{dimension expression} from the
+%   Subtracts the result of the \meta{dim expr} from the
 %   current content of the \meta{dimension}.
 % \end{function}
 %
@@ -152,29 +157,29 @@
 %
 % \begin{function}[updated = 2012-09-26, EXP]{\dim_abs:n}
 %   \begin{syntax}
-%     \cs{dim_abs:n} \Arg{dimexpr}
+%     \cs{dim_abs:n} \Arg{dim expr}
 %   \end{syntax}
-%   Converts the \meta{dimexpr} to its absolute value, leaving the result
+%   Converts the \meta{dim expr} to its absolute value, leaving the result
 %   in the input stream as a \meta{dimension denotation}.
 % \end{function}
 %
 % \begin{function}[added = 2012-09-09, updated = 2012-09-26, EXP]
 %   {\dim_max:nn, \dim_min:nn}
 %   \begin{syntax}
-%     \cs{dim_max:nn} \Arg{dimexpr_1} \Arg{dimexpr_2}
-%     \cs{dim_min:nn} \Arg{dimexpr_1} \Arg{dimexpr_2}
+%     \cs{dim_max:nn} \Arg{dim expr_1} \Arg{dim expr_2}
+%     \cs{dim_min:nn} \Arg{dim expr_1} \Arg{dim expr_2}
 %   \end{syntax}
-%   Evaluates the two \meta{dimension expressions} and leaves either the
+%   Evaluates the two \meta{dim exprs} and leaves either the
 %   maximum or minimum value in the input stream as appropriate, as a
 %   \meta{dimension denotation}.
 % \end{function}
 %
 % \begin{function}[updated = 2011-10-22, rEXP]{\dim_ratio:nn}
 %   \begin{syntax}
-%     \cs{dim_ratio:nn} \Arg{dimexpr_1} \Arg{dimexpr_2}
+%     \cs{dim_ratio:nn} \Arg{dim expr_1} \Arg{dim expr_2}
 %   \end{syntax}
-%   Parses the two \meta{dimension expressions} and converts the ratio of
-%   the two to a form suitable for use inside a \meta{dimension expression}.
+%   Parses the two \meta{dim exprs} and converts the ratio of
+%   the two to a form suitable for use inside a \meta{dim expr}.
 %   This ratio is then left in the input stream, allowing syntax such as
 %   \begin{verbatim}
 %     \dim_set:Nn \l_my_dim
@@ -194,12 +199,12 @@
 %
 % \begin{function}[EXP,pTF]{\dim_compare:nNn}
 %   \begin{syntax}
-%     \cs{dim_compare_p:nNn} \Arg{dimexpr_1} \meta{relation} \Arg{dimexpr_2} \\
+%     \cs{dim_compare_p:nNn} \Arg{dim expr_1} \meta{relation} \Arg{dim expr_2} \\
 %     \cs{dim_compare:nNnTF}
-%     ~~\Arg{dimexpr_1} \meta{relation} \Arg{dimexpr_2}
+%     ~~\Arg{dim expr_1} \meta{relation} \Arg{dim expr_2}
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   This function first evaluates each of the \meta{dimension expressions}
+%   This function first evaluates each of the \meta{dim exprs}
 %   as described for \cs{dim_eval:n}. The two results are then
 %   compared using the \meta{relation}:
 %   \begin{center}
@@ -217,31 +222,31 @@
 %   \begin{syntax}
 %     \cs{dim_compare_p:n} \\
 %     ~~\{ \\
-%     ~~~~\meta{dimexpr_1} \meta{relation_1} \\
+%     ~~~~\meta{dim expr_1} \meta{relation_1} \\
 %     ~~~~\ldots{} \\
-%     ~~~~\meta{dimexpr_N} \meta{relation_N} \\
-%     ~~~~\meta{dimexpr_{N+1}} \\
+%     ~~~~\meta{dim expr_N} \meta{relation_N} \\
+%     ~~~~\meta{dim expr_{N+1}} \\
 %     ~~\} \\
 %     \cs{dim_compare:nTF}
 %     ~~\{ \\
-%     ~~~~\meta{dimexpr_1} \meta{relation_1} \\
+%     ~~~~\meta{dim expr_1} \meta{relation_1} \\
 %     ~~~~\ldots{} \\
-%     ~~~~\meta{dimexpr_N} \meta{relation_N} \\
-%     ~~~~\meta{dimexpr_{N+1}} \\
+%     ~~~~\meta{dim expr_N} \meta{relation_N} \\
+%     ~~~~\meta{dim expr_{N+1}} \\
 %     ~~\} \\
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   This function evaluates the \meta{dimension expressions} as
+%   This function evaluates the \meta{dim exprs} as
 %   described for \cs{dim_eval:n} and compares consecutive result using
 %   the corresponding \meta{relation}, namely it compares
-%   \meta{dimexpr_1} and \meta{dimexpr_2} using the \meta{relation_1},
-%   then \meta{dimexpr_2} and \meta{dimexpr_3} using the
-%   \meta{relation_2}, until finally comparing \meta{dimexpr_N} and
-%   \meta{dimexpr_{N+1}} using the \meta{relation_N}.  The test yields
+%   \meta{dim expr_1} and \meta{dim expr_2} using the \meta{relation_1},
+%   then \meta{dim expr_2} and \meta{dim expr_3} using the
+%   \meta{relation_2}, until finally comparing \meta{dim expr_N} and
+%   \meta{dim expr_{N+1}} using the \meta{relation_N}.  The test yields
 %   \texttt{true} if all comparisons are \texttt{true}.  Each
-%   \meta{dimension expression} is evaluated only once, and the
+%   \meta{dim expr} is evaluated only once, and the
 %   evaluation is lazy, in the sense that if one comparison is
-%   \texttt{false}, then no other \meta{dimension expression} is
+%   \texttt{false}, then no other \meta{dim expr} is
 %   evaluated and no other comparison is performed.  The
 %   \meta{relations} can be any of the following:
 %   \begin{center}
@@ -260,19 +265,19 @@
 %
 % \begin{function}[added = 2013-07-24, EXP, noTF]{\dim_case:nn}
 %   \begin{syntax}
-%     \cs{dim_case:nnTF} \Arg{test dimension expression} \\
+%     \cs{dim_case:nnTF} \Arg{test dim expr} \\
 %     ~~|{| \\
-%     ~~~~\Arg{dimexpr case_1} \Arg{code case_1} \\
-%     ~~~~\Arg{dimexpr case_2} \Arg{code case_2} \\
+%     ~~~~\Arg{dim expr case_1} \Arg{code case_1} \\
+%     ~~~~\Arg{dim expr case_2} \Arg{code case_2} \\
 %     ~~~~\ldots \\
-%     ~~~~\Arg{dimexpr case_n} \Arg{code case_n} \\
+%     ~~~~\Arg{dim expr case_n} \Arg{code case_n} \\
 %     ~~|}| \\
 %     ~~\Arg{true code}
 %     ~~\Arg{false code}
 %   \end{syntax}
-%   This function evaluates the \meta{test dimension expression} and
+%   This function evaluates the \meta{test dim expr} and
 %   compares this in turn to each of the
-%   \meta{dimension expression cases}. If the two are equal then the
+%   \meta{dim expr cases}. If the two are equal then the
 %   associated \meta{code} is left in the input stream
 %   and other cases are discarded. If any of the
 %   cases are matched, the \meta{true code} is also inserted into the
@@ -298,11 +303,11 @@
 %
 % \begin{function}[rEXP]{\dim_do_until:nNnn}
 %   \begin{syntax}
-%      \cs{dim_do_until:nNnn} \Arg{dimexpr_1} \meta{relation} \Arg{dimexpr_2} \Arg{code}
+%      \cs{dim_do_until:nNnn} \Arg{dim expr_1} \meta{relation} \Arg{dim expr_2} \Arg{code}
 %   \end{syntax}
 %   Places the \meta{code} in the input stream for \TeX{} to process, and
 %   then evaluates the relationship between the two
-%   \meta{dimension expressions} as described for \cs{dim_compare:nNnTF}.
+%   \meta{dim exprs} as described for \cs{dim_compare:nNnTF}.
 %   If the test is \texttt{false} then the \meta{code} is inserted
 %   into the input stream again and a loop occurs until the
 %   \meta{relation} is \texttt{true}.
@@ -310,11 +315,11 @@
 %
 % \begin{function}[rEXP]{\dim_do_while:nNnn}
 %   \begin{syntax}
-%      \cs{dim_do_while:nNnn} \Arg{dimexpr_1} \meta{relation} \Arg{dimexpr_2} \Arg{code}
+%      \cs{dim_do_while:nNnn} \Arg{dim expr_1} \meta{relation} \Arg{dim expr_2} \Arg{code}
 %   \end{syntax}
 %   Places the \meta{code} in the input stream for \TeX{} to process, and
 %   then evaluates the relationship between the two
-%   \meta{dimension expressions} as described for \cs{dim_compare:nNnTF}.
+%   \meta{dim exprs} as described for \cs{dim_compare:nNnTF}.
 %   If the test is \texttt{true} then the \meta{code} is inserted
 %   into the input stream again and a loop occurs until the
 %   \meta{relation} is \texttt{false}.
@@ -322,9 +327,9 @@
 %
 % \begin{function}[rEXP]{\dim_until_do:nNnn}
 %   \begin{syntax}
-%      \cs{dim_until_do:nNnn} \Arg{dimexpr_1} \meta{relation} \Arg{dimexpr_2} \Arg{code}
+%      \cs{dim_until_do:nNnn} \Arg{dim expr_1} \meta{relation} \Arg{dim expr_2} \Arg{code}
 %   \end{syntax}
-%   Evaluates the relationship between the two \meta{dimension expressions}
+%   Evaluates the relationship between the two \meta{dim exprs}
 %   as described for \cs{dim_compare:nNnTF}, and then places the
 %   \meta{code} in the input stream if the \meta{relation} is
 %   \texttt{false}. After the \meta{code} has been processed by \TeX{} the
@@ -334,9 +339,9 @@
 %
 % \begin{function}[rEXP]{\dim_while_do:nNnn}
 %   \begin{syntax}
-%      \cs{dim_while_do:nNnn} \Arg{dimexpr_1} \meta{relation} \Arg{dimexpr_2} \Arg{code}
+%      \cs{dim_while_do:nNnn} \Arg{dim expr_1} \meta{relation} \Arg{dim expr_2} \Arg{code}
 %   \end{syntax}
-%   Evaluates the relationship between the two \meta{dimension expressions}
+%   Evaluates the relationship between the two \meta{dim exprs}
 %   as described for \cs{dim_compare:nNnTF}, and then places the
 %   \meta{code} in the input stream if the \meta{relation} is
 %   \texttt{true}. After the \meta{code} has been processed by \TeX{} the
@@ -444,9 +449,9 @@
 %
 % \begin{function}[updated = 2011-10-22, EXP]{\dim_eval:n}
 %   \begin{syntax}
-%     \cs{dim_eval:n} \Arg{dimension expression}
+%     \cs{dim_eval:n} \Arg{dim expr}
 %   \end{syntax}
-%   Evaluates the \meta{dimension expression}, expanding any
+%   Evaluates the \meta{dim expr}, expanding any
 %   dimensions and token list variables within the \meta{expression}
 %   to their content (without requiring \cs{dim_use:N}/\cs{tl_use:N})
 %   and applying the standard mathematical rules. The result of the
@@ -459,9 +464,9 @@
 %
 % \begin{function}[EXP, added = 2018-11-03]{\dim_sign:n}
 %   \begin{syntax}
-%     \cs{dim_sign:n} \Arg{dimexpr}
+%     \cs{dim_sign:n} \Arg{dim expr}
 %   \end{syntax}
-%   Evaluates the \meta{dimexpr} then leaves $1$ or $0$ or $-1$ in the
+%   Evaluates the \meta{dim expr} then leaves $1$ or $0$ or $-1$ in the
 %   input stream according to the sign of the result.
 % \end{function}
 %
@@ -482,9 +487,9 @@
 %
 % \begin{function}[added = 2014-07-15, EXP]{\dim_to_decimal:n}
 %   \begin{syntax}
-%     \cs{dim_to_decimal:n} \Arg{dimexpr}
+%     \cs{dim_to_decimal:n} \Arg{dim expr}
 %   \end{syntax}
-%   Evaluates the \meta{dimension expression}, and leaves the result,
+%   Evaluates the \meta{dim expr}, and leaves the result,
 %   expressed in points (\texttt{pt}) in the input stream, with \emph{no
 %     units}.  The result is rounded by \TeX{} to four or five decimal
 %   places.  If the decimal part of the result is zero, it is omitted,
@@ -500,9 +505,9 @@
 %
 % \begin{function}[added = 2014-07-15, EXP]{\dim_to_decimal_in_bp:n}
 %   \begin{syntax}
-%     \cs{dim_to_decimal_in_bp:n} \Arg{dimexpr}
+%     \cs{dim_to_decimal_in_bp:n} \Arg{dim expr}
 %   \end{syntax}
-%   Evaluates the \meta{dimension expression}, and leaves the result,
+%   Evaluates the \meta{dim expr}, and leaves the result,
 %   expressed in big points (\texttt{bp}) in the input stream, with \emph{no
 %   units}.  The result is rounded by \TeX{} to four or five decimal
 %   places.  If the decimal part of the result is zero, it is omitted,
@@ -518,9 +523,9 @@
 %
 % \begin{function}[added = 2015-05-18, EXP]{\dim_to_decimal_in_sp:n}
 %   \begin{syntax}
-%     \cs{dim_to_decimal_in_sp:n} \Arg{dimexpr}
+%     \cs{dim_to_decimal_in_sp:n} \Arg{dim expr}
 %   \end{syntax}
-%   Evaluates the \meta{dimension expression}, and leaves the result,
+%   Evaluates the \meta{dim expr}, and leaves the result,
 %   expressed in scaled points (\texttt{sp}) in the input stream, with \emph{no
 %   units}.  The result is necessarily an integer.
 % \end{function}
@@ -528,10 +533,10 @@
 % \begin{function}[added = 2014-07-15, EXP]
 %   {\dim_to_decimal_in_unit:nn}
 %   \begin{syntax}
-%     \cs{dim_to_decimal_in_unit:nn} \Arg{dimexpr_1} \Arg{dimexpr_2}
+%     \cs{dim_to_decimal_in_unit:nn} \Arg{dim expr_1} \Arg{dim expr_2}
 %   \end{syntax}
-%   Evaluates the \meta{dimension expressions}, and leaves the value of
-%   \meta{dimexpr_1}, expressed in a unit given by \meta{dimexpr_2}, in
+%   Evaluates the \meta{dim exprs}, and leaves the value of
+%   \meta{dim expr_1}, expressed in a unit given by \meta{dim expr_2}, in
 %   the input stream.  The result is a decimal number, rounded by \TeX{}
 %   to four or five decimal places.  If the decimal part of the result
 %   is zero, it is omitted, together with the decimal marker.
@@ -554,10 +559,10 @@
 % \begin{function}[EXP, added = 2012-05-08, tested = m3fp-convert002]
 %   {\dim_to_fp:n}
 %   \begin{syntax}
-%     \cs{dim_to_fp:n} \Arg{dimexpr}
+%     \cs{dim_to_fp:n} \Arg{dim expr}
 %   \end{syntax}
 %   Expands to an internal floating point number equal to the value of
-%   the \meta{dimexpr} in \texttt{pt}.  Since dimension expressions are
+%   the \meta{dim expr} in \texttt{pt}.  Since dimension expressions are
 %   evaluated much faster than their floating point equivalent,
 %   \cs{dim_to_fp:n} can be used to speed up parts of a computation
 %   where a low precision and a smaller range are acceptable.
@@ -574,9 +579,9 @@
 %
 % \begin{function}[added = 2011-11-22, updated = 2015-08-07]{\dim_show:n}
 %   \begin{syntax}
-%     \cs{dim_show:n} \Arg{dimension expression}
+%     \cs{dim_show:n} \Arg{dim expr}
 %    \end{syntax}
-%   Displays the result of evaluating the \meta{dimension expression}
+%   Displays the result of evaluating the \meta{dim expr}
 %   on the terminal.
 % \end{function}
 %
@@ -589,9 +594,9 @@
 %
 % \begin{function}[added = 2014-08-22, updated = 2015-08-07]{\dim_log:n}
 %   \begin{syntax}
-%     \cs{dim_log:n} \Arg{dimension expression}
+%     \cs{dim_log:n} \Arg{dim expr}
 %    \end{syntax}
-%   Writes the result of evaluating the \meta{dimension expression}
+%   Writes the result of evaluating the \meta{dim expr}
 %   in the log file.
 % \end{function}
 %
@@ -636,11 +641,11 @@
 %
 % \begin{function}[added = 2012-03-05]{\skip_const:Nn, \skip_const:cn}
 %   \begin{syntax}
-%     \cs{skip_const:Nn} \meta{skip} \Arg{skip expression}
+%     \cs{skip_const:Nn} \meta{skip} \Arg{skip expr}
 %   \end{syntax}
 %   Creates a new constant \meta{skip} or raises an error if the
 %   name is already taken. The value of the \meta{skip} is set
-%   globally to the \meta{skip expression}.
+%   globally to the \meta{skip expr}.
 % \end{function}
 %
 % \begin{function}{\skip_zero:N, \skip_zero:c, \skip_gzero:N, \skip_gzero:c}
@@ -676,18 +681,18 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\skip_add:Nn, \skip_add:cn, \skip_gadd:Nn, \skip_gadd:cn}
 %   \begin{syntax}
-%     \cs{skip_add:Nn} \meta{skip} \Arg{skip expression}
+%     \cs{skip_add:Nn} \meta{skip} \Arg{skip expr}
 %   \end{syntax}
-%   Adds the result of the \meta{skip expression} to the current
+%   Adds the result of the \meta{skip expr} to the current
 %   content of the \meta{skip}.
 % \end{function}
 %
 % \begin{function}[updated = 2011-10-22]
 %   {\skip_set:Nn, \skip_set:cn, \skip_gset:Nn, \skip_gset:cn}
 %   \begin{syntax}
-%     \cs{skip_set:Nn} \meta{skip} \Arg{skip expression}
+%     \cs{skip_set:Nn} \meta{skip} \Arg{skip expr}
 %   \end{syntax}
-%   Sets \meta{skip} to the value of \meta{skip expression}, which
+%   Sets \meta{skip} to the value of \meta{skip expr}, which
 %   must evaluate to a length with units and may include a rubber
 %   component (for example |1 cm plus 0.5 cm|.
 % \end{function}
@@ -706,9 +711,9 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\skip_sub:Nn, \skip_sub:cn, \skip_gsub:Nn, \skip_gsub:cn}
 %   \begin{syntax}
-%     \cs{skip_sub:Nn} \meta{skip} \Arg{skip expression}
+%     \cs{skip_sub:Nn} \meta{skip} \Arg{skip expr}
 %   \end{syntax}
-%   Subtracts the result of the \meta{skip expression} from the
+%   Subtracts the result of the \meta{skip expr} from the
 %   current content of the \meta{skip}.
 % \end{function}
 %
@@ -716,13 +721,13 @@
 %
 % \begin{function}[EXP,pTF]{\skip_if_eq:nn}
 %   \begin{syntax}
-%     \cs{skip_if_eq_p:nn} \Arg{skipexpr_1} \Arg{skipexpr_2}
+%     \cs{skip_if_eq_p:nn} \Arg{skip expr_1} \Arg{skip expr_2}
 %     \cs{skip_if_eq:nnTF}
-%     ~~\Arg{skipexpr_1} \Arg{skipexpr_2}
+%     ~~\Arg{skip expr_1} \Arg{skip expr_2}
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   This function first evaluates each of the
-%   \meta{skip expressions} as described for \cs{skip_eval:n}.
+%   \meta{skip exprs} as described for \cs{skip_eval:n}.
 %   The two results are then compared for exact equality,
 %   \emph{i.e.}~both the fixed and rubber components must be the same
 %   for the test to be true.
@@ -730,10 +735,10 @@
 %
 % \begin{function}[EXP, pTF, added = 2012-03-05]{\skip_if_finite:n}
 %   \begin{syntax}
-%     \cs{skip_if_finite_p:n} \Arg{skipexpr}
-%     \cs{skip_if_finite:nTF} \Arg{skipexpr} \Arg{true code} \Arg{false code}
+%     \cs{skip_if_finite_p:n} \Arg{skip expr}
+%     \cs{skip_if_finite:nTF} \Arg{skip expr} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Evaluates the \meta{skip expression} as described for \cs{skip_eval:n},
+%   Evaluates the \meta{skip expr} as described for \cs{skip_eval:n},
 %   and then tests if all of its components are finite.
 % \end{function}
 %
@@ -741,9 +746,9 @@
 %
 % \begin{function}[updated = 2011-10-22, EXP]{\skip_eval:n}
 %   \begin{syntax}
-%     \cs{skip_eval:n} \Arg{skip expression}
+%     \cs{skip_eval:n} \Arg{skip expr}
 %   \end{syntax}
-%   Evaluates the \meta{skip expression}, expanding any skips
+%   Evaluates the \meta{skip expr}, expanding any skips
 %   and token list variables within the \meta{expression}
 %   to their content (without requiring \cs{skip_use:N}/\cs{tl_use:N})
 %   and applying the standard mathematical rules. The result of the
@@ -779,9 +784,9 @@
 %
 % \begin{function}[added = 2011-11-22, updated = 2015-08-07]{\skip_show:n}
 %   \begin{syntax}
-%     \cs{skip_show:n} \Arg{skip expression}
+%     \cs{skip_show:n} \Arg{skip expr}
 %    \end{syntax}
-%   Displays the result of evaluating the \meta{skip expression}
+%   Displays the result of evaluating the \meta{skip expr}
 %   on the terminal.
 % \end{function}
 %
@@ -794,9 +799,9 @@
 %
 % \begin{function}[added = 2014-08-22, updated = 2015-08-07]{\skip_log:n}
 %   \begin{syntax}
-%     \cs{skip_log:n} \Arg{skip expression}
+%     \cs{skip_log:n} \Arg{skip expr}
 %    \end{syntax}
-%   Writes the result of evaluating the \meta{skip expression}
+%   Writes the result of evaluating the \meta{skip expr}
 %   in the log file.
 % \end{function}
 %
@@ -833,7 +838,7 @@
 %   {\skip_horizontal:N, \skip_horizontal:c, \skip_horizontal:n}
 %   \begin{syntax}
 %     \cs{skip_horizontal:N} \meta{skip}
-%     \cs{skip_horizontal:n} \Arg{skipexpr}
+%     \cs{skip_horizontal:n} \Arg{skip expr}
 %   \end{syntax}
 %   Inserts a horizontal \meta{skip} into the current list.
 %   The argument can also be a \meta{dim}.
@@ -846,7 +851,7 @@
 %   {\skip_vertical:N, \skip_vertical:c, \skip_vertical:n}
 %   \begin{syntax}
 %     \cs{skip_vertical:N} \meta{skip}
-%     \cs{skip_vertical:n} \Arg{skipexpr}
+%     \cs{skip_vertical:n} \Arg{skip expr}
 %   \end{syntax}
 %   Inserts a vertical \meta{skip} into the current list.
 %   The argument can also be a \meta{dim}.
@@ -868,11 +873,11 @@
 %
 % \begin{function}[added = 2012-03-05]{\muskip_const:Nn, \muskip_const:cn}
 %   \begin{syntax}
-%     \cs{muskip_const:Nn} \meta{muskip} \Arg{muskip expression}
+%     \cs{muskip_const:Nn} \meta{muskip} \Arg{muskip expr}
 %   \end{syntax}
 %   Creates a new constant \meta{muskip} or raises an error if the
 %   name is already taken. The value of the \meta{muskip} is set
-%   globally to the \meta{muskip expression}.
+%   globally to the \meta{muskip expr}.
 % \end{function}
 %
 % \begin{function}
@@ -912,18 +917,18 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\muskip_add:Nn, \muskip_add:cn, \muskip_gadd:Nn, \muskip_gadd:cn}
 %   \begin{syntax}
-%     \cs{muskip_add:Nn} \meta{muskip} \Arg{muskip expression}
+%     \cs{muskip_add:Nn} \meta{muskip} \Arg{muskip expr}
 %   \end{syntax}
-%   Adds the result of the \meta{muskip expression} to the current
+%   Adds the result of the \meta{muskip expr} to the current
 %   content of the \meta{muskip}.
 % \end{function}
 %
 % \begin{function}[updated = 2011-10-22]
 %   {\muskip_set:Nn, \muskip_set:cn, \muskip_gset:Nn, \muskip_gset:cn}
 %   \begin{syntax}
-%     \cs{muskip_set:Nn} \meta{muskip} \Arg{muskip expression}
+%     \cs{muskip_set:Nn} \meta{muskip} \Arg{muskip expr}
 %   \end{syntax}
-%   Sets \meta{muskip} to the value of \meta{muskip expression}, which
+%   Sets \meta{muskip} to the value of \meta{muskip expr}, which
 %   must evaluate to a math length with units and may include a rubber
 %   component (for example |1 mu plus 0.5 mu|.
 % \end{function}
@@ -945,9 +950,9 @@
 % \begin{function}[updated = 2011-10-22]
 %   {\muskip_sub:Nn, \muskip_sub:cn, \muskip_gsub:Nn, \muskip_gsub:cn}
 %   \begin{syntax}
-%     \cs{muskip_sub:Nn} \meta{muskip} \Arg{muskip expression}
+%     \cs{muskip_sub:Nn} \meta{muskip} \Arg{muskip expr}
 %   \end{syntax}
-%   Subtracts the result of the \meta{muskip expression} from the
+%   Subtracts the result of the \meta{muskip expr} from the
 %   current content of the \meta{muskip}.
 % \end{function}
 %
@@ -955,9 +960,9 @@
 %
 % \begin{function}[updated = 2011-10-22, EXP]{\muskip_eval:n}
 %   \begin{syntax}
-%     \cs{muskip_eval:n} \Arg{muskip expression}
+%     \cs{muskip_eval:n} \Arg{muskip expr}
 %   \end{syntax}
-%   Evaluates the \meta{muskip expression}, expanding any skips
+%   Evaluates the \meta{muskip expr}, expanding any skips
 %   and token list variables within the \meta{expression}
 %   to their content (without requiring \cs{muskip_use:N}/\cs{tl_use:N})
 %   and applying the standard mathematical rules. The result of the
@@ -993,9 +998,9 @@
 %
 % \begin{function}[added = 2011-11-22, updated = 2015-08-07]{\muskip_show:n}
 %   \begin{syntax}
-%     \cs{muskip_show:n} \Arg{muskip expression}
+%     \cs{muskip_show:n} \Arg{muskip expr}
 %    \end{syntax}
-%   Displays the result of evaluating the \meta{muskip expression}
+%   Displays the result of evaluating the \meta{muskip expr}
 %   on the terminal.
 % \end{function}
 %
@@ -1008,9 +1013,9 @@
 %
 % \begin{function}[added = 2014-08-22, updated = 2015-08-07]{\muskip_log:n}
 %   \begin{syntax}
-%     \cs{muskip_log:n} \Arg{muskip expression}
+%     \cs{muskip_log:n} \Arg{muskip expr}
 %    \end{syntax}
-%   Writes the result of evaluating the \meta{muskip expression}
+%   Writes the result of evaluating the \meta{muskip expr}
 %   in the log file.
 % \end{function}
 %

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -187,7 +187,7 @@
 %
 % \begin{function}[added = 2017-05-27]{\sys_gset_rand_seed:n}
 %   \begin{syntax}
-%     \cs{sys_gset_rand_seed:n} \Arg{intexpr}
+%     \cs{sys_gset_rand_seed:n} \Arg{int expr}
 %   \end{syntax}
 %   Globally sets the seed for the engine's pseudo-random number
 %   generator to the \meta{integer expression}.  This random seed

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -223,7 +223,7 @@
 %
 % \begin{function}[updated = 2015-11-11]{\char_set_catcode:nn}
 %   \begin{syntax}
-%     \cs{char_set_catcode:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{char_set_catcode:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
 %   These functions set the category code of the \meta{character} which
 %   has character code as given by the \meta{integer expression}.
@@ -254,7 +254,7 @@
 %
 % \begin{function}[updated = 2015-08-06]{\char_set_lccode:nn}
 %   \begin{syntax}
-%     \cs{char_set_lccode:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{char_set_lccode:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
 %   Sets up the behaviour of the \meta{character} when
 %   found inside \cs{text_lowercase:n}, such that \meta{character_1}
@@ -291,7 +291,7 @@
 %
 % \begin{function}[updated = 2015-08-06]{\char_set_uccode:nn}
 %   \begin{syntax}
-%     \cs{char_set_uccode:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{char_set_uccode:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
 %   Sets up the behaviour of the \meta{character} when
 %   found inside \cs{text_uppercase:n}, such that \meta{character_1}
@@ -328,7 +328,7 @@
 %
 % \begin{function}[updated = 2015-08-06]{\char_set_mathcode:nn}
 %   \begin{syntax}
-%     \cs{char_set_mathcode:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{char_set_mathcode:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
 %   This function sets up the math code of \meta{character}.
 %   The \meta{character} is specified as
@@ -357,7 +357,7 @@
 %
 % \begin{function}[updated = 2015-08-06]{\char_set_sfcode:nn}
 %   \begin{syntax}
-%     \cs{char_set_sfcode:nn} \Arg{intexpr_1} \Arg{intexpr_2}
+%     \cs{char_set_sfcode:nn} \Arg{int expr_1} \Arg{int expr_2}
 %   \end{syntax}
 %   This function sets up the space factor for the \meta{character}.
 %   The \meta{character} is specified as


### PR DESCRIPTION
fpexpr  and floating point expression -> fp expr
ditto for intexpr dimexpr skipexpr and muskipexpr

not sure which is better short or long.

There is also an issue with l3doc which I temp corrected in interface3 to see how it comes out. \meta does italic but \Arg uses meta inside \texttt so the two differ next to each other, not sure how this is best handled \Arg to use normalfont itshape or \meta us tt it as I did here?