### PR TITLE
Add support for validity scope for keys

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 - `\prop_to_keyval:N`
+- Support for validity scope for keys
 
 ### Changed
 - Allow indirect conversions between colorspaces though fallback models

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -315,7 +315,9 @@
 % \begin{function}[updated = 2011-09-06]
 %   {
 %     \clist_remove_all:Nn,  \clist_remove_all:cn,
-%     \clist_gremove_all:Nn, \clist_gremove_all:cn
+%     \clist_remove_all:NV,  \clist_remove_all:cV,
+%     \clist_gremove_all:Nn, \clist_gremove_all:cn,
+%     \clist_gremove_all:NV, \clist_gremove_all:cV
 %   }
 %   \begin{syntax}
 %     \cs{clist_remove_all:Nn} \meta{comma list} \Arg{item}
@@ -1407,9 +1409,17 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}{\clist_remove_all:Nn, \clist_remove_all:cn}
+% \begin{macro}
+%   {
+%     \clist_remove_all:Nn, \clist_remove_all:cn,
+%     \clist_remove_all:NV, \clist_remove_all:cV
+%   }
 % \UnitTested
-% \begin{macro}{\clist_gremove_all:Nn, \clist_gremove_all:cn}
+% \begin{macro}
+%   {
+%     \clist_gremove_all:Nn, \clist_gremove_all:cn,
+%     \clist_gremove_all:NV, \clist_remove_all:cV
+%   }
 % \UnitTested
 % \begin{macro}{\@@_remove_all:NNNn}
 % \begin{macro}{\@@_remove_all:w}
@@ -1482,8 +1492,8 @@
 \cs_new:Npn \@@_remove_all:
   { \exp_after:wN \@@_remove_all:w \@@_tmp:w , }
 \cs_new:Npn \@@_remove_all:w #1 , \s_@@_mark , #2 , { \exp_not:n {#1} }
-\cs_generate_variant:Nn \clist_remove_all:Nn  { c }
-\cs_generate_variant:Nn \clist_gremove_all:Nn { c }
+\cs_generate_variant:Nn \clist_remove_all:Nn  { c , NV , cV }
+\cs_generate_variant:Nn \clist_gremove_all:Nn { c , NV , cV }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -687,16 +687,16 @@
 % way, \pkg{l3keys} allows this information to be specified using the
 % \texttt{.validity:n} property.
 %
-% \begin{function}[added = 2021-11-26]{.usage:n}
+% \begin{function}[added = 2022-01-10]{.validity:n}
 %   \begin{syntax}
-%     \meta{key} .usage:n = \meta{scope}
+%     \meta{key} .validity:n = \meta{scope}
 %   \end{syntax}
 %   Defines the \meta{key} to have usage within the \meta{scope}, which
 %   should be one of \texttt{general}, \texttt{preamble} or \texttt{load}.
 % \end{function}
 %
-% \begin{variable}[added = 2021-11-29]
-%   {\l_keys_usage_load_prop, \l_keys_usage_preamble_prop}
+% \begin{variable}[added = 2022-01-10]
+%   {\l_keys_validity_load_prop, \l_keys_validity_preamble_prop}
 %   \pkg{l3keys} itself does \emph{not} attempt to redefine keys based on the
 %   validity scope. Rather, this information is made available with these
 %   two property lists. These hold an entry for each module (prefix); the
@@ -1650,11 +1650,11 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\l_keys_usage_load_prop, \l_keys_usage_preamble_prop}
+% \begin{variable}{\l_keys_validity_load_prop, \l_keys_validity_preamble_prop}
 %   Global data for document-level information.
 %    \begin{macrocode}
-\prop_new:N \l_keys_usage_load_prop
-\prop_new:N \l_keys_usage_preamble_prop
+\prop_new:N \l_keys_validity_load_prop
+\prop_new:N \l_keys_validity_preamble_prop
 %    \end{macrocode}
 % \end{variable}
 %
@@ -2179,57 +2179,57 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}{\@@_usage:n}
-% \begin{macro}{\@@_usage:NN}
-% \begin{macro}{\@@_usage:w}
+% \begin{macro}{\@@_validity:n}
+% \begin{macro}{\@@_validity:NN}
+% \begin{macro}{\@@_validity:w}
 %   Save the relevant data.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_usage:n #1
+\cs_new_protected:Npn \@@_validity:n #1
   {
     \str_case:nnF {#1}
       {
         { general }
           {
-            \@@_usage:NN \l_keys_usage_load_prop
+            \@@_validity:NN \l_keys_validity_load_prop
               \c_false_bool
-            \@@_usage:NN \l_keys_usage_preamble_prop
+            \@@_validity:NN \l_keys_validity_preamble_prop
               \c_false_bool
           }
         { load }
           {
-            \@@_usage:NN \l_keys_usage_load_prop
+            \@@_validity:NN \l_keys_validity_load_prop
               \c_true_bool
-            \@@_usage:NN \l_keys_usage_preamble_prop
+            \@@_validity:NN \l_keys_validity_preamble_prop
               \c_false_bool
           }
         { preamble }
           {
-            \@@_usage:NN \l_keys_usage_load_prop
+            \@@_validity:NN \l_keys_validity_load_prop
               \c_false_bool
-            \@@_usage:NN \l_keys_usage_preamble_prop
+            \@@_validity:NN \l_keys_validity_preamble_prop
               \c_true_bool
           }
       }
       {
         \msg_error:nnnn { keys }
           { choice-unknown }
-          { .usage:n }
+          { .validity:n }
           {#1}
       }
   }
-\cs_new_protected:Npn \@@_usage:NN #1#2
+\cs_new_protected:Npn \@@_validity:NN #1#2
   {
     \prop_get:NVNF #1 \l_@@_module_str \l_@@_tmpa_tl
       { \tl_clear:N \l_@@_tmpa_tl }
     \tl_set:Nx \l_@@_tmpb_tl
-      { \exp_after:wN \@@_usage:w \l_keys_path_str \s_@@_stop }
+      { \exp_after:wN \@@_validity:w \l_keys_path_str \s_@@_stop }
     \bool_if:NTF #2
       { \clist_put_right:NV \l_@@_tmpa_tl \l_@@_tmpb_tl }
       { \clist_remove_all:NV \l_@@_tmpa_tl \l_@@_tmpb_tl }
     \prop_put:NVV #1 \l_@@_module_str
       \l_@@_tmpa_tl
   }
-\cs_new:Npn \@@_usage:w #1 / #2 \s_@@_stop {#2}
+\cs_new:Npn \@@_validity:w #1 / #2 \s_@@_stop {#2}
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -2638,8 +2638,8 @@
 %
 % \begin{macro}{.validity:n}
 %    \begin{macrocode}
-\cs_new_protected:cpn { \c_@@_props_root_str .usage:n } #1
-  { \@@_usage:n {#1} }
+\cs_new_protected:cpn { \c_@@_props_root_str .validity:n } #1
+  { \@@_validity:n {#1} }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2657,7 +2657,7 @@
 %
 % \subsection{Key properties for \LaTeXe{} options}
 %
-% \begin{macro}{.if, .store, .usage}
+% \begin{macro}{.if, .store, validity}
 %    \begin{macrocode}
 \group_begin:
   \cs_set_protected:Npn \@@_tmp:nn #1#2
@@ -2671,7 +2671,7 @@
   \@@_tmp:nn
     { legacy_if:n } { if }
     { tl_set:N }    { store }
-    { usage:n }     { usage }
+    { validity:n }  { validity }
     { \q_recursion_tail } { }
     \q_recursion_stop
 \group_end:

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -2654,8 +2654,8 @@
     {
       \quark_if_recursion_tail_stop:n {#1}
       \cs_new_eq:cc
-        { \c_@@_props_root_str . #1 }
         { \c_@@_props_root_str . #2 }
+        { \c_@@_props_root_str . #1 }
       \@@_tmp:nn
     }
   \@@_tmp:nn

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -679,6 +679,29 @@
 % \cs{l_keys_choice_tl} and \cs{l_keys_choice_int} in exactly
 % the same way as described for \texttt{.choices:nn}.
 %
+% \subsection{Key validity}
+%
+% Some keys will be used as settings which have a strictly limited scope
+% of validity. Some will be only available once, others will only be valid
+% until typesetting begins. To allow formats to support this in a structured
+% way, \pkg{l3keys} allows this information to be specified using the
+% \texttt{.validity:n} property.
+%
+% \begin{function}[added = 2021-11-25]{.validity:n}
+%   \begin{syntax}
+%     \meta{key} .validity:n = \meta{scope}
+%   \end{syntax}
+%   Defines the \meta{key} to have validty within the \meta{scope}, which
+%   should be one of \texttt{general}, \texttt{preamble} or \texttt{load-time}.
+% \end{function}
+%
+% \begin{variable}{\g_keys_load_time_seq, \g_keys_preamble_seq}
+%   \pkg{l3keys} itself does \emph{not} attempt to redefine keys based on the
+%   validity scope. Rather, this information is made available with these
+%   sequences. Each entry will be a full key path, which can therefore
+%   be used to disable each key when it is out-of-scope.
+% \end{variable}
+%
 % \section{Setting keys}
 %
 % \begin{function}[updated = 2017-11-14]
@@ -1625,6 +1648,14 @@
 %    \end{macrocode}
 % \end{variable}
 %
+% \begin{variable}{\g_keys_load_time_seq, \g_keys_preamble_seq}
+%   Global data for document-level information.
+%    \begin{macrocode}
+\seq_new:N \g_keys_load_time_seq
+\seq_new:N \g_keys_preamble_seq
+%    \end{macrocode}
+% \end{variable}
+%
 % \subsubsection{Internal auxiliaries}
 %
 % \begin{variable}{\s_@@_nil,\s_@@_mark,\s_@@_stop}
@@ -2146,6 +2177,39 @@
 % \end{macro}
 % \end{macro}
 %
+% \begin{macro}{\@@_validity:n}
+%   Save the relevant data.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_validity:n #1
+  {
+    \str_case:nnF {#1}
+      {
+        { general }
+          {
+            \seq_gremove:NV \g_keys_load_time_seq \l_keys_path_str
+            \seq_gremove:NV \g_keys_preamble_seq \l_keys_path_str
+          }
+        { load-time }
+          {
+            \seq_gput:NV \g_keys_load_time_seq \l_keys_path_str
+            \seq_gremove:NV \g_keys_preamble_seq \l_keys_path_str
+          }
+        { preamble }
+          {
+            \seq_gremove:NV \g_keys_load_time_seq \l_keys_path_str
+            \seq_gput:NV \g_keys_preamble_seq \l_keys_path_str
+
+          }
+      }
+      {
+        \msg_error:nnx { keys }
+          { choice-unknown }
+          { .validity:n }
+      }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{\@@_variable_set:NnnN, \@@_variable_set:cnnN}
 % \begin{macro}{\@@_variable_set_required:NnnN, \@@_variable_set_required:cnnN}
 %   Setting a variable takes the type and scope separately so that
@@ -2544,6 +2608,13 @@
 %    \begin{macrocode}
 \cs_new_protected:cpn { \c_@@_props_root_str .undefine: }
   { \@@_undefine: }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{.validity:n}
+%    \begin{macrocode}
+\cs_new_protected:cpn { \c_@@_props_root_str .valdity:n } #1
+  { \@@_validty:n {#1} }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -3358,6 +3358,7 @@
       { \prg_return_true: }
       { \prg_return_false: }
   }
+\prg_generate_conditional_variant:Nnn \keys_if_exist:nn { nx } { T , F , TF }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -2657,7 +2657,7 @@
 %
 % \subsection{Key properties for \LaTeXe{} options}
 %
-% \begin{macro}{.if, .store, validity}
+% \begin{macro}{.if, .store, .validity}
 %    \begin{macrocode}
 \group_begin:
   \cs_set_protected:Npn \@@_tmp:nn #1#2

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -695,7 +695,7 @@
 %   should be one of \texttt{general}, \texttt{preamble} or \texttt{load}.
 % \end{function}
 %
-% \begin{variable}{\g_keys_usage_load_prop, \g_keys_usage_preamble_seq}
+% \begin{variable}{\l_keys_usage_load_prop, \l_keys_usage_preamble_seq}
 %   \pkg{l3keys} itself does \emph{not} attempt to redefine keys based on the
 %   validity scope. Rather, this information is made available with these
 %   two variables. The property list holds an entry for each module (prefix).
@@ -1650,11 +1650,11 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\g_keys_usage_load_prop, \g_keys_usage_preamble_seq}
+% \begin{variable}{\l_keys_usage_load_prop, \l_keys_usage_preamble_seq}
 %   Global data for document-level information.
 %    \begin{macrocode}
-\prop_new:N \g_keys_usage_load_prop
-\seq_new:N \g_keys_usage_preamble_seq
+\prop_new:N \l_keys_usage_load_prop
+\seq_new:N \l_keys_usage_preamble_seq
 %    \end{macrocode}
 % \end{variable}
 %
@@ -2191,19 +2191,19 @@
           {
             \@@_usage_aux:n
               { \clist_remove:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_gremove:NV \g_keys_usage_preamble_seq \l_keys_path_str
+            \seq_remove:NV \l_keys_usage_preamble_seq \l_keys_path_str
           }
         { load }
           {
             \@@_usage_aux:n
               { \clist_put_right:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_gremove:NV \g_keys_usage_preamble_seq \l_keys_path_str
+            \seq_remove:NV \l_keys_usage_preamble_seq \l_keys_path_str
           }
         { preamble }
           {
             \@@_usage_aux:n
               { \clist_remove:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_gput:NV \g_keys_usage_preamble_seq \l_keys_path_str
+            \seq_put:NV \l_keys_usage_preamble_seq \l_keys_path_str
           }
       }
       {
@@ -2214,11 +2214,10 @@
   }
 \cs_new_protected:Npn \@@_usage_aux:n #1
   {
-    \prop_get:NVNF \g_keys_usage_load_prop \l_@@_module_str
+    \prop_get:NVNF \l_keys_usage_load_prop \l_@@_module_str
       \l_@@_tmpa_tl
       { \tl_clear:N \l_@@_tmpa_tl }
-    
-    \prop_gput:NVV \g_keys_usage_load_prop \l_@@_module_str
+    \prop_put:NVV \l_keys_usage_load_prop \l_@@_module_str
       \l_@@_tmpa_tl
   }
 %    \end{macrocode}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -2630,6 +2630,28 @@
 % \end{macro}
 % \end{macro}
 %
+% \subsection{Key properties for \LaTeXe{} options}
+%
+% \begin{macro}{.if, .store, .validity}
+%    \begin{macrocode}
+\group_begin:
+  \cs_set_protected:Npn \@@_tmp:nn #1#2
+    {
+      \quark_if_recursion_tail_stop:n {#1}
+      \cs_new_eq:cc
+        { \c_@@_props_root_str . #1 }
+        { \c_@@_props_root_str . #2 } 
+    }
+  \@@_tmp:nn
+    { legacy_if:n } { if }
+    { tl_set:N }    { store }
+    { validity:n }  { validity }
+    { \q_recursion_tail } { }
+    \q_recursion_stop
+\group_end:
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsection{Setting keys}
 %
 % \begin{macro}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -691,7 +691,7 @@
 %   \begin{syntax}
 %     \meta{key} .validity:n = \meta{scope}
 %   \end{syntax}
-%   Defines the \meta{key} to have usage within the \meta{scope}, which
+%   Defines the \meta{key} to have validity within the \meta{scope}, which
 %   should be one of \texttt{general}, \texttt{preamble} or \texttt{load}.
 % \end{function}
 %

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -695,11 +695,13 @@
 %   should be one of \texttt{general}, \texttt{preamble} or \texttt{load-time}.
 % \end{function}
 %
-% \begin{variable}{\g_keys_load_time_seq, \g_keys_preamble_seq}
+% \begin{variable}{\g_keys_load_time_prop, \g_keys_preamble_seq}
 %   \pkg{l3keys} itself does \emph{not} attempt to redefine keys based on the
 %   validity scope. Rather, this information is made available with these
-%   sequences. Each entry will be a full key path, which can therefore
-%   be used to disable each key when it is out-of-scope.
+%   two variables. The property list holds an entry for each module (prefix).
+%   Each of these entries, and the sequence of preamble-only keys, comprise
+%   a set of fully-qualified key paths. This data can therefore
+%   be used to disable each key when it is out-of-scope. 
 % \end{variable}
 %
 % \section{Setting keys}
@@ -1648,10 +1650,10 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\g_keys_load_time_seq, \g_keys_preamble_seq}
+% \begin{variable}{\g_keys_load_time_prop, \g_keys_preamble_seq}
 %   Global data for document-level information.
 %    \begin{macrocode}
-\seq_new:N \g_keys_load_time_seq
+\prop_new:N \g_keys_load_time_prop
 \seq_new:N \g_keys_preamble_seq
 %    \end{macrocode}
 % \end{variable}
@@ -2178,6 +2180,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_validity:n}
+% \begin{macro}{\@@_validity_aux:n}
 %   Save the relevant data.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_validity:n #1
@@ -2186,19 +2189,21 @@
       {
         { general }
           {
-            \seq_gremove:NV \g_keys_load_time_seq \l_keys_path_str
+            \@@_validity_aux:n
+              { \clist_remove:NV \l_@@_tmpa_tl \l_keys_path_str }
             \seq_gremove:NV \g_keys_preamble_seq \l_keys_path_str
           }
         { load-time }
           {
-            \seq_gput:NV \g_keys_load_time_seq \l_keys_path_str
+            \@@_validity_aux:n
+              { \clist_put_right:NV \l_@@_tmpa_tl \l_keys_path_str }
             \seq_gremove:NV \g_keys_preamble_seq \l_keys_path_str
           }
         { preamble }
           {
-            \seq_gremove:NV \g_keys_load_time_seq \l_keys_path_str
+            \@@_validity_aux:n
+              { \clist_remove:NV \l_@@_tmpa_tl \l_keys_path_str }
             \seq_gput:NV \g_keys_preamble_seq \l_keys_path_str
-
           }
       }
       {
@@ -2207,7 +2212,17 @@
           { .validity:n }
       }
   }
+\cs_new_protected:Npn \@@_validity_aux:n #1
+  {
+    \prop_get:NVNF \g_keys_load_time_prop \l_@@_module_str
+      \l_@@_tmpa_tl
+      { \tl_clear:N \l_@@_tmpa_tl }
+    
+    \prop_gput:NVV \g_keys_load_time_prop \l_@@_module_str
+      \l_@@_tmpa_tl
+  }
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 % \begin{macro}{\@@_variable_set:NnnN, \@@_variable_set:cnnN}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1654,7 +1654,7 @@
 %   Global data for document-level information.
 %    \begin{macrocode}
 \prop_new:N \l_keys_usage_load_prop
-\seq_new:N \l_keys_usage_preamble_prop
+\prop_new:N \l_keys_usage_preamble_prop
 %    \end{macrocode}
 % \end{variable}
 %
@@ -2181,6 +2181,7 @@
 %
 % \begin{macro}{\@@_usage:n}
 % \begin{macro}{\@@_usage:NN}
+% \begin{macro}{\@@_usage:w}
 %   Save the relevant data.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_usage:n #1
@@ -2210,22 +2211,27 @@
           }
       }
       {
-        \msg_error:nnx { keys }
+        \msg_error:nnnn { keys }
           { choice-unknown }
           { .usage:n }
+          {#1}
       }
   }
 \cs_new_protected:Npn \@@_usage:NN #1#2
   {
     \prop_get:NVNF #1 \l_@@_module_str \l_@@_tmpa_tl
       { \tl_clear:N \l_@@_tmpa_tl }
+    \tl_set:Nx \l_@@_tmpb_tl
+      { \exp_after:wN \@@_usage:w \l_keys_path_str \s_@@_stop }
     \bool_if:NTF #2
-      { \clist_put_right:Nn \l_@@_tmpa_tl \l_keys_key_str }
-      { \clist_remove_all:Nn \l_@@_tmpa_tl \l_keys_key_str }
+      { \clist_put_right:NV \l_@@_tmpa_tl \l_@@_tmpb_tl }
+      { \clist_remove_all:NV \l_@@_tmpa_tl \l_@@_tmpb_tl }
     \prop_put:NVV #1 \l_@@_module_str
       \l_@@_tmpa_tl
   }
+\cs_new:Npn \@@_usage:w #1 / #2 \s_@@_stop {#2}
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 %

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -2212,7 +2212,7 @@
       {
         \msg_error:nnx { keys }
           { choice-unknown }
-          { .validity:n }
+          { .usage:n }
       }
   }
 \cs_new_protected:Npn \@@_usage:NN #1#2

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -2655,7 +2655,8 @@
       \quark_if_recursion_tail_stop:n {#1}
       \cs_new_eq:cc
         { \c_@@_props_root_str . #1 }
-        { \c_@@_props_root_str . #2 } 
+        { \c_@@_props_root_str . #2 }
+      \@@_tmp:nn
     }
   \@@_tmp:nn
     { legacy_if:n } { if }

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -695,13 +695,13 @@
 %   should be one of \texttt{general}, \texttt{preamble} or \texttt{load}.
 % \end{function}
 %
-% \begin{variable}{\l_keys_usage_load_prop, \l_keys_usage_preamble_seq}
+% \begin{variable}[added = 2021-11-29]
+%   {\l_keys_usage_load_prop, \l_keys_usage_preamble_prop}
 %   \pkg{l3keys} itself does \emph{not} attempt to redefine keys based on the
 %   validity scope. Rather, this information is made available with these
-%   two variables. The property list holds an entry for each module (prefix).
-%   Each of these entries, and the sequence of preamble-only keys, comprise
-%   a set of fully-qualified key paths. This data can therefore
-%   be used to disable each key when it is out-of-scope. 
+%   two property lists. These hold an entry for each module (prefix); the
+%   value of each entry is a comma-separated list of the usage-restricted
+%   key(s).
 % \end{variable}
 %
 % \section{Setting keys}
@@ -1650,11 +1650,11 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\l_keys_usage_load_prop, \l_keys_usage_preamble_seq}
+% \begin{variable}{\l_keys_usage_load_prop, \l_keys_usage_preamble_prop}
 %   Global data for document-level information.
 %    \begin{macrocode}
 \prop_new:N \l_keys_usage_load_prop
-\seq_new:N \l_keys_usage_preamble_seq
+\seq_new:N \l_keys_usage_preamble_prop
 %    \end{macrocode}
 % \end{variable}
 %
@@ -2180,7 +2180,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_usage:n}
-% \begin{macro}{\@@_validity_aux:n}
+% \begin{macro}{\@@_usage:NN}
 %   Save the relevant data.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_usage:n #1
@@ -2189,21 +2189,24 @@
       {
         { general }
           {
-            \@@_usage_aux:n
-              { \clist_remove:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_remove:NV \l_keys_usage_preamble_seq \l_keys_path_str
+            \@@_usage:NN \l_keys_usage_load_prop
+              \c_false_bool
+            \@@_usage:NN \l_keys_usage_preamble_prop
+              \c_false_bool
           }
         { load }
           {
-            \@@_usage_aux:n
-              { \clist_put_right:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_remove:NV \l_keys_usage_preamble_seq \l_keys_path_str
+            \@@_usage:NN \l_keys_usage_load_prop
+              \c_true_bool
+            \@@_usage:NN \l_keys_usage_preamble_prop
+              \c_false_bool
           }
         { preamble }
           {
-            \@@_usage_aux:n
-              { \clist_remove:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_put:NV \l_keys_usage_preamble_seq \l_keys_path_str
+            \@@_usage:NN \l_keys_usage_load_prop
+              \c_false_bool
+            \@@_usage:NN \l_keys_usage_preamble_prop
+              \c_true_bool
           }
       }
       {
@@ -2212,12 +2215,14 @@
           { .validity:n }
       }
   }
-\cs_new_protected:Npn \@@_usage_aux:n #1
+\cs_new_protected:Npn \@@_usage:NN #1#2
   {
-    \prop_get:NVNF \l_keys_usage_load_prop \l_@@_module_str
-      \l_@@_tmpa_tl
+    \prop_get:NVNF #1 \l_@@_module_str \l_@@_tmpa_tl
       { \tl_clear:N \l_@@_tmpa_tl }
-    \prop_put:NVV \l_keys_usage_load_prop \l_@@_module_str
+    \bool_if:NTF #2
+      { \clist_put_right:Nn \l_@@_tmpa_tl \l_keys_key_str }
+      { \clist_remove_all:Nn \l_@@_tmpa_tl \l_keys_key_str }
+    \prop_put:NVV #1 \l_@@_module_str
       \l_@@_tmpa_tl
   }
 %    \end{macrocode}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -679,26 +679,26 @@
 % \cs{l_keys_choice_tl} and \cs{l_keys_choice_int} in exactly
 % the same way as described for \texttt{.choices:nn}.
 %
-% \subsection{Key validity}
+% \subsection{Key usage scope}
 %
 % Some keys will be used as settings which have a strictly limited scope
-% of validity. Some will be only available once, others will only be valid
+% of usage. Some will be only available once, others will only be valid
 % until typesetting begins. To allow formats to support this in a structured
 % way, \pkg{l3keys} allows this information to be specified using the
-% \texttt{.validity:n} property.
+% \texttt{.usage:n} property.
 %
-% \begin{function}[added = 2022-01-10]{.validity:n}
+% \begin{function}[added = 2022-01-10]{.usage:n}
 %   \begin{syntax}
-%     \meta{key} .validity:n = \meta{scope}
+%     \meta{key} .usage:n = \meta{scope}
 %   \end{syntax}
-%   Defines the \meta{key} to have validity within the \meta{scope}, which
+%   Defines the \meta{key} to have usage within the \meta{scope}, which
 %   should be one of \texttt{general}, \texttt{preamble} or \texttt{load}.
 % \end{function}
 %
 % \begin{variable}[added = 2022-01-10]
-%   {\l_keys_validity_load_prop, \l_keys_validity_preamble_prop}
+%   {\l_keys_usage_load_prop, \l_keys_usage_preamble_prop}
 %   \pkg{l3keys} itself does \emph{not} attempt to redefine keys based on the
-%   validity scope. Rather, this information is made available with these
+%   usage scope. Rather, this information is made available with these
 %   two property lists. These hold an entry for each module (prefix); the
 %   value of each entry is a comma-separated list of the usage-restricted
 %   key(s).
@@ -1650,11 +1650,11 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\l_keys_validity_load_prop, \l_keys_validity_preamble_prop}
+% \begin{variable}{\l_keys_usage_load_prop, \l_keys_usage_preamble_prop}
 %   Global data for document-level information.
 %    \begin{macrocode}
-\prop_new:N \l_keys_validity_load_prop
-\prop_new:N \l_keys_validity_preamble_prop
+\prop_new:N \l_keys_usage_load_prop
+\prop_new:N \l_keys_usage_preamble_prop
 %    \end{macrocode}
 % \end{variable}
 %
@@ -2179,57 +2179,57 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}{\@@_validity:n}
-% \begin{macro}{\@@_validity:NN}
-% \begin{macro}{\@@_validity:w}
+% \begin{macro}{\@@_usage:n}
+% \begin{macro}{\@@_usage:NN}
+% \begin{macro}{\@@_usage:w}
 %   Save the relevant data.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_validity:n #1
+\cs_new_protected:Npn \@@_usage:n #1
   {
     \str_case:nnF {#1}
       {
         { general }
           {
-            \@@_validity:NN \l_keys_validity_load_prop
+            \@@_usage:NN \l_keys_usage_load_prop
               \c_false_bool
-            \@@_validity:NN \l_keys_validity_preamble_prop
+            \@@_usage:NN \l_keys_usage_preamble_prop
               \c_false_bool
           }
         { load }
           {
-            \@@_validity:NN \l_keys_validity_load_prop
+            \@@_usage:NN \l_keys_usage_load_prop
               \c_true_bool
-            \@@_validity:NN \l_keys_validity_preamble_prop
+            \@@_usage:NN \l_keys_usage_preamble_prop
               \c_false_bool
           }
         { preamble }
           {
-            \@@_validity:NN \l_keys_validity_load_prop
+            \@@_usage:NN \l_keys_usage_load_prop
               \c_false_bool
-            \@@_validity:NN \l_keys_validity_preamble_prop
+            \@@_usage:NN \l_keys_usage_preamble_prop
               \c_true_bool
           }
       }
       {
         \msg_error:nnnn { keys }
           { choice-unknown }
-          { .validity:n }
+          { .usage:n }
           {#1}
       }
   }
-\cs_new_protected:Npn \@@_validity:NN #1#2
+\cs_new_protected:Npn \@@_usage:NN #1#2
   {
     \prop_get:NVNF #1 \l_@@_module_str \l_@@_tmpa_tl
       { \tl_clear:N \l_@@_tmpa_tl }
     \tl_set:Nx \l_@@_tmpb_tl
-      { \exp_after:wN \@@_validity:w \l_keys_path_str \s_@@_stop }
+      { \exp_after:wN \@@_usage:w \l_keys_path_str \s_@@_stop }
     \bool_if:NTF #2
       { \clist_put_right:NV \l_@@_tmpa_tl \l_@@_tmpb_tl }
       { \clist_remove_all:NV \l_@@_tmpa_tl \l_@@_tmpb_tl }
     \prop_put:NVV #1 \l_@@_module_str
       \l_@@_tmpa_tl
   }
-\cs_new:Npn \@@_validity:w #1 / #2 \s_@@_stop {#2}
+\cs_new:Npn \@@_usage:w #1 / #2 \s_@@_stop {#2}
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -2636,10 +2636,10 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{.validity:n}
+% \begin{macro}{.usage:n}
 %    \begin{macrocode}
-\cs_new_protected:cpn { \c_@@_props_root_str .validity:n } #1
-  { \@@_validity:n {#1} }
+\cs_new_protected:cpn { \c_@@_props_root_str .usage:n } #1
+  { \@@_usage:n {#1} }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2657,7 +2657,7 @@
 %
 % \subsection{Key properties for \LaTeXe{} options}
 %
-% \begin{macro}{.if, .store, .validity}
+% \begin{macro}{.if, .store, .usage}
 %    \begin{macrocode}
 \group_begin:
   \cs_set_protected:Npn \@@_tmp:nn #1#2
@@ -2671,7 +2671,7 @@
   \@@_tmp:nn
     { legacy_if:n } { if }
     { tl_set:N }    { store }
-    { validity:n }  { validity }
+    { usage:n }     { usage }
     { \q_recursion_tail } { }
     \q_recursion_stop
 \group_end:

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1650,11 +1650,11 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{\g_keys_load_time_prop, \g_keys_preamble_seq}
+% \begin{variable}{\g_keys_usage_load_prop, \g_keys_usage_preamble_seq}
 %   Global data for document-level information.
 %    \begin{macrocode}
-\prop_new:N \g_keys_load_time_prop
-\seq_new:N \g_keys_preamble_seq
+\prop_new:N \g_keys_usage_load_prop
+\seq_new:N \g_keys_usage_preamble_seq
 %    \end{macrocode}
 % \end{variable}
 %

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -687,15 +687,15 @@
 % way, \pkg{l3keys} allows this information to be specified using the
 % \texttt{.validity:n} property.
 %
-% \begin{function}[added = 2021-11-25]{.validity:n}
+% \begin{function}[added = 2021-11-26]{.usage:n}
 %   \begin{syntax}
-%     \meta{key} .validity:n = \meta{scope}
+%     \meta{key} .usage:n = \meta{scope}
 %   \end{syntax}
-%   Defines the \meta{key} to have validty within the \meta{scope}, which
-%   should be one of \texttt{general}, \texttt{preamble} or \texttt{load-time}.
+%   Defines the \meta{key} to have usage within the \meta{scope}, which
+%   should be one of \texttt{general}, \texttt{preamble} or \texttt{load}.
 % \end{function}
 %
-% \begin{variable}{\g_keys_load_time_prop, \g_keys_preamble_seq}
+% \begin{variable}{\g_keys_usage_load_prop, \g_keys_usage_preamble_seq}
 %   \pkg{l3keys} itself does \emph{not} attempt to redefine keys based on the
 %   validity scope. Rather, this information is made available with these
 %   two variables. The property list holds an entry for each module (prefix).
@@ -2179,31 +2179,31 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}{\@@_validity:n}
+% \begin{macro}{\@@_usage:n}
 % \begin{macro}{\@@_validity_aux:n}
 %   Save the relevant data.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_validity:n #1
+\cs_new_protected:Npn \@@_usage:n #1
   {
     \str_case:nnF {#1}
       {
         { general }
           {
-            \@@_validity_aux:n
+            \@@_usage_aux:n
               { \clist_remove:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_gremove:NV \g_keys_preamble_seq \l_keys_path_str
+            \seq_gremove:NV \g_keys_usage_preamble_seq \l_keys_path_str
           }
-        { load-time }
+        { load }
           {
-            \@@_validity_aux:n
+            \@@_usage_aux:n
               { \clist_put_right:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_gremove:NV \g_keys_preamble_seq \l_keys_path_str
+            \seq_gremove:NV \g_keys_usage_preamble_seq \l_keys_path_str
           }
         { preamble }
           {
-            \@@_validity_aux:n
+            \@@_usage_aux:n
               { \clist_remove:NV \l_@@_tmpa_tl \l_keys_path_str }
-            \seq_gput:NV \g_keys_preamble_seq \l_keys_path_str
+            \seq_gput:NV \g_keys_usage_preamble_seq \l_keys_path_str
           }
       }
       {
@@ -2212,13 +2212,13 @@
           { .validity:n }
       }
   }
-\cs_new_protected:Npn \@@_validity_aux:n #1
+\cs_new_protected:Npn \@@_usage_aux:n #1
   {
-    \prop_get:NVNF \g_keys_load_time_prop \l_@@_module_str
+    \prop_get:NVNF \g_keys_usage_load_prop \l_@@_module_str
       \l_@@_tmpa_tl
       { \tl_clear:N \l_@@_tmpa_tl }
     
-    \prop_gput:NVV \g_keys_load_time_prop \l_@@_module_str
+    \prop_gput:NVV \g_keys_usage_load_prop \l_@@_module_str
       \l_@@_tmpa_tl
   }
 %    \end{macrocode}
@@ -2628,8 +2628,8 @@
 %
 % \begin{macro}{.validity:n}
 %    \begin{macrocode}
-\cs_new_protected:cpn { \c_@@_props_root_str .valdity:n } #1
-  { \@@_validty:n {#1} }
+\cs_new_protected:cpn { \c_@@_props_root_str .usage:n } #1
+  { \@@_usage:n {#1} }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2647,7 +2647,7 @@
 %
 % \subsection{Key properties for \LaTeXe{} options}
 %
-% \begin{macro}{.if, .store, .validity}
+% \begin{macro}{.if, .store, .usage}
 %    \begin{macrocode}
 \group_begin:
   \cs_set_protected:Npn \@@_tmp:nn #1#2
@@ -2661,7 +2661,7 @@
   \@@_tmp:nn
     { legacy_if:n } { if }
     { tl_set:N }    { store }
-    { validity:n }  { validity }
+    { usage:n }     { usage }
     { \q_recursion_tail } { }
     \q_recursion_stop
 \group_end:

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -874,7 +874,8 @@
 %
 % \section{Utility functions for keys}
 %
-% \begin{function}[EXP, pTF, updated = 2017-11-14]{\keys_if_exist:nn}
+% \begin{function}[EXP, pTF, updated = 2022-01-10]
+%   {\keys_if_exist:nn, \keys_if_exist:ne}
 %   \begin{syntax}
 %     \cs{keys_if_exist_p:nn} \Arg{module} \Arg{key} \\
 %     \cs{keys_if_exist:nnTF} \Arg{module} \Arg{key} \Arg{true code} \Arg{false code}
@@ -3368,7 +3369,7 @@
       { \prg_return_true: }
       { \prg_return_false: }
   }
-\prg_generate_conditional_variant:Nnn \keys_if_exist:nn { nx } { T , F , TF }
+\prg_generate_conditional_variant:Nnn \keys_if_exist:nn { ne } { T , F , TF }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/testfiles/m3keys007.lvt
+++ b/l3kernel/testfiles/m3keys007.lvt
@@ -1,0 +1,56 @@
+% Copyright (C) 2021 The LaTeX Project
+
+
+\documentclass{minimal}
+\input{regression-test}
+
+\RequirePackage[enable-debug]{expl3}
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation , log-functions }
+\ExplSyntaxOff
+
+
+\begin{document}
+\START
+\AUTHOR{Joseph Wright}
+\ExplSyntaxOn
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { .usage:n ~ basics }
+  {
+    \keys_define:nn { module }
+      {
+        key-one .code:n  = #1 ,
+        key-one .usage:n = load ,
+        key-two .code:n  = #1 ,
+        key-two .usage:n = preamble ,
+        key-three .code:n  = #1 ,
+        key-three .usage:n = general ,
+        key-four .code:n  = #1 ,
+        key-four .usage:n = oops
+      }
+    \prop_show:N \l_keys_usage_load_prop
+    \prop_show:N \l_keys_usage_preamble_prop
+  }
+
+\TEST { .usage:n ~ adding ~ and ~ removing }
+  {
+    \keys_define:nn { module }
+      {
+        key-one .code:n  = #1 ,
+        key-one .usage:n = load ,
+        key-two .code:n  = #1 ,
+        key-two .usage:n = load ,
+        key-three .code:n  = #1 ,
+        key-three .usage:n = load ,
+        key-three .usage:n = preamble ,
+        key-four .code:n  = #1 ,
+        key-four .usage:n = load ,
+        key-four .usage:n = general
+      }
+    \prop_show:N \l_keys_usage_load_prop
+    \prop_show:N \l_keys_usage_preamble_prop
+  }
+
+\END

--- a/l3kernel/testfiles/m3keys007.lvt
+++ b/l3kernel/testfiles/m3keys007.lvt
@@ -17,21 +17,21 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { .usage:n ~ basics }
+\TEST { .validity:n ~ basics }
   {
     \keys_define:nn { module }
       {
         key-one .code:n  = #1 ,
-        key-one .usage:n = load ,
+        key-one .validity:n = load ,
         key-two .code:n  = #1 ,
-        key-two .usage:n = preamble ,
+        key-two .validity:n = preamble ,
         key-three .code:n  = #1 ,
-        key-three .usage:n = general ,
+        key-three .validity:n = general ,
         key-four .code:n  = #1 ,
-        key-four .usage:n = oops
+        key-four .validity:n = oops
       }
-    \prop_show:N \l_keys_usage_load_prop
-    \prop_show:N \l_keys_usage_preamble_prop
+    \prop_show:N \l_keys_validity_load_prop
+    \prop_show:N \l_keys_validity_preamble_prop
   }
 
 \TEST { .usage:n ~ adding ~ and ~ removing }
@@ -39,18 +39,18 @@
     \keys_define:nn { module }
       {
         key-one .code:n  = #1 ,
-        key-one .usage:n = load ,
+        key-one .validity:n = load ,
         key-two .code:n  = #1 ,
-        key-two .usage:n = load ,
+        key-two .validity:n = load ,
         key-three .code:n  = #1 ,
-        key-three .usage:n = load ,
-        key-three .usage:n = preamble ,
+        key-three .validity:n = load ,
+        key-three .validity:n = preamble ,
         key-four .code:n  = #1 ,
-        key-four .usage:n = load ,
-        key-four .usage:n = general
+        key-four .validity:n = load ,
+        key-four .validity:n = general
       }
-    \prop_show:N \l_keys_usage_load_prop
-    \prop_show:N \l_keys_usage_preamble_prop
+    \prop_show:N \l_keys_validity_load_prop
+    \prop_show:N \l_keys_validity_preamble_prop
   }
 
 \END

--- a/l3kernel/testfiles/m3keys007.lvt
+++ b/l3kernel/testfiles/m3keys007.lvt
@@ -17,21 +17,21 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { .validity:n ~ basics }
+\TEST { .usage:n ~ basics }
   {
     \keys_define:nn { module }
       {
         key-one .code:n  = #1 ,
-        key-one .validity:n = load ,
+        key-one .usage:n = load ,
         key-two .code:n  = #1 ,
-        key-two .validity:n = preamble ,
+        key-two .usage:n = preamble ,
         key-three .code:n  = #1 ,
-        key-three .validity:n = general ,
+        key-three .usage:n = general ,
         key-four .code:n  = #1 ,
-        key-four .validity:n = oops
+        key-four .usage:n = oops
       }
-    \prop_show:N \l_keys_validity_load_prop
-    \prop_show:N \l_keys_validity_preamble_prop
+    \prop_show:N \l_keys_usage_load_prop
+    \prop_show:N \l_keys_usage_preamble_prop
   }
 
 \TEST { .usage:n ~ adding ~ and ~ removing }
@@ -39,18 +39,18 @@
     \keys_define:nn { module }
       {
         key-one .code:n  = #1 ,
-        key-one .validity:n = load ,
+        key-one .usage:n = load ,
         key-two .code:n  = #1 ,
-        key-two .validity:n = load ,
+        key-two .usage:n = load ,
         key-three .code:n  = #1 ,
-        key-three .validity:n = load ,
-        key-three .validity:n = preamble ,
+        key-three .usage:n = load ,
+        key-three .usage:n = preamble ,
         key-four .code:n  = #1 ,
-        key-four .validity:n = load ,
-        key-four .validity:n = general
+        key-four .usage:n = load ,
+        key-four .usage:n = general
       }
-    \prop_show:N \l_keys_validity_load_prop
-    \prop_show:N \l_keys_validity_preamble_prop
+    \prop_show:N \l_keys_usage_load_prop
+    \prop_show:N \l_keys_usage_preamble_prop
   }
 
 \END

--- a/l3kernel/testfiles/m3keys007.tlg
+++ b/l3kernel/testfiles/m3keys007.tlg
@@ -2,24 +2,24 @@ This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
 Author: Joseph Wright
 ============================================================
-TEST 1: .usage:n basics
+TEST 1: .validity:n basics
 ============================================================
 Defining key module/key-one on line ...
 Defining key module/key-two on line ...
 Defining key module/key-three on line ...
 Defining key module/key-four on line ...
-! LaTeX3 Error: Key '.usage:n' accepts only a fixed set of choices.
+! LaTeX3 Error: Key '.validity:n' accepts only a fixed set of choices.
 For immediate help type H <return>.
  ...                                              
 l. ...  }
-The key '.usage:n' only accepts predefined values, and 'oops' is not one of
+The key '.validity:n' only accepts predefined values, and 'oops' is not one of
 these.
-The property list \l_keys_usage_load_prop contains the pairs (without outer
+The property list \l_keys_validity_load_prop contains the pairs (without outer
 braces):
 >  {module}  =>  {key-one}.
 <recently read> }
 l. ...  }
-The property list \l_keys_usage_preamble_prop contains the pairs (without
+The property list \l_keys_validity_preamble_prop contains the pairs (without
 outer braces):
 >  {module}  =>  {key-two}.
 <recently read> }
@@ -32,12 +32,12 @@ Defining key module/key-one on line ...
 Defining key module/key-two on line ...
 Defining key module/key-three on line ...
 Defining key module/key-four on line ...
-The property list \l_keys_usage_load_prop contains the pairs (without outer
+The property list \l_keys_validity_load_prop contains the pairs (without outer
 braces):
 >  {module}  =>  {key-one,key-two}.
 <recently read> }
 l. ...  }
-The property list \l_keys_usage_preamble_prop contains the pairs (without
+The property list \l_keys_validity_preamble_prop contains the pairs (without
 outer braces):
 >  {module}  =>  {key-three}.
 <recently read> }

--- a/l3kernel/testfiles/m3keys007.tlg
+++ b/l3kernel/testfiles/m3keys007.tlg
@@ -2,24 +2,24 @@ This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
 Author: Joseph Wright
 ============================================================
-TEST 1: .validity:n basics
+TEST 1: .usage:n basics
 ============================================================
 Defining key module/key-one on line ...
 Defining key module/key-two on line ...
 Defining key module/key-three on line ...
 Defining key module/key-four on line ...
-! LaTeX3 Error: Key '.validity:n' accepts only a fixed set of choices.
+! LaTeX3 Error: Key '.usage:n' accepts only a fixed set of choices.
 For immediate help type H <return>.
  ...                                              
 l. ...  }
-The key '.validity:n' only accepts predefined values, and 'oops' is not one of
+The key '.usage:n' only accepts predefined values, and 'oops' is not one of
 these.
-The property list \l_keys_validity_load_prop contains the pairs (without outer
+The property list \l_keys_usage_load_prop contains the pairs (without outer
 braces):
 >  {module}  =>  {key-one}.
 <recently read> }
 l. ...  }
-The property list \l_keys_validity_preamble_prop contains the pairs (without
+The property list \l_keys_usage_preamble_prop contains the pairs (without
 outer braces):
 >  {module}  =>  {key-two}.
 <recently read> }
@@ -32,12 +32,12 @@ Defining key module/key-one on line ...
 Defining key module/key-two on line ...
 Defining key module/key-three on line ...
 Defining key module/key-four on line ...
-The property list \l_keys_validity_load_prop contains the pairs (without outer
+The property list \l_keys_usage_load_prop contains the pairs (without outer
 braces):
 >  {module}  =>  {key-one,key-two}.
 <recently read> }
 l. ...  }
-The property list \l_keys_validity_preamble_prop contains the pairs (without
+The property list \l_keys_usage_preamble_prop contains the pairs (without
 outer braces):
 >  {module}  =>  {key-three}.
 <recently read> }

--- a/l3kernel/testfiles/m3keys007.tlg
+++ b/l3kernel/testfiles/m3keys007.tlg
@@ -1,0 +1,45 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Joseph Wright
+============================================================
+TEST 1: .usage:n basics
+============================================================
+Defining key module/key-one on line ...
+Defining key module/key-two on line ...
+Defining key module/key-three on line ...
+Defining key module/key-four on line ...
+! LaTeX3 Error: Key '.usage:n' accepts only a fixed set of choices.
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+The key '.usage:n' only accepts predefined values, and 'oops' is not one of
+these.
+The property list \l_keys_usage_load_prop contains the pairs (without outer
+braces):
+>  {module}  =>  {key-one}.
+<recently read> }
+l. ...  }
+The property list \l_keys_usage_preamble_prop contains the pairs (without
+outer braces):
+>  {module}  =>  {key-two}.
+<recently read> }
+l. ...  }
+============================================================
+============================================================
+TEST 2: .usage:n adding and removing
+============================================================
+Defining key module/key-one on line ...
+Defining key module/key-two on line ...
+Defining key module/key-three on line ...
+Defining key module/key-four on line ...
+The property list \l_keys_usage_load_prop contains the pairs (without outer
+braces):
+>  {module}  =>  {key-one,key-two}.
+<recently read> }
+l. ...  }
+The property list \l_keys_usage_preamble_prop contains the pairs (without
+outer braces):
+>  {module}  =>  {key-three}.
+<recently read> }
+l. ...  }
+============================================================


### PR DESCRIPTION
This PR covers the `expl3` part of the plans for option handling. All internal l3keys work is covered here at present.