### PR TITLE
implement more robust __tl_act:NNNn

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -3178,118 +3178,146 @@
 %
 % \subsection{Token by token changes}
 %
-% \begin{variable}{\s_@@_act_stop}
-%   The \cs[no-index]{@@_act_\ldots{}} functions may be applied to any token list.
-%   Hence, we use a private quark, to allow any token, even quarks,
-%   in the token list.
-%   Only \cs{s_@@_act_stop} may not appear in the token lists manipulated by
-%   \cs{@@_act:NNNn} functions.
-%    \begin{macrocode}
-\scan_new:N \s_@@_act_stop
-%    \end{macrocode}
-% \end{variable}
-%
 % \begin{macro}[EXP]{\@@_act:NNNn}
 % \begin{macro}[EXP]{\@@_act_output:n, \@@_act_reverse_output:n}
-% \begin{macro}[EXP]{\@@_act_loop:w}
-% \begin{macro}[EXP]{\@@_act_normal:NwNNN}
-% \begin{macro}[EXP]{\@@_act_group:nwNNN}
-% \begin{macro}[EXP]{\@@_act_space:wwNNN}
-% \begin{macro}[EXP]{\@@_act_end:w}
+% \begin{macro}[EXP]{\@@_act_loop:nNNN}
+% \begin{macro}[EXP]{\@@_act_normal:NwNNN,\@@_act_normal:NnNNN}
 % \begin{macro}[EXP]
-%   {
-%     \@@_act_if_head_is_space:nTF,
-%     \@@_act_if_head_is_space:w,
-%     \@@_act_if_head_is_space_true:w
-%   }
-% \begin{macro}[EXP]{\@@_use_none_delimit_by_q_act_stop:w}
+%   {\@@_act_group:nNNN,\@@_act_group:nnNNN,\@@_act_group_split:nw}
+% \begin{macro}[EXP]{\@@_act_space:wNNN,\@@_act_space:nNNN}
+% \begin{macro}[EXP]{\@@_act_end:wn,\@@_act_end_aux:wn}
 %   To help control the expansion, \cs{@@_act:NNNn} should always
 %   be preceeded by \cs{exp:w} and ends by producing \cs{exp_end:}
-%   once the result has been obtained. This way no internal token of it can be
-%   accidentally end up in the input stream.
-%   Because \cs{s_@@_act_stop} can't appear without braces around it in the
-%   argument~|#1| of \cs{@@_act_loop:w}, we can use this marker to set up a fast
-%   test for leading spaces.
-%    \begin{macrocode}
-\cs_set_protected:Npn \@@_tmp:w #1
-  {
-    \cs_new:Npn \@@_act_if_head_is_space:nTF ##1
-      {
-        \@@_act_if_head_is_space:w
-          \s_@@_act_stop ##1 \s_@@_act_stop \@@_act_if_head_is_space_true:w
-          \s_@@_act_stop #1  \s_@@_act_stop \use_ii:nn
-      }
-    \cs_new:Npn \@@_act_if_head_is_space:w
-        ##1 \s_@@_act_stop #1 ##2 \s_@@_act_stop
-      {}
-    \cs_new:Npn \@@_act_if_head_is_space_true:w
-        \s_@@_act_stop #1 \s_@@_act_stop \use_ii:nn ##1 ##2
-      {##1}
-  }
-\@@_tmp:w { ~ }
-%    \end{macrocode}
-%   (We expand the definition \cs{@@_act_if_head_is_space:nTF} when
-%   setting up \cs{@@_act_loop:w}, so we can then undefine the auxiliary.)
-%   In the loop, we check how the token list begins and act
-%   accordingly. In the \enquote{group} case, we may have
-%   reached \cs{s_@@_act_stop}, the end of the list. Then
-%   leave \cs{exp_end:} and the result in the input stream,
-%   to terminate the expansion of \cs{exp:w}.
-%   Otherwise, apply the relevant function to the
-%   \enquote{arguments}, |#3|
-%   and to the head of the token list. Then repeat the loop.
-%   The scheme is the same if the token list starts with an |N|-type
-%   or with a space, making sure that
-%   \cs{@@_act_space:wwNNN} gobbles the space.
-%    \begin{macrocode}
-\exp_args:Nnx \use:n { \cs_new:Npn \@@_act_loop:w #1 \s_@@_act_stop }
-  {
-    \exp_not:o { \@@_act_if_head_is_space:nTF {#1} }
-      \exp_not:N \@@_act_space:wwNNN
-      {
-        \exp_not:o { \tl_if_head_is_group:nTF {#1} }
-          \exp_not:N \@@_act_group:nwNNN
-          \exp_not:N \@@_act_normal:NwNNN
-      }
-    \exp_not:n {#1} \s_@@_act_stop
-  }
-\cs_undefine:N \@@_act_if_head_is_space:nTF
-\cs_new:Npn \@@_act_normal:NwNNN #1 #2 \s_@@_act_stop #3
-  {
-    #3 #1
-    \@@_act_loop:w #2 \s_@@_act_stop
-    #3
-  }
-\cs_new:Npn \@@_use_none_delimit_by_s_act_stop:w #1 \s_@@_act_stop { }
-\cs_new:Npn \@@_act_end:wn #1 \@@_act_result:n #2
-  { \group_align_safe_end: \exp_end: #2 }
-\cs_new:Npn \@@_act_group:nwNNN #1 #2 \s_@@_act_stop #3#4#5
-  {
-    \@@_use_none_delimit_by_s_act_stop:w #1 \@@_act_end:wn \s_@@_act_stop
-    #5 {#1}
-    \@@_act_loop:w #2 \s_@@_act_stop
-    #3 #4 #5
-  }
-\exp_last_unbraced:NNo
-  \cs_new:Npn \@@_act_space:wwNNN \c_space_tl #1 \s_@@_act_stop #2#3
-  {
-    #3
-    \@@_act_loop:w #1 \s_@@_act_stop
-    #2 #3
-  }
-%    \end{macrocode}
-%   \cs{@@_act:NNNn} loops over tokens, groups, and spaces in |#4|.
-%   |{\s_@@_act_stop}| serves as the end of token list marker, the |?| after it
-%   avoids losing outer braces. The result is stored as an argument for the
-%   dummy function \cs{@@_act_result:n}.
+%   once the result has been obtained. This way no internal token of it can
+%   accidentally end up in the input stream. For micro-speed optimisation we
+%   change the order of the arguments of \cs{@@_act:NNNn}, the function for an
+%   |N|-type token (|#1|) is expected to be the most frequently called, hence
+%   stays first. The second most frequent is assumed to be a space, hence |#3|
+%   is put before the function for groups (|#2|). The results will be stored as
+%   an argument for the dummy function \cs{@@_act_result:n}.
+%
+%   The fourth argument of \cs{@@_act:NNNn} can contain arbitrary tokens, the
+%   first three arguments must not contain \cs{@@_act_result:n}, and must not
+%   expand to either \cs{@@_act_output:n} or \cs{@@_act_reverse_output:n}
+%   followed by \cs{@@_act_result:n} outside of braces.
 %    \begin{macrocode}
 \cs_new:Npn \@@_act:NNNn #1#2#3#4
+  { \group_align_safe_begin: \@@_act_loop:nNNN {#4} #1#3#2 \@@_act_result:n {} }
+%    \end{macrocode}
+%   In the loop, we check how the token list begins and act
+%   accordingly. In the \enquote{normal} case, we may have
+%   reached the end of the list. Then leave \cs{exp_end:}
+%   and the result in the input stream, to terminate the
+%   expansion of \cs{exp:w}.
+%   Otherwise, apply the relevant function to the
+%   the head of the token list. Then repeat the loop.
+%   The scheme is the same if the token list starts with an |N|-type
+%   or with a space, making sure that \cs{@@_act_space:wwNNN}
+%   gobbles the space.
+%
+%   The \enquote{group} case grabs the entire argument, while for the other two
+%   cases we want to grab the first token and be able to get the rest as a
+%   normal argument, hence we input an unmatched closing brace using
+%   \cs{if_false:}.
+%    \begin{macrocode}
+\cs_new:Npn \@@_act_loop:nNNN #1
   {
-    \group_align_safe_begin:
-    \@@_act_loop:w #4 { \s_@@_act_stop } ? \s_@@_act_stop
-    #1 #3 #2
-    \@@_act_result:n { }
+    \tl_if_head_is_group:nTF {#1}
+      { \@@_act_group:nNNN {#1} }
+      {
+        \if_false: { \fi:
+        \tl_if_head_is_space:nTF {#1}
+          { \@@_act_space:wNNN }
+          {
+            \tl_if_empty:nTF {#1}
+              { \@@_act_end:wn }
+              { \@@_act_normal:NwNNN }
+          }
+        #1 }
+      }
   }
+%    \end{macrocode}
+%   The group code differs if \cs{tex_expanded:D} is available or not.
+%   For groups the first group is grabbed using \cs{tl_head:n}. The code here
+%   uses the fact that \cs{tl_head:n} needs exactly two steps of expansion
+%   (which isn't documented) if \cs{tex_expanded:D} isn't available. The
+%   remainder in that case is obtained by removing the first element using
+%   \cs{use_none:n}.
+%    \begin{macrocode}
+\cs_if_exist:NTF \tex_expanded:D
+  {
+%    \end{macrocode}
+%   In case \cs{tex_expanded:D} is available we use it directly to get the first
+%   element of |#1| as one argument and the remainder as another. This is done
+%   by grabbing the first element and protecting it against further expansion
+%   using \cs{exp_not:n}, we then leave in the input stream an unbalanced
+%   closing brace followed by an unbalanced opening brace, the former ending the
+%   \cs{tex_expanded:D} context, the latter serving as the opening brace for the
+%   second argument, while the closing brace of the original \cs{tex_expanded:D} 
+%   call is the end delimiter.
+%    \begin{macrocode}
+    \cs_new:Npn \@@_act_group:nNNN #1
+      {
+        \exp_after:wN \@@_act_group:nnNNN 
+        \tex_expanded:D { \@@_act_group_split:nw #1 }
+      }
+    \cs_new:Npn \@@_act_group_split:nw #1
+      {
+        { \exp_not:n {#1} }
+        \if_false: { \fi: \exp_after:wN } \exp_after:wN { \if_false: } \fi:
+      }
+  }
+  {
+%    \end{macrocode}
+%   If \cs{tex_expanded:D} isn't available we use an undocumented feature of
+%   \cs{tl_head:n}, namely that it expands in exactly two steps (whether
+%   \cs{tex_expanded:D} is available or not). We also remove the first token
+%   using \cs{use_none:n} directly (no need for \cs{tl_tail:n}, we know the
+%   token list isn't blank).
+%    \begin{macrocode}
+    \exp_args:Nno \use:n { \cs_new:Npn \@@_act_group:nNNN #1 }
+      {
+        \exp_after:wN \exp_args:Noo \exp_after:wN
+        \@@_act_group:nnNNN \exp_after:wN
+          { \tl_head:n {#1} }
+          { \use_none:n #1 }
+      }
+  }
+\cs_new:Npn \@@_act_group:nnNNN #1#2#3#4#5
+  {
+    #5 {#1}
+    \@@_act_loop:nNNN {#2} #3#4#5
+  }
+%    \end{macrocode}
+%   The \enquote{space} and \enquote{normal} case are easy to handle, we just
+%   remove the leading space or grab the first |N|-type token and grab the rest
+%   of the token list utilizing unbalanced braces.
+%    \begin{macrocode}
+\exp_last_unbraced:NNo \cs_new:Npn \@@_act_space:wNNN \c_space_tl
+  { \exp_after:wN \@@_act_space:nNNN \exp_after:wN { \if_false: } \fi: }
+\cs_new:Npn \@@_act_space:nNNN #1#2#3
+  {
+    #3
+    \@@_act_loop:nNNN {#1} #2#3
+  }
+\cs_new:Npn \@@_act_normal:NwNNN #1
+  {
+    \exp_after:wN \@@_act_normal:NnNNN
+      \exp_after:wN #1 \exp_after:wN { \if_false: } \fi:
+  }
+\cs_new:Npn \@@_act_normal:NnNNN #1#2#3
+  {
+    #3 #1
+    \@@_act_loop:nNNN {#2} #3
+  }
+%    \end{macrocode}
+%   When the end is reached we need to remove the unbalanced closing brace from
+%   the input stream, which we can easily do with \cs{token_to_str:N}, then we
+%   end the \cs{exp:w} expansion and leave the results in the input stream.
+%    \begin{macrocode}
+\cs_new:Npn \@@_act_end:wn { \exp_after:wN \@@_act_end_aux:wn \token_to_str:N }
+\cs_new:Npn \@@_act_end_aux:wn #1 \__tl_act_result:n #2
+  { \group_align_safe_end: \exp_end: #2 }
 %    \end{macrocode}
 %   Typically, the output is done to the right of what was already output,
 %   using \cs{@@_act_output:n}, but for the \cs{@@_act_reverse} functions,
@@ -3300,8 +3328,6 @@
 \cs_new:Npn \@@_act_reverse_output:n #1 #2 \@@_act_result:n #3
   { #2 \@@_act_result:n { #1 #3 } }
 %    \end{macrocode}
-% \end{macro}
-% \end{macro}
 % \end{macro}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/testfiles/m3quark001.tlg
+++ b/l3kernel/testfiles/m3quark001.tlg
@@ -82,7 +82,6 @@ LaTeX has been asked to create a new scan mark '\s__foo' but this name has
 already been used for a scan mark.
 \s_stop 
 \s__quark 
-\s__tl_act_stop 
 \s__tl_nil 
 \s__tl_mark 
 \s__tl_stop 


### PR DESCRIPTION
This PR implements a version of `\__tl_act:NNNn` that can work on arbitrary tokens in its fourth argument (earlier versions had the limitation that the argument could not contain `\s__tl_act_stop` at any group level).

There are still some minor limitations on the first three arguments (those are the same as they currently are): They must not contain `\__tl_act_result:n` and must not expand to `\__tl_act_output:n` or `\__tl_act_reverse_output:n` followed by `\__tl_act_result:n` at the same group level.

The result is considerably slower (small tests indicate a slowdown of at least factor two using `\tl_reverse:n`). And while this is more robust the question whether the limitation (not working on a single token which is only used inside that code, and only in a way it can't remain in the input stream for correct code due to `\exp:w` expansion) is that serious to justify this slowdown.