### PR TITLE
Fix `cs_to_str:N` misspelled as `cs_to_sr:N`

### DIFF
--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -1639,7 +1639,7 @@
 % \begin{macro}{\tl_build_end:N, \tl_build_gend:N, \@@_build_end_loop:NN}
 %   Get the data then clear the \meta{next~tl} recursively until finding
 %   an empty one.  It is perhaps wasteful to repeatedly use
-%   \cs{cs_to_sr:N}.  The local/global scope is checked by
+%   \cs{cs_to_str:N}.  The local/global scope is checked by
 %   \cs{tl_set:Nx} or \cs{tl_gset:Nx}.
 %    \begin{macrocode}
 \cs_new_protected:Npn \tl_build_end:N #1


### PR DESCRIPTION
They indexed separately.
![image](https://user-images.githubusercontent.com/23036788/192595021-a8448258-9bf8-4ed9-b344-fe2e22f05af4.png)

![image](https://user-images.githubusercontent.com/23036788/192594822-c3fa5859-fcca-4c87-9603-6b307e63082d.png)
