### PR TITLE
Add \token_if_cs_word:NTF to test if token is control word

### DIFF
--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -627,6 +627,25 @@
 %   Tests if the \meta{token} is a control sequence.
 % \end{function}
 %
+% \begin{function}[EXP,pTF, added=2023-05-25]{\token_if_cs_word:N}
+%   \begin{syntax}
+%     \cs{token_if_cs_word_p:N} \meta{token} \\
+%     \cs{token_if_cs_word:NTF} \meta{token} \Arg{true code} \Arg{False}
+%   \end{syntax}
+%   First tests if the \meta{token} is a control sequence,
+%   then check if it consists of the escape character followed by
+%   one or more letters (called ``control word''),
+% \end{function}
+%
+% \begin{function}[EXP,pTF, add=2023-05-25]{\token_if_control_word:N}
+%   \begin{syntax}
+%     \cs{token_if_control_word_p:N} \meta{token}
+%     \cs{token_if_control_word:NTF} \meta{token} \Arg{true code} \Arg{false code}
+%   \end{syntax}
+%   Test if the \meta{token} consists of the escape character followed by
+%   one or more letters (called ``control word''),
+% \end{function}
+%
 % \begin{function}[EXP,pTF]{\token_if_expandable:N}
 %   \begin{syntax}
 %     \cs{token_if_expandable_p:N} \meta{token} \\
@@ -2158,6 +2177,50 @@
       \prg_return_true: \else: \prg_return_false: \fi:
   }
 %    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[pTF]{\token_if_cs_word:N}
+%   First check if token has same catcode as a control sequence,
+%   then check if it consists of the escape character followed by
+%   one or more letters (called ``control word''), 
+%   i.e.~\tn{a} and \tn{relax}.
+%   We use the fact that the result of \cs{tl_to_str:n} a control word
+%   is \cs{token_to_str:N} the control word followed by a space.
+%    \begin{macrocode}
+\prg_new_conditional:Npnn \token_if_cs_word:N #1 { p , T , F , TF }
+  {
+    \if_catcode:w \exp_not:N #1 \scan_stop:
+      \if:w 0 \tex_strcmp:D { \exp_not:N #1 } { \token_to_str:N #1 }
+        \prg_return_false: \else: \prg_return_true: \fi:
+    \else: 
+      \prg_return_false:
+    \fi:
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[pTF]{\token_if_control_word:N}
+% \begin{macro}{\__token_if_control_word_aux:w}
+%   Check if token consists of the escape character followed by
+%   one or more letters.
+%   Hence we do not check catcode, we have to check if it is a
+%   character whose catcode is parameter, or much easier, we just test
+%   if it is a character. And |#1| could be a control symbol let to
+%   \cs{else:} or \cs{fi:}, etc., so we use a auxiliary function
+%   to grab second \cs{if:w}.
+%    \begin{macrocode}
+\prg_new_conditional:Npnn \token_if_control_word:N #1 { p , T , F , TF }
+  {
+    \if:w 0 \tex_strcmp:D { \exp_not:N #1 } { \token_to_str:N #1 }
+      \__token_if_control_word_aux:w 
+    \else:
+      \if:w \exp_not:N #1 \token_to_str:N #1
+        \prg_return_false: \else: \prg_return_true: \fi:
+    \fi:
+  }
+\cs_new:Npn \__token_if_control_word_aux:w #1 \fi: { \prg_return_false: }
+%    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 % \begin{macro}[pTF]{\token_if_expandable:N}

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -630,7 +630,7 @@
 % \begin{function}[EXP,pTF, added=2023-05-25]{\token_if_cs_word:N}
 %   \begin{syntax}
 %     \cs{token_if_cs_word_p:N} \meta{token} \\
-%     \cs{token_if_cs_word:NTF} \meta{token} \Arg{true code} \Arg{False}
+%     \cs{token_if_cs_word:NTF} \meta{token} \Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   First tests if the \meta{token} is a control sequence,
 %   then check if it consists of the escape character followed by

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -634,7 +634,11 @@
 %   \end{syntax}
 %   First tests if the \meta{token} is a control sequence,
 %   then check if it consists of the escape character followed by
-%   one or more letters (called ``control word''),
+%   one or more letters (called ``control word'').
+% \begin{texnote}
+%   The test function is based on current catcode regime, when catcode changed,
+%   the result will be changed too.
+% \end{texnote}
 % \end{function}
 %
 % \begin{function}[EXP,pTF, add=2023-05-25]{\token_if_control_word:N}
@@ -643,7 +647,11 @@
 %     \cs{token_if_control_word:NTF} \meta{token} \Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   Test if the \meta{token} consists of the escape character followed by
-%   one or more letters (called ``control word''),
+%   one or more letters (called ``control word'').
+% \begin{texnote}
+%   The test function is based on current catcode regime, when catcode changed,
+%   the result will be changed too.
+% \end{texnote}
 % \end{function}
 %
 % \begin{function}[EXP,pTF]{\token_if_expandable:N}


### PR DESCRIPTION
Add \token_if_cs_word:NTF and \token_if_control_word:NTF to test if token is a control word. see #1128 