### PR TITLE
fix box_gresize_to_ht_plus_dp to be global

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Fix `\box_gresize_to_ht_plust_dp:Nn` to do a global assignment
+
 ## [2021-08-27]
 
 ### Changed

--- a/l3kernel/l3box.dtx
+++ b/l3kernel/l3box.dtx
@@ -2086,7 +2086,7 @@
 \cs_generate_variant:Nn \box_gresize_to_ht_plus_dp:Nn { c }
 \cs_new_protected:Npn \@@_resize_to_ht_plus_dp:NnN #1#2#3
   {
-    \hbox_set:Nn #1
+    #3 #1
       {
         \@@_resize_set_corners:N #1
         \fp_set:Nn \l_@@_scale_y_fp


### PR DESCRIPTION
The macro `\box_gresize_to_ht_plus_dp:Nn` currently does not a global but a local assignment. It's as small as a typo but I'd really to love to get this one fixed. 

I was not sure if I also should touch the “updated” date for the macros. Please let me know If should have adjusted that one was well or if this is up to you.

Thanks a lot.
