### PR TITLE
Fix minor version in `\c_sys_engine_version_str` for pdfTeX and LuaTeX

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Fix minor version in `\c_sys_engine_version_str` for pdfTeX and LuaTeX
+  (issue [\#1186](https://github.com/latex3/latex3/issues/1186))
+
 ## [2023-03-09]
 
 ### Added

--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -1319,7 +1319,9 @@
       {
         { pdftex }
           {
-            \fp_eval:n { round(\int_use:N \tex_pdftexversion:D / 100 , 2) }
+            \int_div_truncate:nn { \tex_pdftexversion:D } { 100 }
+            .
+            \int_mod:nn { \tex_pdftexversion:D } { 100 }
             .
             \tex_pdftexrevision:D
           }
@@ -1338,7 +1340,9 @@
           }
         { luatex }
           {
-            \fp_eval:n { round(\int_use:N \tex_luatexversion:D / 100, 2) }
+            \int_div_truncate:nn { \tex_luatexversion:D } { 100 }
+            .
+            \int_mod:nn { \tex_luatexversion:D } { 100 }
             .
             \tex_luatexrevision:D
           }


### PR DESCRIPTION
Fixes #1186

Need a new test file, perhaps in suite `testfiles-backend`?