### PR TITLE
Fix `\iow_open:N` in ConTeXt MkII

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -1499,10 +1499,21 @@
 %
 % \begin{macro}{\@@_new:N}
 %   As for read streams, copy \tn{newwrite}, making sure
-%   that it is not \tn{outer}.
+%   that it is not \tn{outer}. For \ConTeXt{}, we have to
+%   deal with the fact that \tn{newwrite} works like our
+%   own: it actually checks before altering definition.
 %    \begin{macrocode}
 \exp_args:NNf \cs_new_protected:Npn \@@_new:N
   { \exp_args:NNc \exp_after:wN \exp_stop_f: { newwrite } }
+\cs_if_exist:NT \normalend
+  {
+    \cs_new_eq:NN \@@_new_aux:N \@@_new:N
+    \cs_set_protected:Npn \@@_new:N #1
+      {
+        \cs_undefine:N #1
+        \@@_new_aux:N #1
+      }
+  }
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
For ConTeXt MkII, we have to deal with the fact that `\newwrite` works like our own: it actually checks before altering definition. Thia pull request patches `\__iow_new:N` accordingly. See https://github.com/Witiko/lt3luabridge/pull/3 for a discussion of the issue with @josephwright.