### PR TITLE
docs: fix a typo in l3keys [ci skip]

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -806,7 +806,7 @@
 % setting, even though these keys have the same path. For example, with
 % a set of keys defined using
 % \begin{verbatim}
-%   \keys define:nn { mymodule }
+%   \keys_define:nn { mymodule }
 %     {
 %       key-one   .code:n   = { \my_func:n {#1} } ,
 %       key-two   .tl_set:N = \l_my_a_tl          ,
@@ -820,7 +820,7 @@
 % arbitrary sets which are independent of the key tree. Thus modifying the
 % example to read
 % \begin{verbatim}
-%   \keys define:nn { mymodule }
+%   \keys_define:nn { mymodule }
 %     {
 %       key-one   .code:n   = { \my_func:n {#1} } ,
 %       key-one   .groups:n = { first }           ,


### PR DESCRIPTION
The current documentation writes `\keys define:nn` instead of `\keys_define:nn`.