### PR TITLE
Support space tokens in \char_generate:nn

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -16,6 +16,8 @@ this project uses date-based 'snapshot' version identifiers.
 ### Changed
 - Definition of `\legacy_if:n(TF)` to support primitive conditionals
 - `\str_<type>case:n` now case changes codepoints above 127 with all engines
+- `\char_generate:nn` now also allows to generate category 10 tokens (spaces)
+  except for char code 0
 
 ### Fixed
 - Nesting of `\tl_analysis_map_inline:nn`

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -317,6 +317,7 @@ local scan_string  = token.scan_string
 local scan_keyword = token.scan_keyword
 local put_next     = token.put_next
 local token_create = token.create
+local token_new    = token.new
 %    \end{macrocode}
 %
 %   Since token.create only returns useful values after the tokens

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -1854,8 +1854,6 @@
   { Cannot~generate~null~char~as~a~space. }
 \msg_new:nnn { char } { out-of-range }
   { Charcode~requested~out~of~engine~range. }
-\msg_new:nnn { char } { space }
-  { Cannot~generate~space~chars. }
 \msg_new:nnnn { ior } { quote-in-shell }
   { Quotes~in~shell~command~'#1'. }
   { Shell~commands~cannot~contain~quotes~("). }

--- a/l3kernel/l3names.dtx
+++ b/l3kernel/l3names.dtx
@@ -1470,9 +1470,9 @@
 %   Here \enquote{smaller} refers to codepoint order which does not correspond to
 %   the user expected order for most non-ASCII strings.
 %    \begin{macrocode}
-local minus_tok = token.new(string.byte'-', 12)
-local zero_tok = token.new(string.byte'0', 12)
-local one_tok = token.new(string.byte'1', 12)
+local minus_tok = token_new(string.byte'-', 12)
+local zero_tok = token_new(string.byte'0', 12)
+local one_tok = token_new(string.byte'1', 12)
 luacmd('tex_strcmp:D', function()
   local first = scan_string()
   local second = scan_string()
@@ -1487,14 +1487,19 @@ end, 'global')
 %
 % \begin{macro}{\tex_Ucharcat:D}
 %   Creating arbitrary chars using |tex.cprint|.
-%   The alternative approach using |token.put_next(token.create(...))|
-%   would be about 10\% slower.
+%   The alternative approach using |token.new(...)| is about 10\% slower
+%   but needed to create arbitrary space tokens.
 %    \begin{macrocode}
+local sprint = tex.sprint
 local cprint = tex.cprint
 luacmd('tex_Ucharcat:D', function()
   local charcode = scan_int()
   local catcode = scan_int()
-  cprint(catcode, utf8_char(charcode))
+  if catcode == 10 then
+    sprint(token_new(charcode, 10))
+  else
+    cprint(catcode, utf8_char(charcode))
+  end
 end, 'global')
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -1529,24 +1529,22 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_generate_aux:w #1 ; #2 ;
   {
-    \if_int_odd:w 1
-        \if_int_compare:w #2 = 10 \exp_stop_f: \else: 0 \fi:
-        \if_int_compare:w #1 = \c_zero_int     \else: 0 \fi: \exp_stop_f:
-      \msg_expandable_error:nn { char } { null-space }
+    \if_int_odd:w 0
+        \if_int_compare:w #2 < 1  \exp_stop_f: 1 \fi:
+        \if_int_compare:w #2 = 5  \exp_stop_f: 1 \fi:
+        \if_int_compare:w #2 = 9  \exp_stop_f: 1 \fi:
+        \if_int_compare:w #2 > 13 \exp_stop_f: 1 \fi: \exp_stop_f:
+      \msg_expandable_error:nn { char }
+        { invalid-catcode }
     \else:
       \if_int_odd:w 0
-          \if_int_compare:w #2 < 1  \exp_stop_f: 1 \fi:
-          \if_int_compare:w #2 = 5  \exp_stop_f: 1 \fi:
-          \if_int_compare:w #2 = 9  \exp_stop_f: 1 \fi:
-          \if_int_compare:w #2 > 13 \exp_stop_f: 1 \fi: \exp_stop_f:
+        \if_int_compare:w #1 < \c_zero_int 1 \fi:
+        \if_int_compare:w #1 > \c_max_char_int 1 \fi: \exp_stop_f:
         \msg_expandable_error:nn { char }
-          { invalid-catcode }
+          { out-of-range }
       \else:
-        \if_int_odd:w 0
-          \if_int_compare:w #1 < \c_zero_int 1 \fi:
-          \if_int_compare:w #1 > \c_max_char_int 1 \fi: \exp_stop_f:
-          \msg_expandable_error:nn { char }
-            { out-of-range }
+        \if_int_compare:w #2#1 = 100 \exp_stop_f:
+          \msg_expandable_error:nn { char } { null-space }
         \else:
           \@@_generate_aux:nnw {#1} {#2}
         \fi:

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -1527,12 +1527,10 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_generate_aux:w #1 ; #2 ;
   {
-    \if_int_compare:w #2 = 10 \exp_stop_f:
-      \if_int_compare:w #1 =  \c_zero_int
-        \msg_expandable_error:nn { char } { null-space }
-      \else:
-        \msg_expandable_error:nn { char } { space }
-      \fi:
+    \if_int_odd:w 1
+        \if_int_compare:w #2 = 10 \exp_stop_f: \else: 0 \fi:
+        \if_int_compare:w #1 = \c_zero_int     \else: 0 \fi: \exp_stop_f:
+      \msg_expandable_error:nn { char } { null-space }
     \else:
       \if_int_odd:w 0
           \if_int_compare:w #2 < 1  \exp_stop_f: 1 \fi:

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -139,12 +139,14 @@
 %     \item $6$ (parameter)
 %     \item $7$ (math superscript)
 %     \item $8$ (math subscript)
+%     \item $10$ (space)
 %     \item $11$ (letter)
 %     \item $12$ (other)
 %     \item $13$ (active)
 %   \end{itemize}
 %   and other values raise an error. The \meta{charcode} may be any one valid
-%   for the engine in use.
+%   for the engine in use, except that for \meta{catcode} $10$, \meta{charcode}
+%   $0$ is not allowed.
 %   Active characters cannot be generated in older versions of \XeTeX{}.
 %   Another way to build token lists with unusual category codes is
 %   \cs{regex_replace:nnN} |{.*}| \Arg{replacement} \meta{tl~var}.

--- a/l3kernel/testfiles/m3char001.luatex.tlg
+++ b/l3kernel/testfiles/m3char001.luatex.tlg
@@ -78,7 +78,7 @@ l. ...  }
 l. ...  }
 ============================================================
 ============================================================
-TEST 2: Generate 7-bit alignment and math tokens
+TEST 2: Generate 7-bit alignment and math and space tokens
 ============================================================
 > \l_tmpa_tl=^^@.
 <recently read> }
@@ -224,6 +224,36 @@ l. ...  }
 > subscript character ^^?.
 \l_tmpa_tl ->^^?
 l. ...  }
+> \l_tmpa_tl=^^L.
+<recently read> }
+l. ...  }
+> blank space ^^L.
+\l_tmpa_tl ->^^L
+l. ...  }
+> \l_tmpa_tl= .
+<recently read> }
+l. ...  }
+> blank space  .
+\l_tmpa_tl -> 
+l. ...  }
+> \l_tmpa_tl=@.
+<recently read> }
+l. ...  }
+> blank space @.
+\l_tmpa_tl ->@
+l. ...  }
+> \l_tmpa_tl=P.
+<recently read> }
+l. ...  }
+> blank space P.
+\l_tmpa_tl ->P
+l. ...  }
+> \l_tmpa_tl=^^?.
+<recently read> }
+l. ...  }
+> blank space ^^?.
+\l_tmpa_tl ->^^?
+l. ...  }
 ============================================================
 ============================================================
 TEST 3: Generate 7-bit awkward
@@ -345,14 +375,6 @@ followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
       ! LaTeX3 Error: Invalid catcode for char generation.
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-! Use of \??? doesn't match its definition.
-<argument> \???  
-      ! LaTeX3 Error: Cannot generate space chars.
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are

--- a/l3kernel/testfiles/m3char001.lvt
+++ b/l3kernel/testfiles/m3char001.lvt
@@ -52,7 +52,7 @@
     \test:nn { 127 }  { 12 }
   }
 
-\TEST { Generate~7-bit~alignment~and~math~tokens }
+\TEST { Generate~7-bit~alignment~and~math~and~space~tokens }
   {
     \test:nn { 0 }    { 3 }
     \test:nn { 12 }   { 3 }
@@ -78,6 +78,11 @@
     \test:nn { 64 }   { 8 }
     \test:nn { 80 }   { 8 }
     \test:nn { 127 }  { 8 }
+    \test:nn { 12 }   { 10 }
+    \test:nn { 32 }   { 10 }
+    \test:nn { 64 }   { 10 }
+    \test:nn { 80 }   { 10 }
+    \test:nn { 127 }  { 10 }
   }
 
 \TEST { Generate~7-bit~awkward }
@@ -105,7 +110,6 @@
     \char_generate:nn { 64 } { 0 }
     \char_generate:nn { 64 } { 5 }
     \char_generate:nn { 64 } { 9 }
-    \char_generate:nn { 64 } { 10 }
     \char_generate:nn { 64 } { 13 }
     \char_generate:nn { 64 } { 14 }
     \char_generate:nn { 64 } { 15 }

--- a/l3kernel/testfiles/m3char001.ptex.tlg
+++ b/l3kernel/testfiles/m3char001.ptex.tlg
@@ -78,7 +78,7 @@ l. ...  }
 l. ...  }
 ============================================================
 ============================================================
-TEST 2: Generate 7-bit alignment and math tokens
+TEST 2: Generate 7-bit alignment and math and space tokens
 ============================================================
 > \l_tmpa_tl=^^@.
 <recently read> }
@@ -224,6 +224,36 @@ l. ...  }
 > subscript character ^^?.
 \l_tmpa_tl ->^^?
 l. ...  }
+> \l_tmpa_tl=^^L.
+<recently read> }
+l. ...  }
+> blank space ^^L.
+\l_tmpa_tl ->^^L
+l. ...  }
+> \l_tmpa_tl= .
+<recently read> }
+l. ...  }
+> blank space  .
+\l_tmpa_tl -> 
+l. ...  }
+> \l_tmpa_tl=@.
+<recently read> }
+l. ...  }
+> blank space @.
+\l_tmpa_tl ->@
+l. ...  }
+> \l_tmpa_tl=P.
+<recently read> }
+l. ...  }
+> blank space P.
+\l_tmpa_tl ->P
+l. ...  }
+> \l_tmpa_tl=^^?.
+<recently read> }
+l. ...  }
+> blank space ^^?.
+\l_tmpa_tl ->^^?
+l. ...  }
 ============================================================
 ============================================================
 TEST 3: Generate 7-bit awkward
@@ -345,14 +375,6 @@ followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
                  ! LaTeX3 Error: Invalid catcode for char generation.
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-! Use of \??? doesn't match its definition.
-<argument> \???  
-                 ! LaTeX3 Error: Cannot generate space chars.
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are

--- a/l3kernel/testfiles/m3char001.tlg
+++ b/l3kernel/testfiles/m3char001.tlg
@@ -78,7 +78,7 @@ l. ...  }
 l. ...  }
 ============================================================
 ============================================================
-TEST 2: Generate 7-bit alignment and math tokens
+TEST 2: Generate 7-bit alignment and math and space tokens
 ============================================================
 > \l_tmpa_tl=^^@.
 <recently read> }
@@ -224,6 +224,36 @@ l. ...  }
 > subscript character ^^?.
 \l_tmpa_tl ->^^?
 l. ...  }
+> \l_tmpa_tl=^^L.
+<recently read> }
+l. ...  }
+> blank space ^^L.
+\l_tmpa_tl ->^^L
+l. ...  }
+> \l_tmpa_tl= .
+<recently read> }
+l. ...  }
+> blank space  .
+\l_tmpa_tl -> 
+l. ...  }
+> \l_tmpa_tl=@.
+<recently read> }
+l. ...  }
+> blank space @.
+\l_tmpa_tl ->@
+l. ...  }
+> \l_tmpa_tl=P.
+<recently read> }
+l. ...  }
+> blank space P.
+\l_tmpa_tl ->P
+l. ...  }
+> \l_tmpa_tl=^^?.
+<recently read> }
+l. ...  }
+> blank space ^^?.
+\l_tmpa_tl ->^^?
+l. ...  }
 ============================================================
 ============================================================
 TEST 3: Generate 7-bit awkward
@@ -345,14 +375,6 @@ followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
                  ! LaTeX3 Error: Invalid catcode for char generation.
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-! Use of \??? doesn't match its definition.
-<argument> \???  
-                 ! LaTeX3 Error: Cannot generate space chars.
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are

--- a/l3kernel/testfiles/m3char001.uptex.tlg
+++ b/l3kernel/testfiles/m3char001.uptex.tlg
@@ -78,7 +78,7 @@ l. ...  }
 l. ...  }
 ============================================================
 ============================================================
-TEST 2: Generate 7-bit alignment and math tokens
+TEST 2: Generate 7-bit alignment and math and space tokens
 ============================================================
 > \l_tmpa_tl=^^@.
 <recently read> }
@@ -224,6 +224,36 @@ l. ...  }
 > subscript character ^^?.
 \l_tmpa_tl ->^^?
 l. ...  }
+> \l_tmpa_tl=^^L.
+<recently read> }
+l. ...  }
+> blank space ^^L.
+\l_tmpa_tl ->^^L
+l. ...  }
+> \l_tmpa_tl= .
+<recently read> }
+l. ...  }
+> blank space  .
+\l_tmpa_tl -> 
+l. ...  }
+> \l_tmpa_tl=@.
+<recently read> }
+l. ...  }
+> blank space @.
+\l_tmpa_tl ->@
+l. ...  }
+> \l_tmpa_tl=P.
+<recently read> }
+l. ...  }
+> blank space P.
+\l_tmpa_tl ->P
+l. ...  }
+> \l_tmpa_tl=^^?.
+<recently read> }
+l. ...  }
+> blank space ^^?.
+\l_tmpa_tl ->^^?
+l. ...  }
 ============================================================
 ============================================================
 TEST 3: Generate 7-bit awkward
@@ -345,14 +375,6 @@ followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
                  ! LaTeX3 Error: Invalid catcode for char generation.
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-! Use of \??? doesn't match its definition.
-<argument> \???  
-                 ! LaTeX3 Error: Cannot generate space chars.
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are

--- a/l3kernel/testfiles/m3char001.xetex.tlg
+++ b/l3kernel/testfiles/m3char001.xetex.tlg
@@ -78,7 +78,7 @@ l. ...  }
 l. ...  }
 ============================================================
 ============================================================
-TEST 2: Generate 7-bit alignment and math tokens
+TEST 2: Generate 7-bit alignment and math and space tokens
 ============================================================
 > \l_tmpa_tl=^^@.
 <recently read> }
@@ -224,6 +224,36 @@ l. ...  }
 > subscript character ^^?.
 \l_tmpa_tl ->^^?
 l. ...  }
+> \l_tmpa_tl=^^L.
+<recently read> }
+l. ...  }
+> blank space ^^L.
+\l_tmpa_tl ->^^L
+l. ...  }
+> \l_tmpa_tl= .
+<recently read> }
+l. ...  }
+> blank space  .
+\l_tmpa_tl -> 
+l. ...  }
+> \l_tmpa_tl=@.
+<recently read> }
+l. ...  }
+> blank space @.
+\l_tmpa_tl ->@
+l. ...  }
+> \l_tmpa_tl=P.
+<recently read> }
+l. ...  }
+> blank space P.
+\l_tmpa_tl ->P
+l. ...  }
+> \l_tmpa_tl=^^?.
+<recently read> }
+l. ...  }
+> blank space ^^?.
+\l_tmpa_tl ->^^?
+l. ...  }
 ============================================================
 ============================================================
 TEST 3: Generate 7-bit awkward
@@ -345,14 +375,6 @@ followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
                  ! LaTeX3 Error: Invalid catcode for char generation.
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-! Use of \??? doesn't match its definition.
-<argument> \???  
-                 ! LaTeX3 Error: Cannot generate space chars.
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are


### PR DESCRIPTION
Pretty much what the title says... Add LuaTeX support by injecting token userdata instead of relying on `cprint` to avoid changing the charcode to 32, for other engines it just removes the check.