### PR TITLE
Fix small typo

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -3195,7 +3195,7 @@
 % \begin{macro}[EXP]{\@@_act_normal:NwNNN}
 % \begin{macro}[EXP]{\@@_act_group:nwNNN}
 % \begin{macro}[EXP]{\@@_act_space:wwNNN}
-% \begin{macro}[EXP]{\@@_act_end:w}
+% \begin{macro}[EXP]{\@@_act_end:wn}
 % \begin{macro}[EXP]
 %   {
 %     \@@_act_if_head_is_space:nTF,


### PR DESCRIPTION
Just a minor typo in a control sequence name.