### PR TITLE
Add new command `\lua_load_module:n`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Add `\lua_load_module:n`
+
 ### Fixed
 - Typo in implemenation of titlecase `hy-x-yiwn`
 - Definition order issue with `\str_case:Nn(TF)`

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -361,6 +361,9 @@ local cprint     = tex.cprint
 local write      = tex.write
 local write_nl   = texio.write_nl
 local utf8_char  = utf8.char
+local package_loaded    = package.loaded
+local package_searchers = package.searchers
+local table_concat      = table.concat
 
 local scan_int     = token.scan_int or token.scan_integer
 local scan_string  = token.scan_string
@@ -605,6 +608,33 @@ end
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}[int]{try_require}
+%   Loads a Lua module. This function loads the module similarly to the standard
+%   Lua global function |require|, with a few differences. On success,
+%   |try_require| returns |true, module|. If the module cannot be found, it
+%   returns |false, err_msg|. If the module is found, but something goes wrong
+%   when loading it, the function throws an error.
+%    \begin{macrocode}
+local function try_require(name)
+  if package_loaded[name] then
+    return true, package_loaded[name]
+  end
+
+  local failure_details = {}
+  for _, searcher in ipairs(package_searchers) do
+    local loader, data = searcher(name)
+    if type(loader) == 'function' then
+      package_loaded[name] = loader(name, data) or true
+      return true, package_loaded[name]
+    elseif type(loader) == 'string' then
+      failure_details[#failure_details + 1] = loader
+    end
+  end
+
+  return false, table_concat(failure_details, '\n')
+end
+%    \end{macrocode}
+% \end{macro}
 %
 % \begin{macro}{\@@_load_module_p:n}
 %   Check to see if we can load a module using |require|. If we
@@ -617,7 +647,7 @@ local c_false_bool = token_create(0, char_given)
 local c_str_cctab  = token_create('c_str_cctab').mode
 
 luacmd('@@_load_module_p:n', function()
-  local success, result = pcall(require, scan_string())
+  local success, result = try_require(scan_string())
   if success then
     set_macro(c_str_cctab, 'l_@@_err_msg_str', '')
     put_next(c_true_bool)

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -347,23 +347,20 @@ local tonumber = tonumber
 %
 %   Local copies of standard functions.
 %    \begin{macrocode}
-local abs               = math.abs
-local byte              = string.byte
-local floor             = math.floor
-local format            = string.format
-local gsub              = string.gsub
-local lfs_attr          = lfs.attributes
-local open              = io.open
-local os_date           = os.date
-local setcatcode        = tex.setcatcode
-local sprint            = tex.sprint
-local cprint            = tex.cprint
-local write             = tex.write
-local write_nl          = texio.write_nl
-local utf8_char         = utf8.char
-local package_loaded    = package.loaded
-local package_searchers = package.searchers
-local table_concat      = table.concat
+local abs        = math.abs
+local byte       = string.byte
+local floor      = math.floor
+local format     = string.format
+local gsub       = string.gsub
+local lfs_attr   = lfs.attributes
+local open       = io.open
+local os_date    = os.date
+local setcatcode = tex.setcatcode
+local sprint     = tex.sprint
+local cprint     = tex.cprint
+local write      = tex.write
+local write_nl   = texio.write_nl
+local utf8_char  = utf8.char
 
 local scan_int     = token.scan_int or token.scan_integer
 local scan_string  = token.scan_string

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -187,14 +187,6 @@
 %   found, nothing is returned with \emph{no error raised}.
 % \end{function}
 %
-% \begin{function}[added = 2022-05-14]{ltx.utils.require}
-%   \begin{syntax}
-%     |err_msg = ltx.utils.require(|\meta{module name}|)| \\
-%   \end{syntax}
-%   Loads a Lua module, returining |nil| on success and an error message
-%   on failure.
-% \end{function}
-%
 % \end{documentation}
 %
 % \begin{implementation}
@@ -249,16 +241,16 @@
 % \end{macro}
 %
 % \begin{macro}{\lua_load_module:n}
-%   Wrapper around |ltx.utils.require'|\meta{module}|'|.
+%   Wrapper around |require'|\meta{module}|'|.
 %    \begin{macrocode}
-\cs_generate_variant:Nn \bool_if:nF { e }
+\str_new:N \l_@@_err_msg_str
 \cs_generate_variant:Nn \msg_error:nnnn { nnnV }
 \cs_new_protected:Npn \lua_load_module:n #1
   {
-    \bool_if:eF { \@@_load_module_p:n { #1 } }
+    \bool_if:nF { \@@_load_module_p:n { #1 } }
       {
         \msg_error:nnnV
-          { luatex } { module-not-found } { #1 } { \g_@@_err_msg_str }
+          { luatex } { module-not-found } { #1 } { \l_@@_err_msg_str }
       }
   }
 %    \end{macrocode}
@@ -616,42 +608,11 @@ end
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{ltx.utils.require}
-%   Loads a Lua module. This function loads the module just like the standard
-%   Lua global function |require|, with two key differences:
-%   \begin{enumerate}
-%     \item This function is guaranteed not to throw an error.
-%     \item This function does \emph{not} return the loaded module; instead, it
-%           returns |nil| on success and an error message on failure.
-%   \end{enumerate}
-%    \begin{macrocode}
-local function require(name)
-  if package_loaded[name] then
-    return
-  end
-
-  local failure_details = {}
-  for _, searcher in ipairs(package_searchers) do
-    local loader, data = searcher(name)
-    if type(loader) == 'function' then
-      package_loaded[name] = loader(name, data) or true
-      return
-    elseif type(loader) == 'string' then
-      failure_details[#failure_details + 1] = loader
-    end
-  end
-
-  return table_concat(failure_details, '\n')
-end
-
-ltx.utils.require = require
-%    \end{macrocode}
-% \end{macro}
 %
 % \begin{macro}{\@@_load_module_p:n}
-%   Check to see if we can load a module using |ltx.utils.require|. If we can
-%   load the module, then we load it immediately. Otherwise, we save the error
-%   message in |\g_@@_err_msg_str|.
+%   Check to see if we can load a module using |require|. If we
+%   can load the module, then we load it immediately. Otherwise, we save the
+%   error message in |\l_@@_err_msg_str|.
 %    \begin{macrocode}
 local char_given   = command_id'char_given'
 local c_true_bool  = token_create(1, char_given)
@@ -659,12 +620,12 @@ local c_false_bool = token_create(0, char_given)
 local c_str_cctab  = token_create('c_str_cctab').mode
 
 luacmd('@@_load_module_p:n', function()
-  local result = require(scan_string())
-  if result == nil then
-    set_macro(c_str_cctab, 'g_@@_err_msg_str', '', 'global')
+  local success, result = pcall(require, scan_string())
+  if success then
+    set_macro(c_str_cctab, 'l_@@_err_msg_str', '')
     put_next(c_true_bool)
   else
-    set_macro(c_str_cctab, 'g_@@_err_msg_str', result, 'global')
+    set_macro(c_str_cctab, 'l_@@_err_msg_str', result)
     put_next(c_false_bool)
   end
 end)

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -115,6 +115,25 @@
 %   \end{texnote}
 % \end{function}
 %
+% \begin{function}[added = 2022-05-07]{\lua_load_module:n}
+%   \begin{syntax}
+%     \cs{lua_load_module:n} \Arg{Lua module name}
+%   \end{syntax}
+%   Loads a Lua module into the Lua interpreter.
+%
+%   \cs{lua_now:n} passes its \Arg{token list} argument to the Lua interpreter
+%   as a single line, with characters interpreted under the current catcode
+%   regime. These two facts mean that \cs{lua_now:n} rarely behaves as expected
+%   for larger pieces of code. Therefore, package authors should \textbf{not}
+%   write significant amounts of Lua code in the arguments to \cs{lua_now:n}.
+%   Instead, it is strongly recommended that they write the majorty of their Lua
+%   code in a separate file, and then load it using \cs{lua_load_module:n}.
+%   \begin{texnote}
+%     This is a wrapper around the Lua call
+%     \texttt{require~\string"\meta{module}\string"}.
+%   \end{texnote}
+% \end{function}
+%
 % \section{Lua interfaces}
 %
 % As well as interfaces for \TeX{}, there are a small number of Lua functions
@@ -208,9 +227,7 @@
 % \begin{macro}[EXP]{\lua_now:n, \lua_now:e}
 % \begin{macro}{\lua_shipout_e:n, \lua_shipout:n}
 % \begin{macro}[EXP]{\lua_escape:n, \lua_escape:e}
-%   Wrappers around the primitives. As with engines other than \LuaTeX{}
-%   these have to be macros, we give them the same status in all cases.
-%   When \LuaTeX{} is not in use, simply give an error message/
+%   Wrappers around the primitives.
 %    \begin{macrocode}
 \cs_new:Npn \lua_now:e #1 { \@@_now:n {#1} }
 \cs_new:Npn \lua_now:n #1 { \lua_now:e { \exp_not:n {#1} } }
@@ -219,6 +236,34 @@
   { \lua_shipout_e:n { \exp_not:n {#1} } }
 \cs_new:Npn \lua_escape:e #1 { \@@_escape:n {#1} }
 \cs_new:Npn \lua_escape:n #1 { \lua_escape:e { \exp_not:n {#1} } }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\lua_load_module:n}
+%   Wrapper around the Lua call \texttt{require~\string"\meta{module}\string"},
+%   with a friendlier error message when the module cannot be found.
+%    \begin{macrocode}
+\cs_new_protected:Npn \lua_load_module:n #1
+  {
+    \file_if_exist:nTF { #1 .lua }
+      {
+        \@@_now:n { require "\@@_escape:n { #1 }" }
+      }
+      {
+        \msg_error:nnn
+          { luatex } { module-not-found } { #1 }
+      }
+  }
+
+%    \end{macrocode}
+% \end{macro}
+%
+%   As with engines other than \LuaTeX{}
+%   these have to be macros, we give them the same status in all cases.
+%   When \LuaTeX{} is not in use, simply give an error message/
+%    \begin{macrocode}
 \sys_if_engine_luatex:F
   {
     \clist_map_inline:nn
@@ -234,7 +279,7 @@
           }
       }
     \clist_map_inline:nn
-      { \lua_shipout_e:n , \lua_shipout:n }
+      { \lua_shipout_e:n , \lua_shipout:n, \lua_load_module:n }
       {
         \cs_set_protected:Npn #1 ##1
           {
@@ -244,10 +289,6 @@
       }
   }
 %    \end{macrocode}
-% \end{macro}
-% \end{macro}
-% \end{macro}
-%
 % \subsection{Messages}
 %
 %    \begin{macrocode}
@@ -257,6 +298,18 @@
     The~feature~you~are~using~is~only~available~
     with~the~LuaTeX~engine.~LaTeX3~ignored~'#1'.
   }
+
+\msg_new:nnnn { luatex } { module-not-found }
+  { Lua~module~`#1'~not~found. }
+  {
+    The~file~`#1.lua'~could~not~be~found~in~the~current~
+    directory~or~in~the~TeX~search~path.~Please~ensure~that~
+    the~file~was~properly~installed~and~that~the~filename~
+    database~is~current.
+  }
+
+\prop_gput:Nnn \g_msg_module_name_prop { luatex } { LaTeX3 }
+\prop_gput:Nnn \g_msg_module_type_prop { luatex } { }
 %    \end{macrocode}
 %
 %    \begin{macrocode}
@@ -595,7 +648,7 @@ if luatexbase then
     end
 %    \end{macrocode}
 % \end{macro}
-% 
+%
 % The actual work is done in \texttt{pre_dump}. The \texttt{luadata_order} is used
 % to ensure that the order is consistent over multiple runs.
 %    \begin{macrocode}

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -115,7 +115,7 @@
 %   \end{texnote}
 % \end{function}
 %
-% \begin{function}[added = 2022-05-07]{\lua_load_module:n}
+% \begin{function}[added = 2022-05-14]{\lua_load_module:n}
 %   \begin{syntax}
 %     \cs{lua_load_module:n} \Arg{Lua module name}
 %   \end{syntax}
@@ -129,8 +129,7 @@
 %   Instead, it is strongly recommended that they write the majorty of their Lua
 %   code in a separate file, and then load it using \cs{lua_load_module:n}.
 %   \begin{texnote}
-%     This is a wrapper around the Lua call
-%     \texttt{require~\string"\meta{module}\string"}.
+%     This is a wrapper around the Lua call |require '|\meta{module}|'|.
 %   \end{texnote}
 % \end{function}
 %
@@ -188,6 +187,14 @@
 %   found, nothing is returned with \emph{no error raised}.
 % \end{function}
 %
+% \begin{function}[added = 2022-05-14]{ltx.utils.require}
+%   \begin{syntax}
+%     |err_msg = ltx.utils.require(|\meta{module name}|)| \\
+%   \end{syntax}
+%   Loads a Lua module, returining |nil| on success and an error message
+%   on failure.
+% \end{function}
+%
 % \end{documentation}
 %
 % \begin{implementation}
@@ -242,21 +249,18 @@
 % \end{macro}
 %
 % \begin{macro}{\lua_load_module:n}
-%   Wrapper around the Lua call \texttt{require~\string"\meta{module}\string"},
-%   with a friendlier error message when the module cannot be found.
+%   Wrapper around |ltx.utils.require'|\meta{module}|'|.
 %    \begin{macrocode}
+\cs_generate_variant:Nn \bool_if:nF { e }
+\cs_generate_variant:Nn \msg_error:nnnn { nnnV }
 \cs_new_protected:Npn \lua_load_module:n #1
   {
-    \file_if_exist:nTF { #1 .lua }
+    \bool_if:eF { \@@_load_module_p:n { #1 } }
       {
-        \@@_now:n { require "\@@_escape:n { #1 }" }
-      }
-      {
-        \msg_error:nnn
-          { luatex } { module-not-found } { #1 }
+        \msg_error:nnnV
+          { luatex } { module-not-found } { #1 } { \g_@@_err_msg_str }
       }
   }
-
 %    \end{macrocode}
 % \end{macro}
 %
@@ -302,10 +306,11 @@
 \msg_new:nnnn { luatex } { module-not-found }
   { Lua~module~`#1'~not~found. }
   {
-    The~file~`#1.lua'~could~not~be~found~in~the~current~
-    directory~or~in~the~TeX~search~path.~Please~ensure~that~
-    the~file~was~properly~installed~and~that~the~filename~
-    database~is~current.
+    The~file~`#1.lua'~could~not~be~found.~Please~ensure~
+    that~the~file~was~properly~installed~and~that~the~
+    filename~database~is~current. \\ \\
+    The~Lua~loader~provided~this~additional~information: \\
+    #2
   }
 
 \prop_gput:Nnn \g_msg_module_name_prop { luatex } { LaTeX3 }
@@ -350,20 +355,23 @@ local tonumber = tonumber
 %
 %   Local copies of standard functions.
 %    \begin{macrocode}
-local abs        = math.abs
-local byte       = string.byte
-local floor      = math.floor
-local format     = string.format
-local gsub       = string.gsub
-local lfs_attr   = lfs.attributes
-local open       = io.open
-local os_date    = os.date
-local setcatcode = tex.setcatcode
-local sprint     = tex.sprint
-local cprint     = tex.cprint
-local write      = tex.write
-local write_nl   = texio.write_nl
-local utf8_char  = utf8.char
+local abs               = math.abs
+local byte              = string.byte
+local floor             = math.floor
+local format            = string.format
+local gsub              = string.gsub
+local lfs_attr          = lfs.attributes
+local open              = io.open
+local os_date           = os.date
+local setcatcode        = tex.setcatcode
+local sprint            = tex.sprint
+local cprint            = tex.cprint
+local write             = tex.write
+local write_nl          = texio.write_nl
+local utf8_char         = utf8.char
+local package_loaded    = package.loaded
+local package_searchers = package.searchers
+local table_concat      = table.concat
 
 local scan_int     = token.scan_int or token.scan_integer
 local scan_string  = token.scan_string
@@ -371,6 +379,7 @@ local scan_keyword = token.scan_keyword
 local put_next     = token.put_next
 local token_create = token.create
 local token_new    = token.new
+local set_macro    = token.set_macro
 %    \end{macrocode}
 %
 %   Since token.create only returns useful values after the tokens
@@ -604,6 +613,61 @@ local luacmd do
     end
   end
 end
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{ltx.utils.require}
+%   Loads a Lua module. This function loads the module just like the standard
+%   Lua global function |require|, with two key differences:
+%   \begin{enumerate}
+%     \item This function is guaranteed not to throw an error.
+%     \item This function does \emph{not} return the loaded module; instead, it
+%           returns |nil| on success and an error message on failure.
+%   \end{enumerate}
+%    \begin{macrocode}
+local function require(name)
+  if package_loaded[name] then
+    return
+  end
+
+  local failure_details = {}
+  for _, searcher in ipairs(package_searchers) do
+    local loader, data = searcher(name)
+    if type(loader) == 'function' then
+      package_loaded[name] = loader(name, data) or true
+      return
+    elseif type(loader) == 'string' then
+      failure_details[#failure_details + 1] = loader
+    end
+  end
+
+  return table_concat(failure_details, '\n')
+end
+
+ltx.utils.require = require
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_load_module_p:n}
+%   Check to see if we can load a module using |ltx.utils.require|. If we can
+%   load the module, then we load it immediately. Otherwise, we save the error
+%   message in |\g_@@_err_msg_str|.
+%    \begin{macrocode}
+local char_given   = command_id'char_given'
+local c_true_bool  = token_create(1, char_given)
+local c_false_bool = token_create(0, char_given)
+local c_str_cctab  = token_create('c_str_cctab').mode
+
+luacmd('@@_load_module_p:n', function()
+  local result = require(scan_string())
+  if result == nil then
+    set_macro(c_str_cctab, 'g_@@_err_msg_str', '', 'global')
+    put_next(c_true_bool)
+  else
+    set_macro(c_str_cctab, 'g_@@_err_msg_str', result, 'global')
+    put_next(c_false_bool)
+  end
+end)
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
This PR adds a new command `\lua_load_module:n` to the `l3luatex` module as a replacement for `\lua_now:n { require "module" }`.

## Advantages

### Better error handling

Right now, if you try and add a Lua module that doesn't exist, you get a fairly unpleasant error message.

```tex
\ExplSyntaxOn
    \lua_now:n { require "does-not-exist" }
\ExplSyntaxOff
```

```log
[\directlua]:1: module 'does-not-exist' not found:
	no field package.preload['does-not-exist']
	[kpse lua searcher] file not found: 'does-not-exist'
stack traceback:
	[C]: in function 'require'
	[\directlua]:1: in main chunk.
\lua_now:e #1->\__lua_now:n {#1}

l.13     \lua_now:n { require "does-not-exist" }

The lua interpreter ran into a problem, so the
remainder of this lua chunk will be ignored.

! Emergency stop.
```

The problem here is that the file `does-not-exist.lua` doesn't exist, but this isn't immediately obvious from the error message if you don't know any Lua. With this PR, you get a much nicer error message.

```tex
\ExplSyntaxOn
    \lua_load_module:n { does-not-exist }
\ExplSyntaxOff
```

```log
! LaTeX3 Error: Lua module `does-not-exist' not found.

For immediate help type H <return>.
 ...

l.13     \lua_load_module:n { does-not-exist }


The file `does-not-exist.lua' could not be found in the current directory or
in the TeX search path. Please ensure that the file was properly installed and
that the filename database is current.
```

(This is the main motivation for this new command)

### Very commonly used

A significant portion of `\lua_now:(n|e)` calls are used just to load a Lua module. Across GitHub, [12 files match `/\\lua_now:(n|e)\s*\{.*require[\s\(]*("|')/` ](https://cs.github.com/?scopeName=All+repos&scope=&q=%2F%5C%5Clua_now%3A%28n%7Ce%29%5Cs*%5C%7B.*require%5B%5Cs%5C%28%5D*%28%22%7C%27%29%2F#) while [61 files match `/\\lua_now:(n|e)\s*\{/`](https://cs.github.com/?scopeName=All+repos&scope=&q=%2F%5C%5Clua_now%3A%28n%7Ce%29%5Cs*%5C%7B%2F#). These numbers include forks and other copies of `expl3`; if we exclude those I'd say that roughly a quarter of `\lua_now:(n|e)` calls are used to import a Lua module. I think that this is sufficiently popular to merit a specific interface.

### Encourages correct use of Lua

Using `\lua_now` can lead to some pretty surprising results if you aren't familiar with how LuaTeX processes `\directlua`. Having `\lua_load_module:n` should encourage authors to avoid `\lua_now`. In an ideal world, you should only ever need `\lua_load_module:n`, although of course `\lua_now` is sometimes still useful.

### Hooks

With this interface, it would be possible for someone to add hooks like `ltfilehook` package. This probably isn't useful — but it would at least be possible now.

## Specific Details

These are some specific details where I'm unsure; feel free to comment or suggest changes here (or anywhere else too!).

### “package” vs “module”

I named the function `\lua_load_module:n` instead of `\lua_load_package:n` since I _think_ that “module” is the correct term, but it's a little confusing.

From [the Lua manual](https://www.lua.org/manual/5.4/manual.html#6.3):

> The **`package`** library provides basic facilities for loading **modules** in Lua. It exports one function directly in the global environment: `require`. Everything else is exported in the table `package`.

Let me know if you think I should pick a different command name.

### Testing if the module exists

I'm using `\file_if_exist:nTF { #1 .lua }` to see if the module exists. To be technically correct, we should use a Lua test like:

```lua
function search(name)
	for _, searcher in ipairs(package.searchers) do
		if type(searcher(name)) == "function" then
			return true
		end
	end
	return false
end
```

LuaTeX by default has `package.searchers[1]` check to see if the module is already loaded, then `package.searchers[2]` searches with `kpse`. This is essentially equivalent to `\file_if_exist`, so I doubt there will be any difference in practice, but I can use the technically-correct way if you prefer.

### String escaping

I'm using `\lua_escape` to escape the module name. This is technically necessary I guess, but in practice I doubt that anyone would name a file like `a%\b~c $  d.lua` so it can probably safely be removed.

### Message level

I'm using `\msg_error` if the module can't be found, although `\msg_critical` might be more appropriate since there's not much that most packages can do if they can't load their Lua module.

### Variants

`\lua_load_module:n` only covers `\lua_now:n { require "module" }`; I could trivially extend this to `\lua_load_module:nn -> \lua_now:n { #1 = require "#2" }` if you think that's useful.

### Source documentation

All the `l3luatex` code in `source3.pdf` is italicized; I have no idea what is causing this.

### File location

I added this command to `l3luatex.dtx` since that seemed to be the most logical place to put it, although perhaps I should have put it in `l3candidates.dtx`?

---

Let me know if you have any feedback. Thanks!
