### PR TITLE
Add "pdf-attr" key to l3graphics

### DIFF
--- a/l3backend/CHANGELOG.md
+++ b/l3backend/CHANGELOG.md
@@ -6,6 +6,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Pass additional attributes when loading PDF graphics
+
 ### Fixed
 - Remove a stray `>` from graphics inclusion code for `dvipdfmx`
 

--- a/l3backend/CHANGELOG.md
+++ b/l3backend/CHANGELOG.md
@@ -7,7 +7,7 @@ this project uses date-based 'snapshot' version identifiers.
 ## [Unreleased]
 
 ### Changed
-- Pass additional attributes when loading PDF graphics
+- Pass additional attributes when loading graphics in PDF mode
 
 ### Fixed
 - Remove a stray `>` from graphics inclusion code for `dvipdfmx`

--- a/l3backend/l3backend-graphics.dtx
+++ b/l3backend/l3backend-graphics.dtx
@@ -191,6 +191,8 @@
           { :D \l_@@_decodearray_str }
         \bool_if:NT \l_@@_interpolate_bool
           { :I }
+        \str_if_empty:NF \l_@@_pdf_str
+          { :X \l_@@_pdf_str }
       }
     \@@_backend_getbb_auxi:n {#1}
   }
@@ -205,6 +207,8 @@
         : \l_@@_pagebox_tl
         \int_compare:nNnT \l_@@_page_int > 1
           { :P \int_use:N \l_@@_page_int }
+        \str_if_empty:NF \l_@@_pdf_str
+          { :X \l_@@_pdf_str }
       }
     \@@_backend_getbb_auxi:n {#1}
   }
@@ -231,9 +235,12 @@
 \cs_new_protected:Npn \@@_backend_getbb_auxiii:n #1
   {
     \tex_immediate:D \tex_pdfximage:D
-      \bool_lazy_or:nnT
-        { \l_@@_interpolate_bool }
-        { ! \tl_if_empty_p:N \l_@@_decodearray_str }
+      \bool_lazy_any:nT
+        {
+          { \l_@@_interpolate_bool }
+          { ! \tl_if_empty_p:N \l_@@_decodearray_str }
+          { ! \str_if_empty_p:N \l_@@_pdf_str }
+        }
         {
           attr ~
             {
@@ -241,6 +248,7 @@
                 { /Decode~[ \l_@@_decodearray_str ] }
               \bool_if:NT \l_@@_interpolate_bool
                 { /Interpolate~true }
+              \l_@@_pdf_str
             }
         }
       \int_compare:nNnT \l_@@_page_int > 0

--- a/l3experimental/CHANGELOG.md
+++ b/l3experimental/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Key `pdf-attr` to `l3graphics` for additional attribute setting
+
 ### Fixed
 - Grouping in `\draw_path_arc_axes:nnnn` (see \#1195)
 

--- a/l3experimental/l3graphics/l3graphics.dtx
+++ b/l3experimental/l3graphics/l3graphics.dtx
@@ -78,6 +78,13 @@
 %   which may contain multiple pages.
 % \end{variable}
 %
+% \begin{variable}{pdf-attr}
+%   Additional PDF-focussed attributes: available to allow control of
+%   extended |.pdf| structures beyond those needed for graphic inclusion.
+%   Due to backend restrictions, this key is only functional with direct
+%   PDF mode (pdf\TeX{} and Lua\TeX{}).
+% \end{variable}
+%
 % \begin{variable}{pagebox}
 %   The nature of the page box setting used to determine the bounding box of
 %   material: used for |.pdf| files which feature multiple page box
@@ -206,6 +213,7 @@
 %     \l_@@_interpolate_bool ,
 %     \l_@@_page_int         ,
 %     \l_@@_pagebox_tl       ,
+%     \l_@@_pdf_str          ,
 %     \l_@@_type_str
 %   }
 %   Keys which control features of graphics. The standard value of |pagebox|
@@ -235,6 +243,8 @@
       crop ,
     page .int_set:N =
       \l_@@_page_int ,
+    pdf-attr .str_set:N =
+      \l_@@_pdf_str ,
     type . str_set:N =
       \l_@@_type_str
   }


### PR DESCRIPTION
Most of the change here is trivial. Note the adjustment needed for XeTeX
as \XeTeXpdffile does not support adding attributes.