### PR TITLE
add pagesize setting to the backend

### DIFF
--- a/l3backend/l3backend-pdf.dtx
+++ b/l3backend/l3backend-pdf.dtx
@@ -768,6 +768,47 @@
 % \end{macro}
 % \end{macro}
 %
+% \subsubsection{PDF page size (mediabox)}
+% This code is more or less a copy of the code in graphics-def.
+% The code tests that the dimensions are larger than
+% zero as setting a zero page size doesn't make sense.
+% The page size is set in \cs{@kernel@before@begindocument}:
+% this is after the backend code has been loaded but before other
+% settings from package like geometry or graphics or memoir.
+% Similar to the setting in graphics nothing is done if
+% mag has been set. For dvi backends we delay the setting
+% to the shipout/firstpage hook.
+% \begin{macro}{\@@_backend_pagesize_set:nn}
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_backend_pagesize_set:nn #1#2
+  {
+    \bool_lazy_and:nnT
+      {\dim_compare_p:nNn {#1}>{0pt}} {\dim_compare_p:nNn {#2}>{0pt}}
+      {
+        \__kernel_backend_literal:e
+           {papersize=\dim_eval:n{#1},\dim_eval:n{#2}}
+      }
+  }
+
+\tl_gput_right:Nn \@kernel@before@begindocument
+ {
+   \int_compare:nNnT{\mag} = {\@m}
+    {
+      \__kernel_backend_first_shipout:n
+       {
+         \cs_if_exist:NTF \stockwidth
+           {
+             \@@_backend_pagesize_set:nn {\stockwidth}{\stockheight}
+           }
+           {
+             \@@_backend_pagesize_set:nn {\paperwidth}{\paperheight}
+           }
+       }%
+    }
+ }
+%    \end{macrocode}
+% \end{macro}
+%
 %    \begin{macrocode}
 %</dvips>
 %    \end{macrocode}
@@ -1227,6 +1268,43 @@
 % \end{macro}
 % \end{macro}
 %
+% \subsubsection{PDF page size (mediabox)}
+% This code is more or less a copy of the code in graphics-def.
+% The code tests that the dimensions are larger than
+% zero as setting a zero page size doesn't make sense.
+% The page size is set in \cs{@kernel@before@begindocument}:
+% this is after the backend code has been loaded but before other
+% settings from package like geometry or graphics or memoir.
+% Similar to the setting in graphics nothing is done if
+% mag has been set.
+% \begin{macro}{\@@_backend_pagesize_set:nn}
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_backend_pagesize_set:nn #1 #2
+  {
+    \bool_lazy_and:nnT
+      {\dim_compare_p:nNn {#1}>{0pt}} {\dim_compare_p:nNn {#2}>{0pt}}
+      {
+       \dim_set:Nn  \tex_pagewidth:D {#1}
+       \dim_set:Nn  \tex_pageheight:D {#2}
+      }
+  }
+
+\tl_gput_right:Nn \@kernel@before@begindocument
+ {
+   \int_compare:nNnT{\mag} = {\@m}
+    {
+      \cs_if_exist:NTF \stockwidth
+       {
+         \@@_backend_pagesize_set:nn {\stockwidth}{\stockheight}
+       }
+       {
+         \@@_backend_pagesize_set:nn {\paperwidth}{\paperheight}
+       }
+    }
+ }
+%    \end{macrocode}
+% \end{macro}
+
 %    \begin{macrocode}
 %</luatex|pdftex>
 %    \end{macrocode}
@@ -1590,6 +1668,75 @@
 %    \begin{macrocode}
 %</dvipdfmx|xetex>
 %    \end{macrocode}
+% \subsubsection{PDF page size (mediabox)}
+% This code is more or less a copy of the code in graphics-def.
+% The code tests that the dimensions are larger than
+% zero as setting a zero page size doesn't make sense.
+% The page size is set in \cs{@kernel@before@begindocument}:
+% this is after the backend code has been loaded but before other
+% settings from package like geometry or graphics or memoir.
+% Similar to the setting in graphics nothing is done if
+% mag has been set. For dvipdfmx we delay the setting
+% to the shipout/firstpage hook.
+% \begin{macro}{\@@_backend_pagesize_set:nn}
+%    \begin{macrocode}
+%<*xetex>
+\cs_new_protected:Npn \@@_backend_pagesize_set:nn #1 #2
+  {
+    \bool_lazy_and:nnT
+      {\dim_compare_p:nNn {#1}>{0pt}} {\dim_compare_p:nNn {#2}>{0pt}}
+      {
+       \dim_set:Nn  \tex_pagewidth:D {#1}
+       \dim_set:Nn  \tex_pageheight:D {#2}
+      }
+  }
+\tl_gput_right:Nn \@kernel@before@begindocument
+ {
+   \int_compare:nNnT{\mag} = {\@m}
+    {
+      \cs_if_exist:NTF \stockwidth
+       {
+         \@@_backend_pagesize_set:nn {\stockwidth}{\stockheight}
+       }
+       {
+         \@@_backend_pagesize_set:nn {\paperwidth}{\paperheight}
+       }
+    }
+ }
+%</xetex>
+%    \end{macrocode}
+%    \begin{macrocode}
+%<*dvipdfmx>
+\cs_new_protected:Npn \@@_backend_pagesize_set:nn #1 #2
+  {
+    \bool_lazy_and:nnT
+      {\dim_compare_p:nNn {#1}>{0pt}} {\dim_compare_p:nNn {#2}>{0pt}}
+      {
+       \__kernel_backend_literal:e
+         {pdf:pagesize ~ width ~ \dim_eval:n{#1} ~ height ~ \dim_eval:n{#2}}
+      }
+  }
+\tl_gput_right:Nn \@kernel@before@begindocument
+ {
+   \int_compare:nNnT{\mag} = {\@m}
+    {
+      \__kernel_backend_first_shipout:n
+       {
+         \cs_if_exist:NTF \stockwidth
+           {
+             \@@_backend_pagesize_set:nn {\stockwidth}{\stockheight}
+           }
+           {
+             \@@_backend_pagesize_set:nn {\paperwidth}{\paperheight}
+           }
+       }%
+    }
+ }
+%</dvipdfmx>
+%    \end{macrocode}
+% \end{macro}
+
+
 %
 % \subsection{\texttt{dvisvgm} backend}
 %
@@ -1671,7 +1818,12 @@
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
-%
+% \begin{macro}{\@@_backend_pagesize_set:nn}
+%   More no-ops.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_backend_pagesize_set:nn #1#2 { }
+%    \end{macrocode}
+% \end{macro}
 %    \begin{macrocode}
 %</dvisvgm>
 %    \end{macrocode}


### PR DESCRIPTION
This adds the code to set the mediabox /pagesize currently used in graphics-def into l3backend so that the  mediabox are set always and not only if packages like graphics or geometry are loaded. 

There is no public interface currently (changing the pagesize in mid-document doesn't work for all engines with these functions) and testfiles are still missing.