### PR TITLE
Set `\l_keys_value_tl` in `.initial:n`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+
+- Set `\l_keys_value_tl` in `.initial:n` (issue \#1013)
+
 ## [2023-05-22]
 
 ### Added

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -731,8 +731,8 @@
 %   {\l_keys_key_str, \l_keys_path_str, \l_keys_value_tl}
 %   For each key processed, information of the full \emph{path} of the
 %   key, the \emph{name} of the key and the \emph{value} of the key is
-%   available within three token list variables. These may be used within
-%   the code of the key.
+%   available within two string and one token list variables.
+%   These may be used within the code of the key.
 %
 %   The \emph{value} is everything after the \texttt{=}, which may be
 %   empty if no value was given. This is stored in \cs{l_keys_value_tl}, and

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -2079,7 +2079,8 @@
               \l_keys_path_str \s_@@_stop
                 \l_keys_key_tl \l_keys_key_str
             \tl_set_eq:NN \l_keys_key_tl \l_keys_key_str
-            \@@_execute:nn \l_keys_path_str {#1}
+            \tl_set:Nn \l_keys_value_tl {#1}
+            \@@_execute:no \l_keys_path_str \l_keys_value_tl
           }
       }
   }

--- a/l3kernel/testfiles/m3keys001.lvt
+++ b/l3kernel/testfiles/m3keys001.lvt
@@ -98,7 +98,7 @@
       }
   }
 
-\TEST { .initial:n~and~~variants }
+\TEST { .initial:n~and~variants }
   {
     \keys_define:nn { module }
       {
@@ -166,8 +166,14 @@
     \tl_log:N \l_tmpa_tl
     \keys_define:nn { module }
       {
-        key-one .code:n  = \str_show:N \l_keys_key_str ,
-        key-one .initial:n = a
+        key-one .code:n  =
+          \TYPE
+            {
+              key = " \l_keys_key_str " , ~
+              path = " \l_keys_path_str " , ~
+              value = " \tl_to_str:V \l_keys_value_tl "
+            } ,
+        key-one .initial:n = a ,
       }
   }
 

--- a/l3kernel/testfiles/m3keys001.tlg
+++ b/l3kernel/testfiles/m3keys001.tlg
@@ -41,9 +41,7 @@ Defining key module/key-one on line ...
 > \l_tmpa_tl=value.
 > \l_tmpa_tl=xyz.
 > \l_tmpa_tl=value.
-> \l_keys_key_str=key-one.
-<recently read> }
-l. ...  }
+key="key-one", path="module/key-one", value="a"
 ============================================================
 ============================================================
 TEST 4: .meta:n


### PR DESCRIPTION
Similar to ed957e9 (Set \l_keys_key_str in .initial:n(fixes #1013), 2023-05-22).

@blefloch wrote
> When processing `.initial:n`, only `\l_keys_path_str` is set, and not `\l_keys_key_str` (perhaps others are also missing?).

in #1013 hence I think this PR is loosely related to that issue.