### PR TITLE
Use content of `\g__color_backend_stack_int`

### DIFF
--- a/l3backend/CHANGELOG.md
+++ b/l3backend/CHANGELOG.md
@@ -6,6 +6,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Use of color stack int in scope end for `(x)dvipdfmx`
+
 ## [2022-01-12]
 
 ### Changed

--- a/l3backend/l3backend-color.dtx
+++ b/l3backend/l3backend-color.dtx
@@ -246,8 +246,11 @@
     \cs_gset_protected:Npn \__kernel_backend_scope_end:
       {
         \__kernel_backend_literal:n { x:grestore }
-        \__kernel_backend_literal:n
-          { pdfcolorstack ~ \g_@@_backend_stack_int current }
+        \__kernel_backend_literal:x
+          {
+            pdfcolorstack ~
+            \int_use:N \g_@@_backend_stack_int \c_space_tl current
+          }
       }
   }
 %    \end{macrocode}

--- a/l3experimental/l3draw/testfiles/m3draw003.xetex.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw003.xetex.tlg
@@ -19,7 +19,7 @@ TEST 1: \draw_path_moveto:n
 ....\special{pdf:literal 9.96265 9.96265 m}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -44,7 +44,7 @@ TEST 2: \draw_path_lineto:n
 ....\special{pdf:literal 9.96265 9.96265 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -69,7 +69,7 @@ TEST 3: \draw_path_curveto:nnn
 ....\special{pdf:literal 0 28.34647 28.34647 28.34647 28.34647 56.69292 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -98,7 +98,7 @@ TEST 4: \draw_path_close:
 ....\special{pdf:literal h}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -123,7 +123,7 @@ TEST 5: \draw_path_curveto:nnn
 ....\special{pdf:literal 18.89764 19.22972 28.34647 37.79527 28.34647 56.69292 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -149,7 +149,7 @@ TEST 6: \draw_path_arc:nnn (n)
 ....\special{pdf:literal 0 31.31062 -25.38228 56.69292 -56.69292 56.69292 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -172,7 +172,7 @@ l. ...  }
 ....\special{pdf:literal -88.00354 56.69292 -113.38583 31.31064 -113.38583 0 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -196,7 +196,7 @@ l. ...  }
 ....\special{pdf:literal -113.38583 -13.32864 -108.6897 -26.23116 -100.12222 -36.4415 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -221,7 +221,7 @@ l. ...  }
 ....\special{pdf:literal -25.3823 -56.69292 0 -31.31064 0 0 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -243,7 +243,7 @@ l. ...  }
 ....\special{pdf:literal 0 -31.31062 -25.38228 -56.69292 -56.69292 -56.69292 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -266,7 +266,7 @@ l. ...  }
 ....\special{pdf:literal -88.00354 -56.69292 -113.38583 -31.31064 -113.38583 0 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -290,7 +290,7 @@ l. ...  }
 ....\special{pdf:literal -113.38583 31.31062 -88.00356 56.69292 -56.69292 56.69292 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -315,7 +315,7 @@ l. ...  }
 ....\special{pdf:literal -25.3823 56.69292 0 31.31064 0 0 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -337,7 +337,7 @@ l. ...  }
 ....\special{pdf:literal 0 31.31062 -12.69115 56.69292 -28.34647 56.69292 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -362,7 +362,7 @@ TEST 7: \draw_path_arc_axes:nnnn
 ....\special{pdf:literal -28.34647 88.00356 -53.72874 113.38583 -85.03938 113.38583 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -393,7 +393,7 @@ TEST 8: \draw_path_ellipse:nnn
 ....\special{pdf:literal 0.99626 0.99626 m}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -420,7 +420,7 @@ l. ...  }
 ....\special{pdf:literal 28.34647 0 m}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -451,7 +451,7 @@ TEST 9: \draw_path_circle:nn
 ....\special{pdf:literal 0.99626 0.99626 m}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -476,7 +476,7 @@ TEST 10: \draw_path_rectangle:nn
 ....\special{pdf:literal 56.69292 56.69292 28.34647 28.34647 re}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -502,7 +502,7 @@ l. ...  }
 ....\special{pdf:literal 170.07875 56.69292 m}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -533,7 +533,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 56.69292 m}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -554,7 +554,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 56.69292 28.34647 28.34647 re}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -602,7 +602,7 @@ TEST 11: \draw_path_grid:nn
 ....\special{pdf:literal 141.73228 141.73222 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -646,7 +646,7 @@ l. ...  }
 ....\special{pdf:literal 141.73228 141.73222 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -690,7 +690,7 @@ l. ...  }
 ....\special{pdf:literal 141.73228 141.73222 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -728,7 +728,7 @@ l. ...  }
 ....\special{pdf:literal 141.73228 113.3858 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -754,7 +754,7 @@ TEST 12: \draw_path_canvas_moveto:n
 ....\special{pdf:literal 9.96265 9.96265 m}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -780,7 +780,7 @@ TEST 13: \draw_path_canvas_lineto:n
 ....\special{pdf:literal 9.96265 9.96265 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -806,7 +806,7 @@ TEST 14: \draw_path_canvas_curveto:nnn
 ....\special{pdf:literal 0 28.34647 28.34647 28.34647 28.34647 56.69292 c}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3experimental/l3draw/testfiles/m3draw004.xetex.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw004.xetex.tlg
@@ -21,7 +21,7 @@ TEST 1: \l_draw_default_linewidth_dim
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -44,7 +44,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -72,7 +72,7 @@ TEST 2: \draw_linewidth:n
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -100,7 +100,7 @@ TEST 3: \draw_dash_pattern:nn
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -124,7 +124,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -148,7 +148,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -176,7 +176,7 @@ TEST 4: \draw_cap_ ...
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -200,7 +200,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -224,7 +224,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -252,7 +252,7 @@ TEST 5: \draw_join_ ...
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -276,7 +276,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -300,7 +300,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -328,7 +328,7 @@ TEST 6: \draw_miterlimit:n
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -352,7 +352,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -376,7 +376,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -405,7 +405,7 @@ TEST 7: \color_select:n
 ....\special{pdf:literal S}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -438,7 +438,7 @@ l. ...  }
 ....\special{pdfcolorstack 1 pop}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -475,7 +475,7 @@ TEST 8: \color_fill:n
 ....\special{pdfcolorstack 1 pop}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -512,7 +512,7 @@ TEST 9: \color_stroke:n
 ....\special{pdfcolorstack 1 pop}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -539,7 +539,7 @@ TEST 10: \draw_baseline:n
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -562,7 +562,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -585,7 +585,7 @@ l. ...  }
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3experimental/l3draw/testfiles/m3draw005.xetex.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw005.xetex.tlg
@@ -23,13 +23,13 @@ TEST 1: \draw_scope_begin:
 ....\special{pdf:literal 56.69292 0 l}
 ....\special{pdf:literal S}
 ....\special{x:grestore}
-....\special{pdfcolorstack \g__color_backend_stack_int current}
+....\special{pdfcolorstack 1 current}
 ....\special{pdf:literal 0 0 m}
 ....\special{pdf:literal 28.34647 283.46457 l}
 ....\special{pdf:literal 56.69292 566.92912 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -75,18 +75,18 @@ TEST 2: \draw_suspend_begin:
 ...........\special{pdf:literal 56.69292 0 l}
 ...........\special{pdf:literal S}
 ..........\special{x:grestore}
-..........\special{pdfcolorstack \g__color_backend_stack_int current}
+..........\special{pdfcolorstack 1 current}
 ..........\special{pdfcolorstack 1 pop}
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ....\special{pdf:literal 0 0 m}
 ....\special{pdf:literal 28.34647 283.46457 l}
 ....\special{pdf:literal 56.69292 566.92912 l}
 ....\special{pdf:literal S}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3experimental/l3draw/testfiles/m3draw006.xetex.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw006.xetex.tlg
@@ -36,9 +36,9 @@ TEST 1: \draw_box_use:N
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -76,9 +76,9 @@ l. ...  }
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -116,9 +116,9 @@ l. ...  }
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -156,9 +156,9 @@ l. ...  }
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -207,9 +207,9 @@ TEST 2: \draw_coffin_use:N
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -254,9 +254,9 @@ l. ...  }
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -301,9 +301,9 @@ l. ...  }
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -348,9 +348,9 @@ l. ...  }
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -395,9 +395,9 @@ l. ...  }
 .......\glue 0.0 plus 1.0fil minus 1.0fil
 ......\special{pdf:etrans}
 ......\special{x:grestore}
-......\special{pdfcolorstack \g__color_backend_stack_int current}
+......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3experimental/l3draw/testfiles/m3draw007.xetex.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw007.xetex.tlg
@@ -25,7 +25,7 @@ TEST 1: stroke
 ....\special{pdf:literal S}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -56,7 +56,7 @@ TEST 2: fill
 ....\special{pdf:literal f}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -87,7 +87,7 @@ TEST 3: draw
 ....\special{pdf:literal S}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -118,7 +118,7 @@ TEST 4: fill,stroke
 ....\special{pdf:literal B}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 
@@ -155,7 +155,7 @@ TEST 5: clip;fill
 ....\special{pdf:literal f}
 ....\special{pdfcolorstack 1 pop}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ...\special{pdfcolorstack 1 pop}
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3experimental/xcoffins/testfiles/xcoffins003.xetex.tlg
+++ b/l3experimental/xcoffins/testfiles/xcoffins003.xetex.tlg
@@ -347,7 +347,7 @@ l. ...}
 .........\rule(0.0+0.0)x62.22221
 ........\mathoff
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> ...RotateCoffin \aaa {45}\showbox \aaa 
                                                   x\fbox {\usebox \aaa }\Rot...
@@ -537,9 +537,9 @@ l. ...}
 ...............\rule(0.0+0.0)x62.22221
 ..............\mathoff
 ...........\special{x:grestore}
-...........\special{pdfcolorstack \g__color_backend_stack_int current}
+...........\special{pdfcolorstack 1 current}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> ...RotateCoffin \aaa {45}\showbox \aaa 
                                                   x\fbox {\usebox \aaa }
@@ -746,11 +746,11 @@ TEST 2: Test 2: rotation+alignment
 ........................\rule(0.0+0.0)x62.22221
 .......................\mathoff
 ....................\special{x:grestore}
-....................\special{pdfcolorstack \g__color_backend_stack_int current}
+....................\special{pdfcolorstack 1 current}
 ..............\special{x:grestore}
-..............\special{pdfcolorstack \g__color_backend_stack_int current}
+..............\special{pdfcolorstack 1 current}
 ........\special{x:grestore}
-........\special{pdfcolorstack \g__color_backend_stack_int current}
+........\special{pdfcolorstack 1 current}
 ...\kern 0.0
 ...\kern -0.5
 ...\hbox(1.0+0.0)x1.0, shifted 0.5
@@ -814,7 +814,7 @@ TEST 2: Test 2: rotation+alignment
 ..............\rule(*+*)x0.4
 .............\rule(0.4+0.0)x*
 ........\special{x:grestore}
-........\special{pdfcolorstack \g__color_backend_stack_int current}
+........\special{pdfcolorstack 1 current}
 ...\kern 0.0
 ...\kern -0.5
 ...\hbox(1.0+0.0)x1.0, shifted 0.5

--- a/l3kernel/testfiles/d3dvipdfmx.luatex.tlg
+++ b/l3kernel/testfiles/d3dvipdfmx.luatex.tlg
@@ -48,7 +48,7 @@ TEST 1: Clip box
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -81,7 +81,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -114,7 +114,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -147,7 +147,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 20.0
 ! OK.
 <argument> \l_tmpa_box 
@@ -195,7 +195,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -221,7 +221,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -247,7 +247,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -273,7 +273,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -299,7 +299,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -325,7 +325,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -358,9 +358,9 @@ l. ...  }
 .........\OT1/cmr/m/n/10 l
 .........\OT1/cmr/m/n/10 d
 .......\special{x:grestore}
-.......\special{pdfcolorstack \g__color_backend_stack_int current}
+.......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -408,7 +408,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -436,7 +436,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -464,7 +464,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -505,7 +505,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -546,7 +546,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -587,7 +587,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3kernel/testfiles/d3dvipdfmx.tlg
+++ b/l3kernel/testfiles/d3dvipdfmx.tlg
@@ -46,7 +46,7 @@ TEST 1: Clip box
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -77,7 +77,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -108,7 +108,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -139,7 +139,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 20.0
 ! OK.
 <argument> \l_tmpa_box 
@@ -187,7 +187,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -213,7 +213,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -239,7 +239,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -265,7 +265,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -291,7 +291,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -317,7 +317,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -350,9 +350,9 @@ l. ...  }
 .........\OT1/cmr/m/n/10 l
 .........\OT1/cmr/m/n/10 d
 .......\special{x:grestore}
-.......\special{pdfcolorstack \g__color_backend_stack_int current}
+.......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -400,7 +400,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -428,7 +428,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -456,7 +456,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -495,7 +495,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -534,7 +534,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -573,7 +573,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3kernel/testfiles/d3dvipdfmx.xetex.tlg
+++ b/l3kernel/testfiles/d3dvipdfmx.xetex.tlg
@@ -54,7 +54,7 @@ TEST 1: Clip box
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -85,7 +85,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -116,7 +116,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -147,7 +147,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 20.0
 ! OK.
 <argument> \l_tmpa_box 
@@ -195,7 +195,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -221,7 +221,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -247,7 +247,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -273,7 +273,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -299,7 +299,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -325,7 +325,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -358,9 +358,9 @@ l. ...  }
 .........\OT1/cmr/m/n/10 l
 .........\OT1/cmr/m/n/10 d
 .......\special{x:grestore}
-.......\special{pdfcolorstack \g__color_backend_stack_int current}
+.......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -408,7 +408,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -436,7 +436,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -464,7 +464,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -503,7 +503,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -542,7 +542,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -581,7 +581,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3kernel/testfiles/d3dvips.xetex.tlg
+++ b/l3kernel/testfiles/d3dvips.xetex.tlg
@@ -54,7 +54,7 @@ TEST 1: Clip box
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -85,7 +85,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -116,7 +116,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -147,7 +147,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 20.0
 ! OK.
 <argument> \l_tmpa_box 
@@ -195,7 +195,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -221,7 +221,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -247,7 +247,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -273,7 +273,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -299,7 +299,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -325,7 +325,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -358,9 +358,9 @@ l. ...  }
 .........\OT1/cmr/m/n/10 l
 .........\OT1/cmr/m/n/10 d
 .......\special{x:grestore}
-.......\special{pdfcolorstack \g__color_backend_stack_int current}
+.......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -408,7 +408,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -436,7 +436,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -464,7 +464,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -503,7 +503,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -542,7 +542,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -581,7 +581,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3kernel/testfiles/d3pdfmode.xetex.tlg
+++ b/l3kernel/testfiles/d3pdfmode.xetex.tlg
@@ -54,7 +54,7 @@ TEST 1: Clip box
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -85,7 +85,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -116,7 +116,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -147,7 +147,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 20.0
 ! OK.
 <argument> \l_tmpa_box 
@@ -195,7 +195,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -221,7 +221,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -247,7 +247,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -273,7 +273,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -299,7 +299,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -325,7 +325,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -358,9 +358,9 @@ l. ...  }
 .........\OT1/cmr/m/n/10 l
 .........\OT1/cmr/m/n/10 d
 .......\special{x:grestore}
-.......\special{pdfcolorstack \g__color_backend_stack_int current}
+.......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -408,7 +408,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -436,7 +436,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -464,7 +464,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -503,7 +503,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -542,7 +542,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -581,7 +581,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3kernel/testfiles/d3xetex.xetex.tlg
+++ b/l3kernel/testfiles/d3xetex.xetex.tlg
@@ -46,7 +46,7 @@ TEST 1: Clip box
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -77,7 +77,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -108,7 +108,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 86.45851
 ! OK.
 <argument> \l_tmpa_box 
@@ -139,7 +139,7 @@ l. ...  }
 ...\OT1/cmr/m/n/10 n
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 .\special{x:grestore}
-.\special{pdfcolorstack \g__color_backend_stack_int current}
+.\special{pdfcolorstack 1 current}
 .\glue 20.0
 ! OK.
 <argument> \l_tmpa_box 
@@ -187,7 +187,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -213,7 +213,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -239,7 +239,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -265,7 +265,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -291,7 +291,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -317,7 +317,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 l
 .....\OT1/cmr/m/n/10 d
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -350,9 +350,9 @@ l. ...  }
 .........\OT1/cmr/m/n/10 l
 .........\OT1/cmr/m/n/10 d
 .......\special{x:grestore}
-.......\special{pdfcolorstack \g__color_backend_stack_int current}
+.......\special{pdfcolorstack 1 current}
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...  }
@@ -400,7 +400,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -428,7 +428,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -456,7 +456,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 d
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -495,7 +495,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -534,7 +534,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -573,7 +573,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 n
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3kernel/testfiles/m3box004.xetex.tlg
+++ b/l3kernel/testfiles/m3box004.xetex.tlg
@@ -17,7 +17,7 @@ TEST 1: Rotate boxes
 .....\OT1/cmr/m/n/10 a
 .....\OT1/cmr/m/n/10 a
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...}
@@ -34,7 +34,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 .....\OT1/cmr/m/n/10 a
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...}
@@ -51,7 +51,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 .....\OT1/cmr/m/n/10 a
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...}
@@ -68,7 +68,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 .....\OT1/cmr/m/n/10 a
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...}
@@ -85,7 +85,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 .....\OT1/cmr/m/n/10 a
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...}
@@ -102,7 +102,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 .....\OT1/cmr/m/n/10 a
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...}
@@ -119,7 +119,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 .....\OT1/cmr/m/n/10 a
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_box 
 l. ...}
@@ -141,7 +141,7 @@ TEST 2: Scale boxes
 .....\OT1/cmr/m/n/10 a
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -160,7 +160,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -179,7 +179,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -198,7 +198,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -217,7 +217,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -236,7 +236,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -255,7 +255,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 a
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -278,7 +278,7 @@ TEST 3: Resize boxes
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -297,7 +297,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -316,7 +316,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -335,7 +335,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -354,7 +354,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -373,7 +373,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -392,7 +392,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -415,7 +415,7 @@ TEST 4: Resize boxes proportionally
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -434,7 +434,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -453,7 +453,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -472,7 +472,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -491,7 +491,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -510,7 +510,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -529,7 +529,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -548,7 +548,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -567,7 +567,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -586,7 +586,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -605,7 +605,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -624,7 +624,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -643,7 +643,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -662,7 +662,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -681,7 +681,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -700,7 +700,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -719,7 +719,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -738,7 +738,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -757,7 +757,7 @@ l. ...}
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -780,7 +780,7 @@ TEST 5: Resize boxes automatically
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 
@@ -799,7 +799,7 @@ l. ...  }
 .....\OT1/cmr/m/n/10 g
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_box 

--- a/l3kernel/testfiles/m3coffins001.xetex.tlg
+++ b/l3kernel/testfiles/m3coffins001.xetex.tlg
@@ -743,7 +743,7 @@ TEST 6: Rotation
 .......\OT1/cmr/m/n/10 d
 .......\special{pdfcolorstack 1 pop}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...  }
@@ -774,7 +774,7 @@ l. ...  }
 .......\OT1/cmr/m/n/10 d
 .......\special{pdfcolorstack 1 pop}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
@@ -856,7 +856,7 @@ l. ...  }
 .......\OT1/cmr/m/n/10 d
 .......\special{pdfcolorstack 1 pop}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
@@ -919,7 +919,7 @@ l. ...  }
 .......\OT1/cmr/m/n/10 d
 .......\special{pdfcolorstack 1 pop}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...  }
@@ -960,9 +960,9 @@ l. ...  }
 .............\OT1/cmr/m/n/10 d
 .............\special{pdfcolorstack 1 pop}
 ...........\special{x:grestore}
-...........\special{pdfcolorstack \g__color_backend_stack_int current}
+...........\special{pdfcolorstack 1 current}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
@@ -1054,9 +1054,9 @@ l. ...  }
 .............\OT1/cmr/m/n/10 d
 .............\special{pdfcolorstack 1 pop}
 ...........\special{x:grestore}
-...........\special{pdfcolorstack \g__color_backend_stack_int current}
+...........\special{pdfcolorstack 1 current}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
@@ -1119,7 +1119,7 @@ l. ...  }
 .......\OT1/cmr/m/n/10 d
 .......\special{pdfcolorstack 1 pop}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \l_tmpa_coffin 
 l. ...  }
@@ -1170,11 +1170,11 @@ l. ...  }
 ...................\OT1/cmr/m/n/10 d
 ...................\special{pdfcolorstack 1 pop}
 .................\special{x:grestore}
-.................\special{pdfcolorstack \g__color_backend_stack_int current}
+.................\special{pdfcolorstack 1 current}
 ...........\special{x:grestore}
-...........\special{pdfcolorstack \g__color_backend_stack_int current}
+...........\special{pdfcolorstack 1 current}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
@@ -1276,11 +1276,11 @@ l. ...  }
 ...................\OT1/cmr/m/n/10 d
 ...................\special{pdfcolorstack 1 pop}
 .................\special{x:grestore}
-.................\special{pdfcolorstack \g__color_backend_stack_int current}
+.................\special{pdfcolorstack 1 current}
 ...........\special{x:grestore}
-...........\special{pdfcolorstack \g__color_backend_stack_int current}
+...........\special{pdfcolorstack 1 current}
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
@@ -1345,7 +1345,7 @@ TEST 7: Scaling
 .....\special{pdfcolorstack 1 pop}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_coffin 
@@ -1375,7 +1375,7 @@ l. ...  }
 .....\special{pdfcolorstack 1 pop}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \g_tmpa_coffin 
@@ -1456,7 +1456,7 @@ l. ...  }
 .....\special{pdfcolorstack 1 pop}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \g_tmpa_coffin 
@@ -1518,7 +1518,7 @@ l. ...  }
 .....\special{pdfcolorstack 1 pop}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_coffin 
@@ -1555,11 +1555,11 @@ l. ...  }
 .........\special{pdfcolorstack 1 pop}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 .......\special{x:grestore}
-.......\special{pdfcolorstack \g__color_backend_stack_int current}
+.......\special{pdfcolorstack 1 current}
 ......\glue 0.0 plus 1.0fil minus 1.0fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \g_tmpa_coffin 
@@ -1647,11 +1647,11 @@ l. ...  }
 .........\special{pdfcolorstack 1 pop}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 .......\special{x:grestore}
-.......\special{pdfcolorstack \g__color_backend_stack_int current}
+.......\special{pdfcolorstack 1 current}
 ......\glue 0.0 plus 1.0fil minus 1.0fil
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \g_tmpa_coffin 
@@ -1717,7 +1717,7 @@ TEST 8: Resizing
 .....\special{pdfcolorstack 1 pop}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \l_tmpa_coffin 
@@ -1747,7 +1747,7 @@ l. ...  }
 .....\special{pdfcolorstack 1 pop}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \g_tmpa_coffin 
@@ -1828,7 +1828,7 @@ l. ...  }
 .....\special{pdfcolorstack 1 pop}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \g_tmpa_coffin 
@@ -1925,7 +1925,7 @@ TEST 9: Complex poles
 ...............................................\rule(113.81102+0.0)x113.81102
 ..............................................\special{pdfcolorstack 1 pop}
 ............................................\special{x:grestore}
-............................................\special{pdfcolorstack \g__color_backend_stack_int current}
+............................................\special{pdfcolorstack 1 current}
 .......................................\kern -155.46873
 .......................................\kern 56.4055
 .......................................\hbox(1.0+0.0)x1.0, shifted 0.5
@@ -3063,7 +3063,7 @@ Poles of coffin \g_tmpa_coffin:
 ......\glue(\rightskip) 0.0
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \g_tmpa_coffin 
@@ -3140,10 +3140,10 @@ Poles of coffin \g_tmpa_coffin:
 ............\glue(\rightskip) 0.0
 ..........\glue 0.0 plus 1.0fil minus 1.0fil
 .........\special{x:grestore}
-.........\special{pdfcolorstack \g__color_backend_stack_int current}
+.........\special{pdfcolorstack 1 current}
 ........\glue 0.0 plus 1.0fil minus 1.0fil
 .....\special{x:grestore}
-.....\special{pdfcolorstack \g__color_backend_stack_int current}
+.....\special{pdfcolorstack 1 current}
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
@@ -3226,13 +3226,13 @@ Poles of coffin \g_tmpa_coffin:
 ................\glue(\rightskip) 0.0
 ..............\glue 0.0 plus 1.0fil minus 1.0fil
 .............\special{x:grestore}
-.............\special{pdfcolorstack \g__color_backend_stack_int current}
+.............\special{pdfcolorstack 1 current}
 ............\glue 0.0 plus 1.0fil minus 1.0fil
 .........\special{x:grestore}
-.........\special{pdfcolorstack \g__color_backend_stack_int current}
+.........\special{pdfcolorstack 1 current}
 ....\glue 0.0 plus 1.0fil minus 1.0fil
 ...\special{x:grestore}
-...\special{pdfcolorstack \g__color_backend_stack_int current}
+...\special{pdfcolorstack 1 current}
 ..\glue 0.0 plus 1.0fil minus 1.0fil
 ! OK.
 <argument> \g_tmpa_coffin 


### PR DESCRIPTION
Compared to the proposal I posted in #1042, `\c_space_tl` is used right after `\int_use:N \g_xxx_int`, instead of `~`.

The corresponding code lines are introduced in https://github.com/latex3/latex3/commit/3e1892e810c6f47c4b7f6de87aeda7b64db0a257, and the `.tlg` lines in https://github.com/latex3/latex3/commit/87b591a9e2d5f9d983660ed4927b5045cef31756 (mostly as I didn't carefully check it).

Is a changelog entry needed?

Fixes #1042