### PR TITLE
Register prefix `lwc`

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -125,6 +125,7 @@ lltxmath,lualatex-math,Philipp Stephani,https://github.com/phst/lualatex-math,ht
 log,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 lua,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 luatex,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
+lwc,lua-widow-control,Max Chernoff,https://github.com/gucci-on-fleek/lua-widow-control,https://github.com/gucci-on-fleek/lua-widow-control.git,https://github.com/gucci-on-fleek/lua-widow-control/issues,2022-02-24,2022-02-24,
 mark,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 markdown,markdown,Vít Novotný,https://ctan.org/pkg/markdown,https://github.com/witiko/markdown.git,https://github.com/witiko/markdown/issues,2021-09-08,2021-09-08,
 marks,l3kernel/xmarks,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2020-02-17,2020-02-17,


### PR DESCRIPTION
I'm converting my `lua-widow-control` package to use `expl3` at gucci-on-fleek/lua-widow-control#20, so I would like to register the module prefix `lwc`. I'm seeing a few other PRs doing the same thing in this repository, so I _think_ that I did it correctly.

Thanks!