### PR TITLE
Fix doc typo for `l3draw`

### DIFF
--- a/l3experimental/l3draw/l3draw.dtx
+++ b/l3experimental/l3draw/l3draw.dtx
@@ -340,7 +340,7 @@
 %     \draw_join_round:
 %   }
 %   \begin{syntax}
-%     \cs{draw_cap_butt:}
+%     \cs{draw_join_miter:}
 %   \end{syntax}
 %   Sets the style of stroke joins to one of bevel, miter or round.
 % \end{function}


### PR DESCRIPTION
Currently a line cap function `\draw_cap_butt:` is used as the representative  for line join functions (`\draw_join_xxx:n`). This PR corrects it to `\draw_join_miter:`, representing the initial line join state.