### PR TITLE
docs: fix a typo for name of generic load

### DIFF
--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -952,8 +952,8 @@
 % \section{Using \pkg{expl3} with formats other than \LaTeXe{}}
 %
 % As well as the \LaTeXe{} package \pkg{expl3}, there is also a
-% \enquote{generic} loader for the code, \texttt{expl3.tex}. This may be
-% loaded using the plain \TeX{} syntax
+% \enquote{generic} loader for the code, \texttt{expl3-generic.tex}.
+% This may be loaded using the plain \TeX{} syntax
 % \begin{verbatim}
 %   \input expl3-generic %
 % \end{verbatim}


### PR DESCRIPTION
The generic loader is named `expl3-generic.tex`, not `expl3.tex`.

See commit 6edc6754d4f4b1ada1f919974ac7ee9deea1108c