### PR TITLE
add draw_point_intersect_line_circle:nnnnn

### DIFF
--- a/l3experimental/l3draw/l3draw-points.dtx
+++ b/l3experimental/l3draw/l3draw-points.dtx
@@ -477,6 +477,137 @@
 % \end{macro}
 % \end{macro}
 %
+% \begin{macro}[EXP]{\draw_point_intersect_line_circle:nnnnn}
+% \begin{macro}[EXP]{\@@_point_intersect_line_circle_auxi:nnnnnnnn}
+% \begin{macro}[EXP]
+%   {
+%     \@@_point_intersect_line_circle_auxii:nnnnnnnn,
+%     \@@_point_intersect_line_circle_auxii:fnnnnnnn,
+%     \@@_point_intersect_line_circle_auxiii:nnnnnnnn,
+%     \@@_point_intersect_line_circle_auxiii:fffnnnnn
+%   }
+%  \begin{macro}[EXP]
+%    {
+%      \@@_point_intersect_line_circle_auxiv:nnnnnnnn,
+%      \@@_point_intersect_line_circle_auxiv:ffnnnnnn
+%    }
+%  \begin{macro}[EXP]
+%    {
+%      \@@_point_intersect_line_circle_auxv:nnnnn,
+%      \@@_point_intersect_line_circle_auxv:fnnnn
+%    }
+%   The intersection points~$P_{1}$ and~$P_{2}$ between
+%   a line joining points $(x_{1}, y_{1})$ and $(x_{2}, y_{2})$
+%   and a circle with center $(x_{3}, y_{3})$ and radius~$r$.
+%   We use the intermediate
+%   values
+%   \begin{align*}
+%     a &= (x_{2} - x_{1})^{2} + (y_{2} - y_{1})^{2} \\
+%     b &= 2 \times ((x_{2} - x_{1}) \times (x_{1} - x_{3}) + (y_{2} - y_{1}) \times (y_{1} - y_{3})) \\
+%     c &= x_{3}^{2} + y_{3}^{2} + x_{1}^{2} + y_{1}^{2}
+%          - 2\times(x_{3} \times x_{1} + y_{3} \times y_{1}) - r^{2} \\
+%     d &= b^{2} - 4\times a \times c \\
+%     \mu_{1} &= \frac{-b + \sqrt{d}}{2 \times a}\\
+%     \mu_{2} &= \frac{-b - \sqrt{d}}{2 \times a}
+%   \end{align*}
+%   in either
+%   \begin{align*}
+%     P_{1x} &= x_{1} + \mu_{1}\times (x_{2} - x_{1}) \\
+%     P_{1y} &= y_{1} + \mu_{1}\times (y_{2} - y_{1})
+%   \end{align*}
+%   or
+%   \begin{align*}
+%     P_{2x} &= x_{1} + \mu_{2}\times (x_{2} - x_{1}) \\
+%     P_{2y} &= y_{1} + \mu_{2}\times (y_{2} - y_{1})
+%   \end{align*}
+%   depending on which solution is required. The rest of the work is simply
+%   forcing the appropriate expansion and shuffling arguments.
+%    \begin{macrocode}
+\cs_new:Npn \draw_point_intersect_line_circle:nnnnn #1#2#3#4#5
+  {
+    \@@_point_process:nnnn
+      { \@@_point_intersect_line_circle_auxi:nnnnnnnn {#4} {#5} }
+      {#1} {#2} {#3}
+  }
+\cs_new:Npn \@@_point_intersect_line_circle_auxi:nnnnnnnn #1#2#3#4#5#6#7#8
+  {
+    \@@_point_intersect_line_circle_auxii:fnnnnnnn
+      { \fp_eval:n {#1} } {#3} {#4} {#5} {#6} {#7} {#8} {#2}
+  }
+%    \end{macrocode}
+%   At this stage we have all of the information we need, fully expanded:
+%   \begin{enumerate}[label = \#\arabic*, font = \ttfamily]
+%     \item $r$
+%     \item $x_{1}$
+%     \item $y_{1}$
+%     \item $x_{2}$
+%     \item $y_{2}$
+%     \item $x_{3}$
+%     \item $y_{3}$
+%     \item $n$
+%   \end{enumerate}
+%   Once we evaluate $a$, $b$ and $c$, the co-ordinate $(x_{3},y_{3})$
+%   and $r$ are no longer required: handy as we will need various
+%   intermediate values in the following.
+%    \begin{macrocode}
+\cs_new:Npn \@@_point_intersect_line_circle_auxii:nnnnnnnn #1#2#3#4#5#6#7#8
+  {
+    \@@_point_intersect_line_circle_auxiii:fffnnnnn
+      { \fp_eval:n { (#4-#2)*(#4-#2)+(#5-#3)*(#5-#3) } }
+      { \fp_eval:n { 2*((#4-#2)*(#2-#6)+(#5-#3)*(#3-#7)) } }
+      { \fp_eval:n { (#6*#6+#7*#7)+(#2*#2+#3*#3)-(2*(#6*#2+#7*#3))-(#1*#1) } }
+      {#2} {#3} {#4} {#5} {#8}
+  }
+\cs_generate_variant:Nn \@@_point_intersect_line_circle_auxii:nnnnnnnn { f }
+%    \end{macrocode}
+% then we can get $d = b^{2} - 4\times a \times c$ and the usage of $n$.
+%    \begin{macrocode}
+\cs_new:Npn \@@_point_intersect_line_circle_auxiii:nnnnnnnn #1#2#3#4#5#6#7#8
+  {
+    \@@_point_intersect_line_circle_auxiv:ffnnnnnn
+      { \fp_eval:n {  #2 * #2 - 4 * #1 * #3 } }
+      { \int_if_odd:nTF {#8} { 1 } { -1 } }
+      {#1} {#2} {#4} {#5} {#6} {#7}
+  }
+\cs_generate_variant:Nn \@@_point_intersect_line_circle_auxiii:nnnnnnnn { fff }
+%    \end{macrocode}
+%   We now have all of the intermediate values we require, with one division
+%   carried out up-front to avoid doing this expensive step twice:
+%   \begin{enumerate}[label = \#\arabic*, font = \ttfamily]
+%     \item $a$
+%     \item $b$
+%     \item $c$
+%     \item $d$
+%     \item $\pm$(the usage of $n$)
+%     \item $x_{1}$
+%     \item $y_{1}$
+%     \item $x_{2}$
+%     \item $y_{2}$
+%   \end{enumerate}
+%   There are some final pre-calculations,
+%   $\mu = \frac{-b \pm \sqrt{d}}{2 \times a}$
+%   then, we can yield a result.
+%    \begin{macrocode}
+\cs_new:Npn \@@_point_intersect_line_circle_auxiv:nnnnnnnn #1#2#3#4#5#6#7#8
+  {
+    \@@_point_intersect_line_circle_auxv:fnnnn
+      { \fp_eval:n { (-1 * #4 + #2 * sqrt(#1)) / (2 * #3) } }
+      {#5} {#6} {#7} {#8}
+  }
+\cs_generate_variant:Nn \@@_point_intersect_line_circle_auxiv:nnnnnnnn { ff }
+\cs_new:Npn \@@_point_intersect_line_circle_auxv:nnnnn #1#2#3#4#5
+  {
+    \draw_point:n
+      { #2 + #1 * (#4 - #2), #3 + #1 * (#5 - #3) }
+  }
+\cs_generate_variant:Nn \@@_point_intersect_line_circle_auxv:nnnnn { f }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+%
 % \subsection{Interpolation on a line (vector) or arc}
 %
 % \begin{macro}[EXP]{\draw_point_interpolate_line:nnn}

--- a/l3experimental/l3draw/l3draw.dtx
+++ b/l3experimental/l3draw/l3draw.dtx
@@ -528,6 +528,17 @@
 %   \pkg{pgf}, which has the two centers then the two radii.
 % \end{function}
 %
+% \begin{function}[EXP]{\draw_point_intersect_line_circle:nnnnn}
+%   \begin{syntax}
+%     \cs{draw_point_intersect_line_circle:nnnnn}
+%       \Arg{point1} \Arg{point2} \Arg{center} \Arg{radius} \Arg{root}
+%   \end{syntax}
+%   Evaluates the point at the intersection of one line, joining
+%   \meta{point1} and \meta{point2}, and a circle with \meta{center}
+%   and \meta{radius}. If the lines and circle do not intersect and
+%   error will occur.
+% \end{function}
+%
 % \subsubsection{Interpolations}
 %
 % \begin{function}[EXP]{\draw_point_interpolate_line:nnn}


### PR DESCRIPTION
I added a `\draw_point_intersect_line_circle:nnnnn` function to evaluates the point at the intersection of one line, joining ⟨point1 ⟩ and ⟨point2 ⟩, and a circle with ⟨center⟩ and ⟨radius⟩.