### PR TITLE
Deprecated \tl_sort:nN for \tl_sort_use:nN

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,6 +10,7 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - `\text_titlecase_all:n(n)`
 - `\token_to_catcode:N`
+- `\tl_reverse_use:n` (was `\tl_reverse:n`)
 - `\tl_sort_use:nN` (was `\tl_sort:nN`)
 - Support for symbolic variables in fp input:
   `\fp_new_variable:n`, `\fp_set_variable:nn` and `\fp_clear_variable:n`
@@ -22,6 +23,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Deprecated
 - `\text_titlecase:n(n)` as ambiguous: replaced by `\text_titlecase_all:n(n)`
+- `\tl_reverse:n`, replaced by `\tl_reverse_use:n`
 - `\tl_sort:nN`, replaced by `\tl_sort_use:nN` (issue \#914)
 
 ### Fixed

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,6 +10,7 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - `\text_titlecase_all:n(n)`
 - `\token_to_catcode:N`
+- `\tl_sort_use:nN` (was `\tl_sort:nN`)
 - Support for symbolic variables in fp input:
   `\fp_new_variable:n`, `\fp_set_variable:nn` and `\fp_clear_variable:n`
 - Support for user-defined functions in fp expressions:
@@ -21,6 +22,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Deprecated
 - `\text_titlecase:n(n)` as ambiguous: replaced by `\text_titlecase_all:n(n)`
+- `\tl_sort:nN`, replaced by `\tl_sort_use:nN` (issue \#914)
 
 ### Fixed
 - Support arbitrary BCP-47 locales for case-changing overrides (issue \#1239)
@@ -138,6 +140,7 @@ this project uses date-based 'snapshot' version identifiers.
 - `\file_input_raw:n`
 - `\int_if_zero:n(TF)`
 - `\str_mdfive_hash:n`
+
 ### Changed
 - Remove `\noexpand` inside math mode in `\text_expand:n`
 - Re-implement `\dim_to_decimal_in_bp:n` and 

--- a/l3kernel/doc/l3obsolete.txt
+++ b/l3kernel/doc/l3obsolete.txt
@@ -70,6 +70,7 @@ Function                            Date deprecated
 \tl_lower_case:nn                        2020-01-03
 \tl_mixed_case:n                         2020-01-03
 \tl_mixed_case:nn                        2020-01-03
+\tl_sort:nN                              2023-05-19
 \tl_upper_case:n                         2020-01-03
 \tl_upper_case:nn                        2020-01-03
 [x-type variants]                        2023-09-27

--- a/l3kernel/doc/l3obsolete.txt
+++ b/l3kernel/doc/l3obsolete.txt
@@ -70,6 +70,7 @@ Function                            Date deprecated
 \tl_lower_case:nn                        2020-01-03
 \tl_mixed_case:n                         2020-01-03
 \tl_mixed_case:nn                        2020-01-03
+\tl_reverse:n                            2023-05-22
 \tl_sort:nN                              2023-05-19
 \tl_upper_case:n                         2020-01-03
 \tl_upper_case:nn                        2020-01-03

--- a/l3kernel/doc/l3syntax-changes.tex
+++ b/l3kernel/doc/l3syntax-changes.tex
@@ -59,7 +59,7 @@ changes after August 2011 are listed, with an approximate date.
       \meta{normal token or brace group}
       \meta{optional spaces}.
     \]
-  \item \cs{tl_reverse:n} stripped outer braces and lost unprotected spaces.
+  \item \cs{tl_reverse_use:n} stripped outer braces and lost unprotected spaces.
     Now it keeps spaces, leaves unbraced single tokens unbraced, and
     braced groups braced.
   \item \cs{tl_trim_spaces:n} only removed one leading and trailing space.

--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -614,6 +614,13 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\tl_sort:nN}
+%    \begin{macrocode}
+\__kernel_patch_deprecation:nnNNpn { 2023-10-18 } { \tl_sort_use:nN }
+\cs_gset:Npn \tl_sort:nN { \tl_sort_use:nN }
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsection{Deprecated \pkg{l3token} functions}
 %
 % \begin{macro}[EXP]{\char_to_utfviii_bytes:n}

--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -621,6 +621,13 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\tl_reverse:n}
+%    \begin{macrocode}
+\__kernel_patch_deprecation:nnNNpn { 2023-10-18 } { \tl_reverse_use:n }
+\cs_gset:Npn \tl_reverse:n { \tl_reverse_use:n }
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsection{Deprecated \pkg{l3token} functions}
 %
 % \begin{macro}[EXP]{\char_to_utfviii_bytes:n}

--- a/l3kernel/l3sort.dtx
+++ b/l3kernel/l3sort.dtx
@@ -689,14 +689,14 @@
 % first item as a pivot (argument |#4| of \cs{@@:nnNnn}).  The
 % arguments of \cs{@@:nnNnn} are 1.~items less than |#4|, 2.~items
 % greater or equal to |#4|, 3.~comparison, 4.~pivot, 5.~next item to
-% test.  If |#5| is the tail of the list, call \cs{tl_sort:nN} on |#1|
+% test.  If |#5| is the tail of the list, call \cs{tl_sort_use:nN} on |#1|
 % and on |#2|, placing |#4| in between; |\use:ff| expands the parts to
-% make \cs{tl_sort:nN} \texttt{f}-expandable.  Otherwise, compare |#4|
+% make \cs{tl_sort_use:nN} \texttt{f}-expandable.  Otherwise, compare |#4|
 % and |#5| using |#3|.  If they are ordered, place |#5| amongst the
 % \enquote{greater} items, otherwise amongst the \enquote{lesser} items,
 % and continue partitioning.
 % \begin{verbatim}
-% \cs_new:Npn \tl_sort:nN #1#2
+% \cs_new:Npn \tl_sort_use:nN #1#2
 %   {
 %     \tl_if_blank:nF {#1}
 %       {
@@ -707,7 +707,7 @@
 % \cs_new:Npn \__sort:nnNnn #1#2#3#4#5
 %   {
 %     \quark_if_recursion_tail_stop_do:nn {#5}
-%       { \use:ff { \tl_sort:nN {#1} #3 {#4} } { \tl_sort:nN {#2} #3 } }
+%       { \use:ff { \tl_sort_use:nN {#1} #3 {#4} } { \tl_sort_use:nN {#2} #3 } }
 %     #3 {#4} {#5}
 %       { \__sort:nnNnn {#1} { #2 {#5} } #3 {#4} }
 %       { \__sort:nnNnn { #1 {#5} } {#2} #3 {#4} }
@@ -790,7 +790,7 @@
 % after code that sorts the smaller items, and after the (braced)
 % \meta{pivot}.
 %
-% The fourth speed up is avoid the recursive call to \cs{tl_sort:nN}
+% The fourth speed up is avoid the recursive call to \cs{tl_sort_use:nN}
 % with an empty first argument.  For this, we introduce functions
 % similar to the \cs{@@_i:nnnnNn} of the last example, but aware of
 % whether the list of \meta{conditional} \Arg{item} read so far that are
@@ -821,7 +821,7 @@
 % sorting lists of more than a few thousand items would exhaust a
 % typical \TeX{}'s memory.
 %
-% \begin{macro}[EXP]{\tl_sort:nN}
+% \begin{macro}[EXP]{\tl_sort_use:nN}
 % \begin{macro}[EXP]
 %   {
 %     \@@_quick_prepare:Nnnn,
@@ -844,7 +844,7 @@
 %   \cs{s_@@_stop} and leaving \cs{exp_stop_f:} to stop
 %   \texttt{f}-expansion.
 %    \begin{macrocode}
-\cs_new:Npn \tl_sort:nN #1#2
+\cs_new:Npn \tl_sort_use:nN #1#2
   {
     \exp_not:f
       {

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -550,10 +550,13 @@
 %   |a~{bc}| is $6$.
 % \end{function}
 %
-% \begin{function}[updated = 2012-01-08, EXP]
-%   {\tl_reverse:n, \tl_reverse:V, \tl_reverse:o, \tl_reverse:f, \tl_reverse:e}
+% \begin{function}[added = 2023-10-18, EXP]
+%   {
+%     \tl_reverse_use:n, \tl_reverse_use:V, \tl_reverse_use:e,
+%     \tl_reverse_use:f, \tl_reverse_use:o
+%   }
 %   \begin{syntax}
-%     \cs{tl_reverse:n} \Arg{token list}
+%     \cs{tl_reverse_use:n} \Arg{token list}
 %   \end{syntax}
 %   Reverses the order of the \meta{items} in the \meta{token list},
 %   so that \meta{item_1}\meta{item_2}\meta{item_3} \ldots \meta{item_n}
@@ -600,7 +603,7 @@
 %   reversing the order of tokens, and keep the outer set of braces.
 %   Items which are initially not braced are copied with braces in
 %   the result. In cases where preserving spaces is important,
-%   consider the slower function \cs{tl_reverse:n}.
+%   consider the slower function \cs{tl_reverse_use:n}.
 %   \begin{texnote}
 %     The result is returned within \tn{unexpanded}, which means that the token
 %     list does not expand further when appearing in an \texttt{x}-type
@@ -3397,8 +3400,7 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}[EXP]
-%   {\tl_reverse:n, \tl_reverse:o, \tl_reverse:V, \tl_reverse:f, \tl_reverse:e}
+% \begin{macro}[EXP]{\tl_reverse_use:n, \tl_reverse_use:V, \tl_reverse_use:e, \tl_reverse_use:f, \tl_reverse_use:o}
 % \begin{macro}[EXP]{\@@_reverse_normal:nN}
 % \begin{macro}[EXP]{\@@_reverse_group_preserve:nn}
 % \begin{macro}[EXP]{\@@_reverse_space:n}
@@ -3408,7 +3410,7 @@
 %   output. Grouped tokens are output to the left but without any reversal
 %   within the group.
 %    \begin{macrocode}
-\cs_new:Npn \tl_reverse:n #1
+\cs_new:Npn \tl_reverse_use:n #1
   {
     \__kernel_exp_not:w \exp_after:wN
       {
@@ -3420,7 +3422,7 @@
           {#1}
       }
   }
-\cs_generate_variant:Nn \tl_reverse:n { o , V , f , e }
+\cs_generate_variant:Nn \tl_reverse_use:n { o , V , f , e }
 \cs_new:Npn \@@_reverse_normal:N
   { \@@_act_reverse_output:n }
 \cs_new:Npn \@@_reverse_group_preserve:n #1
@@ -3438,9 +3440,9 @@
 %   which stops the \texttt{f}-expansion.
 %    \begin{macrocode}
 \cs_new_protected:Npn \tl_reverse:N #1
-  { \__kernel_tl_set:Ne #1 { \exp_args:No \tl_reverse:n { #1 } } }
+  { \__kernel_tl_set:Ne #1 { \exp_args:No \tl_reverse_use:n { #1 } } }
 \cs_new_protected:Npn \tl_greverse:N #1
-  { \__kernel_tl_gset:Ne #1 { \exp_args:No \tl_reverse:n { #1 } } }
+  { \__kernel_tl_gset:Ne #1 { \exp_args:No \tl_reverse_use:n { #1 } } }
 \cs_generate_variant:Nn \tl_reverse:N  { c }
 \cs_generate_variant:Nn \tl_greverse:N { c }
 %    \end{macrocode}

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -1065,9 +1065,9 @@
 %   described in Section~\ref{sec:l3sort:mech}.
 % \end{function}
 %
-% \begin{function}[added = 2017-02-06, EXP]{\tl_sort:nN}
+% \begin{function}[added = 2023-10-18, EXP]{\tl_sort_use:nN}
 %   \begin{syntax}
-%     \cs{tl_sort:nN} \Arg{token list} \meta{conditional}
+%     \cs{tl_sort_use:nN} \Arg{token list} \meta{conditional}
 %   \end{syntax}
 %   Sorts the items in the \meta{token list}, using the
 %   \meta{conditional} to compare items, and leaves the result in the
@@ -2950,7 +2950,7 @@
 % \end{macro}
 %
 % \begin{macro}
-%   {\tl_sort:Nn, \tl_sort:cn, \tl_gsort:Nn, \tl_gsort:cn, \tl_sort:nN}
+%   {\tl_sort:Nn, \tl_sort:cn, \tl_gsort:Nn, \tl_gsort:cn, \tl_sort_use:nN}
 %   Implemented in \pkg{l3sort}.
 % \end{macro}
 %

--- a/l3kernel/testfiles/m3sort002.lvt
+++ b/l3kernel/testfiles/m3sort002.lvt
@@ -24,13 +24,13 @@
 
 \TESTEXP { Sort~expandably }
   {
-    | \tl_sort:nN { } \ERROR |
+    | \tl_sort_use:nN { } \ERROR |
     \NEWLINE
-    \tl_sort:nN { {a\par b} } \ERROR
+    \tl_sort_use:nN { {a\par b} } \ERROR
     \NEWLINE
-    \tl_sort:nN { 8{+2}3461{-0}2{00}3748 } \test_compare:nnTF
+    \tl_sort_use:nN { 8{+2}3461{-0}2{00}3748 } \test_compare:nnTF
     \NEWLINE
-    \exp_args:Nf \tl_sort:nN
+    \exp_args:Nf \tl_sort_use:nN
       { \prg_replicate:nn { 10 } { 8{+2}3461{-0}2{00}3748 } }
       \test_compare:nnTF
   }
@@ -49,7 +49,7 @@
 \TIMO
 
 \TESTEXP { More~expandable~sorting }
-  { \exp_args:No \tl_sort:nN \l_tmpa_tl \test_compare:nnTF }
+  { \exp_args:No \tl_sort_use:nN \l_tmpa_tl \test_compare:nnTF }
 
 
 \END

--- a/l3kernel/testfiles/m3tl-build001.lvt
+++ b/l3kernel/testfiles/m3tl-build001.lvt
@@ -33,7 +33,7 @@
         {
           \tl_build_gput_right:Nn \g_tmpb_tl { #1 : }
           \tl_build_gput_left:Nn \g_tmpb_tl { #1 ~ }
-          \tl_build_gput_right:Ne \g_tmpb_tl { \tl_reverse:n {#1} ~ }
+          \tl_build_gput_right:Ne \g_tmpb_tl { \tl_reverse_use:n {#1} ~ }
         }
       \tl_build_gend:N \g_tmpb_tl
     \group_end:

--- a/l3kernel/testfiles/m3tl007.lvt
+++ b/l3kernel/testfiles/m3tl007.lvt
@@ -22,20 +22,20 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST{tl_reverse}{
-  \test:n { \tl_reverse:n { } }
-  \test:n { \tl_reverse:n {a\bc} }
-  \test:n { \tl_reverse:n {a~\bc} }
+\TEST{tl_reverse_use}{
+  \test:n { \tl_reverse_use:n { } }
+  \test:n { \tl_reverse_use:n {a\bc} }
+  \test:n { \tl_reverse_use:n {a~\bc} }
   \use:e
     {
       \test:n
         {
-          \exp_not:N \tl_reverse:n
+          \exp_not:N \tl_reverse_use:n
             { a ~ \use:n {~} \exp_not:N \b \c_space_tl }
         }
     }
-  \test:n { \tl_reverse:n { { } } }
-  \test:n { \tl_reverse:n { a ~ { \b { { } c } D # & \if_false: } } }
+  \test:n { \tl_reverse_use:n { { } } }
+  \test:n { \tl_reverse_use:n { a ~ { \b { { } c } D # & \if_false: } } }
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3tl007.tlg
+++ b/l3kernel/testfiles/m3tl007.tlg
@@ -2,7 +2,7 @@ This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
 Author: Bruno Le Floch
 ============================================================
-TEST 1: tl_reverse
+TEST 1: tl_reverse_use
 ============================================================
 ||
 |\bc a|

--- a/l3kernel/testfiles/m3tl009.lvt
+++ b/l3kernel/testfiles/m3tl009.lvt
@@ -182,7 +182,7 @@
         \tl_log:N \l_A_tl
         \tl_log:n { & \tex_cr:D }
         \tex_cr:D
-        \TYPE{1} \tl_reverse:n { \tex_cr:D & }
+        \TYPE{1} \tl_reverse_use:n { \tex_cr:D & }
       }
     }
 }

--- a/l3kernel/testfiles/m3tlist002.lvt
+++ b/l3kernel/testfiles/m3tlist002.lvt
@@ -126,8 +126,8 @@
 
 \tl_set:Nn \l_tmpa_tl { abc~{abc}~abc }
 \TESTEXP{Reversing~(TLIST)}{
-  \tl_reverse:n { abc~{abc}~abc } \NEWLINE
-  \tl_reverse:o { \l_tmpa_tl }
+  \tl_reverse_use:n { abc~{abc}~abc } \NEWLINE
+  \tl_reverse_use:o { \l_tmpa_tl }
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
See #914