### PR TITLE
Fix docs typo

### DIFF
--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -629,7 +629,7 @@
 %   tokens (|{| or |}| assuming normal \TeX{} category codes). Unless
 %   specifically required this should be avoided: expansion should be carried out using an
 %   appropriate argument specifier variant or the appropriate
-%   \cs[no-index]{exp_arg:N} function.
+%   \cs[no-index]{exp_args:N\meta{variant}} function.
 %   \begin{texnote}
 %     This is the \TeX{} primitive \tn{expandafter} renamed.
 %   \end{texnote}


### PR DESCRIPTION
Changes non-existent `\exp_arg:N` to `\exp_args:N<variant>`, as already mentioned in `l3expan.dtx`, line 156 below

https://github.com/latex3/latex3/blob/c250fd483f8806b5986a0dcc838250c452ca5ddd/l3kernel/l3expan.dtx#L147-L157

Fixes #1166