### PR TITLE
LuaMetaTeX/LMTX compatibility

### DIFF
--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -401,6 +401,17 @@ end
 local true_tok     = token_create_safe'prg_return_true:'
 local false_tok    = token_create_safe'prg_return_false:'
 %    \end{macrocode}
+% In Con\TeX{}t lmtx \texttt{token.command_id} does not exist,
+% but it can easily be emulated with Con\TeX{}t's \texttt{tokens.commands}.
+%    \begin{macrocode}
+local command_id   = token.command_id
+if not command_id and tokens and tokens.commands then
+  local id_map = tokens.commands
+  function command_id(name)
+    return id_map[name]
+  end
+end
+%    \end{macrocode}
 %
 %    \begin{macrocode}
 local function deprecated(table, name, func)
@@ -670,7 +681,7 @@ end)
 %    \begin{macrocode}
 local luacmd do
   local set_lua = token.set_lua
-  local undefined_cs = token.command_id'undefined_cs'
+  local undefined_cs = command_id'undefined_cs'
 
   if not context and not luatexbase then require'ltluatex' end
   if luatexbase then

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -709,20 +709,26 @@ do
 % \begin{macro}{\@@_shell_shipout:e}
 %   Execute commands through shell escape at shipout.
 %
-%   For \LuaTeX, we use the same helper as above but delayed to using a late_lua whatsit.
+%   For \LuaTeX, we use the same helper as above but delayed using a |late_lua| whatsit.
+%   Creating a |late_lua| whatsit works a bit different if we are running under Con\TeX{}t.
 %    \begin{macrocode}
 %<*lua>
-  local whatsit_id = node.id'whatsit'
-  local latelua_sub = node.subtype'late_lua'
-  local node_new = node.direct.new
-  local setfield = node.direct.setwhatsitfield or node.direct.setfield
+  local new_latelua = nodes and nodes.nuts and nodes.nuts.pool and nodes.nuts.pool.latelua or (function()
+    local whatsit_id = node.id'whatsit'
+    local latelua_sub = node.subtype'late_lua'
+    local node_new = node.direct.new
+    local setfield = node.direct.setwhatsitfield or node.direct.setfield
+    return function(f)
+      local n = node_new(whatsit_id, latelua_sub)
+      setfield(n, 'data', f)
+      return n
+    end
+  end)()
   local node_write = node.direct.write
 
   luacmd("@@_shell_shipout:e", function()
     local cmd = scan_string()
-    local n = node_new(whatsit_id, latelua_sub)
-    setfield(n, 'data', function() shellescape(cmd) end)
-    node_write(n)
+    node_write(new_latelua(function() shellescape(cmd) end))
   end, "global", "protected")
 end
 %</lua>

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -2592,6 +2592,9 @@
 %   Again, \tn{nullfont} is a special case because it is the only primitive
 %   with the normally non-primitive |set_font| command code.
 %
+%   In LuaMeta\TeX{} some of the command names are different, so we check for
+%   both versions. The first one is always the \LuaTeX{} version.
+%
 %    \begin{macrocode}
 \sys_if_engine_luatex:TF
   {
@@ -2602,9 +2605,10 @@ do
   local get_command = token.get_command
   local get_index = token.get_index
   local get_mode = token.get_mode or token.get_index
-  local cmd = token.command_id
+  local cmd = command_id
   local set_font = cmd'get_font'
-  local biggest_char = token.biggest_char()
+  local biggest_char = token.biggest_char and token.biggest_char()
+                    or status.getconstants().max_character_code
 
   local mode_below_biggest_char = {}
   local index_not_nil = {}
@@ -2613,29 +2617,29 @@ do
     [cmd'left_brace'] = true,
     [cmd'right_brace'] = true,
     [cmd'math_shift'] = true,
-    [cmd'mac_param'] = mode_below_biggest_char,
-    [cmd'sup_mark'] = true,
-    [cmd'sub_mark'] = true,
-    [cmd'endv'] = true,
+    [cmd'mac_param' or cmd'parameter'] = mode_below_biggest_char,
+    [cmd'sup_mark' or cmd'superscript'] = true,
+    [cmd'sub_mark' or cmd'subscript'] = true,
+    [cmd'endv' or cmd'ignore'] = true,
     [cmd'spacer'] = true,
     [cmd'letter'] = true,
     [cmd'other_char'] = true,
-    [cmd'tab_mark'] = mode_below_biggest_char,
+    [cmd'tab_mark' or cmd'alignment_tab'] = mode_below_biggest_char,
     [cmd'char_given'] = true,
-    [cmd'math_given'] = true,
-    [cmd'xmath_given'] = true,
+    [cmd'math_given' or 'math_char_given'] = true,
+    [cmd'xmath_given' or 'math_char_xgiven'] = true,
     [cmd'set_font'] = mode_not_null,
     [cmd'undefined_cs'] = true,
     [cmd'call'] = true,
-    [cmd'long_call'] = true,
-    [cmd'outer_call'] = true,
-    [cmd'long_outer_call'] = true,
-    [cmd'assign_glue'] = index_not_nil,
-    [cmd'assign_mu_glue'] = index_not_nil,
-    [cmd'assign_toks'] = index_not_nil,
-    [cmd'assign_int'] = index_not_nil,
-    [cmd'assign_attr'] = true,
-    [cmd'assign_dimen'] = index_not_nil,
+    [cmd'long_call' or cmd'protected_call'] = true,
+    [cmd'outer_call' or cmd'tolerant_call'] = true,
+    [cmd'long_outer_call' or cmd'tolerant_protected_call'] = true,
+    [cmd'assign_glue' or cmd'register_glue'] = index_not_nil,
+    [cmd'assign_mu_glue' or cmd'register_mu_glue'] = index_not_nil,
+    [cmd'assign_toks' or cmd'register_toks'] = index_not_nil,
+    [cmd'assign_int' or cmd'register_int'] = index_not_nil,
+    [cmd'assign_attr' or cmd'register_attribute'] = true,
+    [cmd'assign_dimen' or cmd'register_dimen'] = index_not_nil,
   }
 
   luacmd("@@_if_primitive_lua:N", function()


### PR DESCRIPTION
Adds support for some of the name changes in LuaMetaTeX. It assues that it runs in a format which provides most of the legacy aliases, but fixes a few remaining issues.

This makes expl3 work with LuaMetaLaTeX and almost with lmtx. The almost refers to file lookup paths, lmtx doesn't find the Unicode data files unless I copy them to the current directory. But since lmtx is basically a separate distribution I'm assuming that that's just an issue of how this is installed.