### PR TITLE
Integrating l3color/l3opacity and luaotfload

### DIFF
--- a/l3backend/CHANGELOG.md
+++ b/l3backend/CHANGELOG.md
@@ -6,6 +6,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Integrate l3color and l3opacity with luaotfload to ensure that
+  opacity specifications don't conflict.
+
 ## [2023-01-16]
 
 ### Changed

--- a/l3backend/build.lua
+++ b/l3backend/build.lua
@@ -9,7 +9,7 @@ bundle = ""
 -- Location of main directory: use Unix-style path separators
 maindir = ".."
 
-installfiles = {"*.def", "*.pro"}
+installfiles = {"*.def", "*.pro", "*.lua"}
 sourcefiles  = {"*.dtx", "*.ins"}
 tagfiles     = {"*.dtx", "CHANGELOG.md", "README.md", "*.ins"}
 typesetfiles = {"l3backend-code.tex"}

--- a/l3backend/build.lua
+++ b/l3backend/build.lua
@@ -9,7 +9,7 @@ bundle = ""
 -- Location of main directory: use Unix-style path separators
 maindir = ".."
 
-installfiles = {"*.def", "*.pro", "*.lua"}
+installfiles = {"*.def", "*.pro", "l3backend*.lua"}
 sourcefiles  = {"*.dtx", "*.ins"}
 tagfiles     = {"*.dtx", "CHANGELOG.md", "README.md", "*.ins"}
 typesetfiles = {"l3backend-code.tex"}

--- a/l3backend/l3backend-color.dtx
+++ b/l3backend/l3backend-color.dtx
@@ -1289,7 +1289,7 @@ end
 if luaotfload and luaotfload.set_transparent_colorstack then
   local htmlcolor = l.Cs(octet * octet * octet * -1 * l.Cc'rg')
   local color_export = {
-    token.create'endlocalcontrol',
+    token.create'tex_endlocalcontrol:D',
     token.create'tex_hpack:D',
     token.new(0, 1),
     token.create'color_export:nnN',

--- a/l3backend/l3backend-color.dtx
+++ b/l3backend/l3backend-color.dtx
@@ -1264,6 +1264,85 @@
 %</package>
 %    \end{macrocode}
 %
+% \subsection{Font handling integration}
+%
+% In \LuaTeX{} these colors should also be usable to color fonts, so
+% \texttt{luaotfload} color handling is extended to include these.
+%
+%    \begin{macrocode}
+%<*luatex>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%<*lua>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+local l = lpeg
+local spaces = l.P' '^0
+local digit16 = l.R('09', 'af', 'AF')
+
+local octet = digit16 * digit16 / function(s)
+  return string.format('%.3g ', tonumber(s, 16) / 255)
+end
+
+if luaotfload and luaotfload.set_transparent_colorstack then
+  local htmlcolor = l.Cs(octet * octet * octet * -1 * l.Cc'rg')
+  local color_export = {
+    token.create'endlocalcontrol',
+    token.create'tex_hpack:D',
+    token.new(0, 1),
+    token.create'color_export:nnN',
+    token.new(0, 1),
+    '',
+    token.new(0, 2),
+    token.new(0, 1),
+    'backend',
+    token.new(0, 2),
+    token.create'l_tmpa_tl',
+    token.create'exp_after:wN',
+    token.create'__color_select:nn',
+    token.create'l_tmpa_tl',
+    token.new(0, 2),
+  }
+  local group_end = token.create'group_end:'
+  local value = (1 - l.P'}')^0
+  luatexbase.add_to_callback('luaotfload.parse_color', function (value)
+% Also allow HTML colors to preserve compatibility
+    local html = htmlcolor:match(value)
+    if html then return html end
+
+    tex.runtoks(function()
+      token.get_next()
+      color_export[6] = value
+      tex.sprint(-2, color_export)
+    end)
+    local list = token.scan_list()
+    if not list.head or list.head.next
+        or list.head.subtype ~= node.subtype'pdf_colorstack' then
+      error'Unexpected backend behavior'
+    end
+    local cmd = list.head.data
+    node.free(list)
+    return cmd
+  end, 'l3color')
+end
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</lua>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%<*package>
+\lua_load_module:n {l3backend-luatex}
+%</package>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</luatex>
+%    \end{macrocode}
+%
 % \end{implementation}
 %
 % \PrintIndex

--- a/l3backend/l3backend-color.dtx
+++ b/l3backend/l3backend-color.dtx
@@ -1270,10 +1270,6 @@
 % \texttt{luaotfload} color handling is extended to include these.
 %
 %    \begin{macrocode}
-%<*luatex>
-%    \end{macrocode}
-%
-%    \begin{macrocode}
 %<*lua>
 %    \end{macrocode}
 %
@@ -1331,6 +1327,10 @@ end
 %
 %    \begin{macrocode}
 %</lua>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%<*luatex>
 %    \end{macrocode}
 %
 %    \begin{macrocode}

--- a/l3backend/l3backend-opacity.dtx
+++ b/l3backend/l3backend-opacity.dtx
@@ -287,6 +287,77 @@
 %</package>
 %    \end{macrocode}
 %
+% \subsection{Font handling integration}
+%
+% In \LuaTeX{} we want to use these functions also for transparent fonts
+% to avoid interference between both uses of transparency.
+%
+%    \begin{macrocode}
+%<*luatex>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%<*lua>
+%    \end{macrocode}
+%
+% First we need to check if pdfmanagement is active from Lua.
+%    \begin{macrocode}
+local pdfmanagement_active do
+  local pdfmanagement_if_active_p = token.create'pdfmanagement_if_active_p:'
+  local cmd = pdfmanagement_if_active_p.cmdname
+  if cmd == 'undefined_cs' then
+    pdfmanagement_active = false
+  else
+    token.put_next(pdfmanagement_if_active_p)
+    pdfmanagement_active = token.scan_int() ~= 0
+  end
+end
+
+if pdfmanagement_active and luaotfload and luaotfload.set_transparent_colorstack then
+  luaotfload.set_transparent_colorstack(token.create'c__opacity_backend_stack_int'.index)
+
+  local transparent_register = {
+    token.create'pdfmanagement_add:nnn',
+    token.new(0, 1),
+      'Page/Resources/ExtGState',
+    token.new(0, 2),
+    token.new(0, 1),
+      '',
+    token.new(0, 2),
+    token.new(0, 1),
+      '<</ca ',
+      '',
+      '/CA ',
+      '',
+      '>>',
+    token.new(0, 2),
+  }
+  luatexbase.add_to_callback('luaotfload.parse_transparent', function(value)
+    value = (octet * -1):match(value)
+    if not value then
+      tex.error'Invalid transparency value'
+      return
+    end
+    value = value:sub(1, -2)
+    local result = 'opacity' .. value
+    tex.runtoks(function()
+      transparent_register[6], transparent_register[10], transparent_register[12] = result, value, value
+      tex.sprint(-2, transparent_register)
+    end)
+    return '/' .. result .. ' gs'
+  end, 'l3opacity')
+end
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</lua>
+%    \end{macrocode}
+%
+%    \begin{macrocode}
+%</luatex>
+%    \end{macrocode}
+%
+%
 % \end{implementation}
 %
 % \PrintIndex

--- a/l3backend/l3backend-opacity.dtx
+++ b/l3backend/l3backend-opacity.dtx
@@ -293,10 +293,6 @@
 % to avoid interference between both uses of transparency.
 %
 %    \begin{macrocode}
-%<*luatex>
-%    \end{macrocode}
-%
-%    \begin{macrocode}
 %<*lua>
 %    \end{macrocode}
 %
@@ -351,10 +347,6 @@ end
 %
 %    \begin{macrocode}
 %</lua>
-%    \end{macrocode}
-%
-%    \begin{macrocode}
-%</luatex>
 %    \end{macrocode}
 %
 %

--- a/l3backend/l3backend.ins
+++ b/l3backend/l3backend.ins
@@ -112,6 +112,14 @@ and all files in that bundle must be distributed together.
   }
 \generate
   {
+    \file{l3backend-luatex.lua}
+      {
+        \from{l3backend-color.dtx}   {lua,luatex}
+        \from{l3backend-opacity.dtx} {lua,luatex}
+      }
+  }
+\generate
+  {
     \file{l3backend-pdftex.def}
       {
         \from{l3backend-basics.dtx}  {package,pdftex}

--- a/l3backend/l3backend.ins
+++ b/l3backend/l3backend.ins
@@ -52,9 +52,6 @@ and all files in that bundle must be distributed together.
 \postamble
 \endpostamble
 
-\edef\luapreamble{--[[^^J\defaultpreamble^^J]]}
-\edef\luapostamble{--[[^^J\defaultpostamble^^J]]}
-
 \keepsilent
 
 \generate
@@ -115,17 +112,6 @@ and all files in that bundle must be distributed together.
   }
 \generate
   {
-    \def\MetaPrefix{--}
-    \usepreamble\luapreamble
-    \usepostamble\luapostamble
-    \file{l3backend-luatex.lua}
-      {
-        \from{l3backend-color.dtx}   {lua,luatex}
-        \from{l3backend-opacity.dtx} {lua,luatex}
-      }
-  }
-\generate
-  {
     \file{l3backend-pdftex.def}
       {
         \from{l3backend-basics.dtx}  {package,pdftex}
@@ -148,6 +134,34 @@ and all files in that bundle must be distributed together.
         \from{l3backend-graphics.dtx}{package,xetex}
         \from{l3backend-pdf.dtx}     {package,xetex}
         \from{l3backend-opacity.dtx} {package,xetex}
+      }
+  }
+
+% Lua code
+
+\def\MetaPrefix{--}
+\preamble
+
+Copyright (C) 2023 The LaTeX Project
+
+It may be distributed and/or modified under the conditions of
+the LaTeX Project Public License (LPPL), either version 1.3c of
+this license or (at your option) any later version.  The latest
+version of this license is in the file:
+
+   https://www.latex-project.org/lppl.txt
+
+This file is part of the "l3backend bundle" (The Work in LPPL)
+and all files in that bundle must be distributed together.
+
+\endpreamble
+\nopostamble
+\generate
+  {
+    \file{l3backend-luatex.lua}
+      {
+        \from{l3backend-color.dtx}   {lua}
+        \from{l3backend-opacity.dtx} {lua}
       }
   }
 

--- a/l3backend/l3backend.ins
+++ b/l3backend/l3backend.ins
@@ -52,6 +52,9 @@ and all files in that bundle must be distributed together.
 \postamble
 \endpostamble
 
+\edef\luapreamble{--[[^^J\defaultpreamble^^J]]}
+\edef\luapostamble{--[[^^J\defaultpostamble^^J]]}
+
 \keepsilent
 
 \generate
@@ -112,6 +115,9 @@ and all files in that bundle must be distributed together.
   }
 \generate
   {
+    \def\MetaPrefix{--}
+    \usepreamble\luapreamble
+    \usepostamble\luapostamble
     \file{l3backend-luatex.lua}
       {
         \from{l3backend-color.dtx}   {lua,luatex}

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- `\tex_endlocalcontrol:D` as expl3 name for the LuaTeX primitive
+
 ## [2023-02-22]
 
 ### Changed

--- a/l3kernel/l3names.dtx
+++ b/l3kernel/l3names.dtx
@@ -832,6 +832,7 @@
   \@@_primitive:NN \dvivariable           \tex_dvivariable:D
   \@@_primitive:NN \eTeXglueshrinkorder   \tex_eTeXglueshrinkorder:D
   \@@_primitive:NN \eTeXgluestretchorder  \tex_eTeXgluestretchorder:D
+  \@@_primitive:NN \endlocalcontrol       \tex_endlocalcontrol:D
   \@@_primitive:NN \etoksapp              \tex_etoksapp:D
   \@@_primitive:NN \etokspre              \tex_etokspre:D
   \@@_primitive:NN \exceptionpenalty      \tex_exceptionpenalty:D


### PR DESCRIPTION
Integrate l3color and l3opacity with luaotfload to allow both systems to set colors and transparency without interfering with one another.