### PR TITLE
Fix typo

### DIFF
--- a/l3packages/README.md
+++ b/l3packages/README.md
@@ -42,7 +42,8 @@ FPU. As such, it is a wrapper around the core `\fp_eval:n` function
 but does not require code syntax. It provides the expandable command
 `\fpeval`, which can be used inside for example `\edef` or contexts
 where TeX requires a number.
-From 2022-06-01 release if LaTeX this will be included in the format
+
+From 2022-06-01 release of LaTeX this will be included in the format
 so that the package  doesn't need loading any longer.
 
 `xfrac`


### PR DESCRIPTION
"From 2022-06-01 release **if** LaTeX" -> "From 2022-06-01 release **of** LaTeX"

introduced in a240694 (prepare for xfp commands to be added to 2e kernel, 2021-11-30)