### PR TITLE
move keyval_allow_blank_keys_bool to kernel namespace

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1022,13 +1022,13 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\l_@@_allow_blank_keys_bool}
+% \begin{variable}{\l__kernel_keyval_allow_blank_keys_bool}
 %   The general behavior of the \pkg{l3keys} module is to throw an error on
 %   blank key names. However to support the usage of \cs{keyval_parse:nnn} in
 %   the \pkg{l3prop} module we allow this error to be switched off temporarily
 %   and just ignore blank names.
 %    \begin{macrocode}
-\bool_new:N \l_@@_allow_blank_keys_bool
+\bool_new:N \l__kernel_keyval_allow_blank_keys_bool
 %    \end{macrocode}
 % \end{variable}
 %
@@ -1376,7 +1376,7 @@
   { \@@_loop_other:nnw }
 \cs_new:Npn \@@_blank_key_error:w \s_@@_mark \s_@@_stop #1 \@@_loop_other:nnw
   {
-    \bool_if:NTF \l_@@_allow_blank_keys_bool
+    \bool_if:NTF \l__kernel_keyval_allow_blank_keys_bool
       { #1 }
       { \msg_expandable_error:nn { keyval } { blank-key-name } }
     \@@_loop_other:nnw

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -850,7 +850,7 @@
 \cs_generate_variant:Nn \prop_const_from_keyval:Nn { c }
 \cs_new_protected:Npn \prop_put_from_keyval:Nn
   {
-    \bool_if:NTF \l__keyval_allow_blank_keys_bool
+    \bool_if:NTF \l__kernel_keyval_allow_blank_keys_bool
       { \@@_keyval_parse:NNNn \c_true_bool }
       { \@@_keyval_parse:NNNn \c_false_bool }
       \prop_put:Nnn
@@ -858,7 +858,7 @@
 \cs_generate_variant:Nn \prop_put_from_keyval:Nn { c }
 \cs_new_protected:Npn \prop_gput_from_keyval:Nn
   {
-    \bool_if:NTF \l__keyval_allow_blank_keys_bool
+    \bool_if:NTF \l__kernel_keyval_allow_blank_keys_bool
       { \@@_keyval_parse:NNNn \c_true_bool }
       { \@@_keyval_parse:NNNn \c_false_bool }
       \prop_gput:Nnn
@@ -868,9 +868,9 @@
   { \msg_error:nnn { prop } { prop-keyval } }
 \cs_new_protected:Npn \@@_keyval_parse:NNNn #1#2#3#4
   {
-    \bool_set_eq:NN \l__keyval_allow_blank_keys_bool \c_true_bool
+    \bool_set_eq:NN \l__kernel_keyval_allow_blank_keys_bool \c_true_bool
     \keyval_parse:nnn \@@_missing_eq:n { #2 #3 } {#4}
-    \bool_set_eq:NN \l__keyval_allow_blank_keys_bool #1
+    \bool_set_eq:NN \l__kernel_keyval_allow_blank_keys_bool #1
   }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
As suggested by @PhelypeOleinik in #1012 this moves the newly introduced `\l__keyval_allow_blank_keys_bool` to the `kernel` namespace since it's used across multiple modules.