### PR TITLE
Update GH Actions

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,7 +16,7 @@ jobs:
     steps:
       # Boilerplate
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # We need Ghostscript for dvips and XeTeX tests.
       - run: sudo apt-get update && sudo apt-get install ghostscript
       - name: Install TeX Live
@@ -37,7 +37,7 @@ jobs:
           retention-days: 3
       # Now create the release (this only runs if the previous steps were successful)
       - name: Create GitHub release
-        uses: ncipollo/release-action@880be3d0a71bc0fa98db60201d2cbdc27324f547
+        uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e # v1.12.0
         id: release
         with:
           artifacts: "*.zip"
@@ -57,7 +57,7 @@ jobs:
       - name: Send mail
         # The explicit commit hash ensures that this can't be used by dawidd6 as a
         # backdoor to execute arbitrary code during our runs.
-        uses: dawidd6/action-send-mail@ceb614a2c5737d913f2d2729e2bcc70ad933382b
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2 # v3.7.1
         with:
           # Currently using my (Marcel's) mail server for sending mails.
           server_address: typesetting.eu
@@ -80,7 +80,7 @@ jobs:
             More information can be found at
             ${{steps.release.outputs.html_url}}
       - name: Send failure notification
-        uses: dawidd6/action-send-mail@ceb614a2c5737d913f2d2729e2bcc70ad933382b
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2 # v3.7.1
         if: ${{ failure() }}
         with:
           server_address: typesetting.eu

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -42,17 +42,6 @@ jobs:
         with:
           artifacts: "*.zip"
           token: ${{ secrets.GITHUB_TOKEN }}
-      # Determine the name of the tag we are working on. Sadly GH Actions only provides
-      # github.ref which has the name prefixed with github.ref and no way to remove a prefix
-      # in normal expressions, so we need an action for that.
-      - name: Get name
-        uses: frabert/replace-string-action@9b62dfe3ae936b1cc380f2421c8ac9e63a4a3e85
-        id: name
-        if: ${{ always() }}
-        with:
-          pattern: "^refs/(?:heads|tags)/"
-          string: ${{ github.ref }}
-          replace-with: ""
       # While the normal notification job only informs about failed runs, we additionally want to notify about successful releases.
       - name: Send mail
         # The explicit commit hash ensures that this can't be used by dawidd6 as a
@@ -73,9 +62,9 @@ jobs:
           # to send from the mail address.
           from: LaTeX CI <github@latex-project.org>
           # Determine the subject and body of the mail.
-          subject: "Version ${{steps.name.outputs.replaced}} of ${{github.repository}} has been released"
+          subject: "Version ${{github.ref_name}} of ${{github.repository}} has been released"
           body: |
-            The release ${{steps.name.outputs.replaced}} has been created for ${{github.repository}}.
+            The release ${{github.ref_name}} has been created for ${{github.repository}}.
 
             More information can be found at
             ${{steps.release.outputs.html_url}}
@@ -91,12 +80,12 @@ jobs:
           from: LaTeX CI <github@latex-project.org>
           priority: high
           # Determine the subject and body of the mail.
-          subject: "Test failure while trying to build release ${{steps.name.outputs.replaced}} in ${{github.repository}}"
+          subject: "Test failure while trying to build release ${{github.ref_name}} in ${{github.repository}}"
           body: |
             Test failure for ${{github.repository}}
             -------------------------------------------------------------
 
-            On tag:           ${{steps.name.outputs.replaced}} (${{github.sha}})
+            On tag:           ${{github.ref_name}} (${{github.sha}})
             Initiated by:     ${{github.actor}}
             Commit URL:       https://github.com/${{github.repository}}/commit/${{github.sha}}
             More information: https://github.com/${{github.repository}}/actions/runs/${{github.run_id}}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -39,7 +39,7 @@ jobs:
     steps:
       # Boilerplate
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       # We need Ghostscript for dvips and XeTeX tests.
       - run: sudo apt-get update && sudo apt-get install ghostscript
       - name: Install TeX Live
@@ -54,7 +54,7 @@ jobs:
       # 1. If we failed running tests
       - name: Archive failed test output
         if: ${{ matrix.artifact_name != 'Documentation' && failure() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.artifact_name }}
           path: build/test*/*.diff
@@ -63,7 +63,7 @@ jobs:
       # 2. If we succeed building documentation
       - name: Archive documentation
         if: ${{ matrix.artifact_name == 'Documentation' && success() }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.artifact_name }}
           path: "**/*.pdf"
@@ -86,7 +86,7 @@ jobs:
       - name: Send mail
         # The explicit commit hash ensures that this can't be used by dawidd6 as a
         # backdoor to execute arbitrary code during our runs.
-        uses: dawidd6/action-send-mail@ceb614a2c5737d913f2d2729e2bcc70ad933382b
+        uses: dawidd6/action-send-mail@6063705cefe50cb915fc53bb06d4049cae2953b2 # v3.7.1
         with:
           # Currently using my (Marcel's) mail server for sending mails.
           server_address: typesetting.eu


### PR DESCRIPTION
- Update GH Actions to eliminate `Node.js 12 actions are deprecated.` warnings
- Use [context `github.ref_name`][github.ref_name] to replace action `frabert/replace-string-action`

PS: Would you like to have a [dependabot]? See use case in [texstudio] and [pgf].

[github.ref_name]: https://docs.github.com/en/actions/learn-github-actions/contexts#github-context
[dependabot]: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
[texstudio]: https://github.com/texstudio-org/texstudio/blob/master/.github/dependabot.yml
[pgf]: https://github.com/pgf-tikz/pgf/blob/master/.github/dependabot.yml

PS 2: Warnings thrown in latest Actions runs
<details>
  <summary> https://github.com/latex3/latex3/actions/runs/4076719889 </summary>

  > [Documentation](https://github.com/latex3/latex3/actions/runs/4076719889/jobs/7024826709)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
  >
  > [Test suite](https://github.com/latex3/latex3/actions/runs/4076719889/jobs/7024826485)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
</details>

<details>
  <summary> https://github.com/latex3/latex3/actions/runs/4077011206 </summary>

  > [Build release](https://github.com/latex3/latex3/actions/runs/4077011206/jobs/7025491269)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, ncipollo/release-action@880be3d0a71bc0fa98db60201d2cbdc27324f547, frabert/replace-string-action@9b62dfe3ae936b1cc380f2421c8ac9e63a4a3e85, dawidd6/action-send-mail@ceb614a2c5737d913f2d2729e2bcc70ad933382b. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
  >
  > [Build release](https://github.com/latex3/latex3/actions/runs/4077011206/jobs/7025491269#step:8:9)
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
</details>