### PR TITLE
Public no value bool for l3keys

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -683,6 +683,20 @@
 %   is stored in \cs{l_keys_key_str}.
 % \end{variable}
 %
+% \begin{variable}[added = 2021-09-09]{\l_keys_no_value_bool}
+%   If no value was given this is set to \texttt{true}, else this Boolean is
+%   \texttt{false}. For example
+%   \begin{verbatim}
+%     \keys_define:nn { mymodule }
+%       {
+%         key-a .code:n =
+%           \bool_if:NTF \l_keys_no_value_bool { true } { false }
+%       }
+%     \keys_set:nn { mymodule } { key-a , key-a = {} }
+%   \end{verbatim}
+%   prints first \texttt{true} then \texttt{false}.
+% \end{variable}
+%
 % \section{Handling of unknown keys}
 % \label{sec:l3keys:unknown}
 %
@@ -1486,11 +1500,11 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\l_@@_no_value_bool}
+% \begin{variable}{\l_keys_no_value_bool}
 %   A marker is needed internally to show if only a key or a key plus a
 %   value was seen: this is recorded here.
 %    \begin{macrocode}
-\bool_new:N \l_@@_no_value_bool
+\bool_new:N \l_keys_no_value_bool
 %    \end{macrocode}
 % \end{variable}
 %
@@ -1631,12 +1645,12 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_define:n #1
   {
-    \bool_set_true:N \l_@@_no_value_bool
+    \bool_set_true:N \l_keys_no_value_bool
     \@@_define_aux:nn {#1} { }
   }
 \cs_new_protected:Npn \@@_define:nn #1#2
   {
-    \bool_set_false:N \l_@@_no_value_bool
+    \bool_set_false:N \l_keys_no_value_bool
     \@@_define_aux:nn {#1} {#2}
   }
 \cs_new_protected:Npn \@@_define_aux:nn #1#2
@@ -1726,7 +1740,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_define_code:n #1
   {
-    \bool_if:NTF \l_@@_no_value_bool
+    \bool_if:NTF \l_keys_no_value_bool
       {
         \exp_after:wN \@@_define_code:w
           \l_@@_property_str \s_@@_stop
@@ -2058,7 +2072,7 @@
   }
 \cs_new_protected:Npn \@@_validate_forbidden:
   {
-    \bool_if:NF \l_@@_no_value_bool
+    \bool_if:NF \l_keys_no_value_bool
       {
         \msg_error:nnxx { keys } { value-forbidden }
           \l_keys_path_str \l_keys_value_tl
@@ -2067,7 +2081,7 @@
   }
 \cs_new_protected:Npn \@@_validate_required:
   {
-    \bool_if:NT \l_@@_no_value_bool
+    \bool_if:NT \l_keys_no_value_bool
       {
         \msg_error:nnx { keys } { value-required }
           \l_keys_path_str
@@ -2688,12 +2702,12 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_set_keyval:n #1
   {
-    \bool_set_true:N \l_@@_no_value_bool
+    \bool_set_true:N \l_keys_no_value_bool
     \@@_set_keyval:onn \l_@@_module_str {#1} { }
   }
 \cs_new_protected:Npn \@@_set_keyval:nn #1#2
   {
-    \bool_set_false:N \l_@@_no_value_bool
+    \bool_set_false:N \l_keys_no_value_bool
     \@@_set_keyval:onn \l_@@_module_str {#1} {#2}
   }
 %    \end{macrocode}
@@ -2824,7 +2838,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_value_or_default:n #1
   {
-    \bool_if:NTF \l_@@_no_value_bool
+    \bool_if:NTF \l_keys_no_value_bool
       {
         \cs_if_exist:cTF { \c_@@_default_root_str \l_keys_path_str }
           {
@@ -2955,7 +2969,7 @@
         \clist_put_right:Nx \l_@@_unused_clist
           {
             \l_keys_key_str
-            \bool_if:NF \l_@@_no_value_bool
+            \bool_if:NF \l_keys_no_value_bool
               { = { \exp_not:o \l_keys_value_tl } }
           }
       }
@@ -2965,7 +2979,7 @@
             \clist_put_right:Nx \l_@@_unused_clist
               {
                 \l_keys_path_str
-                \bool_if:NF \l_@@_no_value_bool
+                \bool_if:NF \l_keys_no_value_bool
                   { = { \exp_not:o \l_keys_value_tl } }
               }
           }
@@ -2993,7 +3007,7 @@
           \clist_put_right:Nx \l_@@_unused_clist
             {
               \exp_not:n {##2}
-              \bool_if:NF \l_@@_no_value_bool
+              \bool_if:NF \l_keys_no_value_bool
                 { = { \exp_not:o \l_keys_value_tl } }
             }
         }

--- a/l3kernel/testfiles/m3keys005.lvt
+++ b/l3kernel/testfiles/m3keys005.lvt
@@ -67,5 +67,17 @@
     \keys_set:nn { f ~ o ~ o } { barbaz = value-c }
   }
 
+\TEST { Value~and~no~value }
+  {
+    \keys_define:nn { foo }
+      {
+         keyA .code:n = \bool_if:NTF \l_keys_no_value_bool \TRUE \FALSE
+        ,keyB .code:n = \bool_if:NTF \l_keys_no_value_bool \TRUE \FALSE
+        ,keyB .default:n = foo
+      }
+    \keys_set:nn { foo } { keyA , keyA = {} , keyA = val }
+    \keys_set:nn { foo } { keyB }
+  }
+
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \END

--- a/l3kernel/testfiles/m3keys005.tlg
+++ b/l3kernel/testfiles/m3keys005.tlg
@@ -50,3 +50,13 @@ l. ...  }
 The module 'f o o' does not have a key called 'f o o/barbaz'.
 Check that you have spelled the key name correctly.
 ============================================================
+============================================================
+TEST 4: Value and no value
+============================================================
+Defining key foo/keyA on line ...
+Defining key foo/keyB on line ...
+TRUE
+FALSE
+FALSE
+TRUE
+============================================================


### PR DESCRIPTION
This PR will make the `\l__keys_no_value_bool` public to allow users to directly test for no value without relying on some `.default:n` trickery (see, e.g., https://tex.stackexchange.com/questions/614690/how-to-distinguish-no-value-from-empty-value-when-setting-l3keys/614719?noredirect=1#comment1535606_614719 for a possible use case).