### PR TITLE
Faster tl_if_head_is_space:n

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -3147,31 +3147,23 @@
 %
 % \begin{macro}[EXP,pTF]{\tl_if_head_is_space:n}
 % \begin{macro}[EXP]{\@@_if_head_is_space:w}
-%   The auxiliary's argument is all that is before the first explicit
-%   space in |\prg_do_nothing:#1?~|.  If that is a single~|\prg_do_nothing:| the
-%   test yields \texttt{true}.  Otherwise, that is more than one token, and the
-%   test yields \texttt{false}.  The work is done within braces (with an
-%   |\if_false: { \fi: ... }| construction) both to hide potential
-%   alignment tab characters from \TeX{} in a table, and to allow for
-%   removing what remains of the token list after its first space.  The use of
-%   \cs{if:w} ensures that the result of a single step of expansion directly
-%   yields a balanced token list (no trailing closing brace).
+%   We directly stringify the argument and then can easily test for a leading
+%   space with the auxiliary that'll remove everything from the first found
+%   space from the input stream. The |?~| serves as a guard against arguments
+%   not containing any space.
 %    \begin{macrocode}
 \prg_new_conditional:Npnn \tl_if_head_is_space:n #1 { p , T , F , TF }
   {
     \if:w
-        \if_false: { \fi: \@@_if_head_is_space:w \prg_do_nothing: #1 ? ~ }
-        \scan_stop: \scan_stop:
+        \scan_stop:
+        \exp_after:wN \@@_if_head_is_space:w \__kernel_tl_to_str:w {#1} ? ~
+        \scan_stop:
       \prg_return_true:
     \else:
       \prg_return_false:
     \fi:
   }
-\exp_args:Nno \use:n { \cs_new:Npn \@@_if_head_is_space:w #1 ~ }
-  {
-    \@@_if_empty_if:o {#1} \else: f \fi:
-    \exp_after:wN \use_none:n \exp_after:wN { \if_false: } \fi:
-  }
+\cs_new:Npn \@@_if_head_is_space:w #1 ~ #2 \scan_stop: { #1 \scan_stop: }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}


### PR DESCRIPTION
This PR changes the `\tl_if_head_is_space:n` tests to use `\__kernel_tl_to_str:w`. This way the complex handling to remove the remainder of the list can be avoided, and since `\__kernel_tl_to_str:w` has no effect on spaces doesn't have any drawback, afaics.

My benchmarks indicate around 40% faster execution.