### PR TITLE
Make ConTeXt detection in l3file more robust

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -981,7 +981,7 @@
 \int_step_inline:nnn
   { 0 }
   {
-    \str_if_eq:VnTF \c_sys_engine_format_str { cont-en }
+    \cs_if_exist:NTF \contextversion
       { \tex_count:D 38 ~ }
       {
         \tex_count:D 16 ~ %
@@ -1061,7 +1061,7 @@
 %    \begin{macrocode}
 \exp_args:NNf \cs_new_protected:Npn \@@_new:N
   { \exp_args:NNc \exp_after:wN \exp_stop_f: { newread } }
-\str_if_eq:VnT \c_sys_engine_format_str { cont-en }
+\cs_if_exist:NT \contextversion
   {
     \cs_new_eq:NN \@@_new_aux:N \@@_new:N
     \cs_gset_protected:Npn \@@_new:N #1
@@ -1441,7 +1441,7 @@
 \int_step_inline:nnn
   { 0 }
   {
-    \str_if_eq:VnTF \c_sys_engine_format_str { cont-en }
+    \cs_if_exist:NTF \contextversion
       { \tex_count:D 39 ~ }
       {
         \tex_count:D 17 ~
@@ -1505,7 +1505,7 @@
 %    \begin{macrocode}
 \exp_args:NNf \cs_new_protected:Npn \@@_new:N
   { \exp_args:NNc \exp_after:wN \exp_stop_f: { newwrite } }
-\str_if_eq:VnT \c_sys_engine_format_str { cont-en }
+\cs_if_exist:NT \contextversion
   {
     \cs_new_eq:NN \@@_new_aux:N \@@_new:N
     \cs_gset_protected:Npn \@@_new:N #1


### PR DESCRIPTION
In #1114, we used `\c_sys_engine_format_str` to detect the ConTeXt format in l3file. However, [further discussion with ConTeXt developers][1] indicates that the existence of the `\contextversion` command is a more robust test. This pull request replaces the four tests in l3file with the more robust test.

[1]: https://mailman.ntg.nl/pipermail/dev-context/2022/003916.html