### PR TITLE
Drop notes about slow \expanded emulation

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Drop notes about slow `\expanded` emulation. `\expanded` is required since
+  release 2023-05-15
+
 ## [2023-06-16]
 
 ### Changed

--- a/l3kernel/README.md
+++ b/l3kernel/README.md
@@ -59,12 +59,11 @@ XeTeX from the 2019 TeX Live release, and has always been available in LuaTeX
 (some by Lua emulation). The Japanese pTeX and upTeX gained all of the above
 (except `\ifincsname`) for TeX Live 2019 `\ifincsname` for TeX Live 2020.
 
-At present, the `\expanded` primitive is emulated if unavailable. This code is
-slow and imposes some coding restrictions. As such, it will be *removed* for TeX
-Live 2022.
+Starting from release 2023-05-15, the `\expanded` primitive is *required*.
+Its slow emulation has been removed.
 
 In addition to the above, engines which are fully Unicode-compatible
-must provde the functionality of the following primitives, documented in the
+must provide the functionality of the following primitives, documented in the
 LuaTeX manual
 
 - `\Uchar`

--- a/l3kernel/doc/source3body.tex
+++ b/l3kernel/doc/source3body.tex
@@ -228,11 +228,10 @@ following argument specifiers:
     this type of expansion. Functions which feature an \texttt{x}-type
     argument are \emph{not} expandable.
   \item[\texttt{e}] The \texttt{e} specifier is in many respects
-    identical to \texttt{x}, but with a very different implementation.
+    identical to \texttt{x}, but uses \tn{expanded} primitive.
+    Parameter character (usually~|#|) in the argument need not be doubled.
     Functions which feature an \texttt{e}-type argument may be
-    expandable.  The drawback is that \texttt{e} is extremely slow
-    (often more than $200$ times slower) in older engines, more
-    precisely in non-\LuaTeX{} engines older than 2019.
+    expandable.
   \item[\texttt{f}] The \texttt{f} specifier stands for \emph{full
     expansion}, and in contrast to \texttt{x} stops at the first
     non-expandable token (reading the argument from left to right) without

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -658,10 +658,9 @@
 %     text of an~\tn{edef}, and the expansion is passed to the function as
 %     a braced token list.  Expansion takes place until only unexpandable
 %     tokens are left.  |x|-type arguments cannot be nested.
-%   \item[e]  Fully-expanded token or braced token list which does
-%     not require doubled |#| tokens. This expansions is very similar
-%     to |x|-type but may be nested and does not require that |#|
-%     tokens are doubled.
+%   \item[e]  Fully-expanded token or braced token list.\\
+%     This expansion is very similar to |x|-type but may be nested and does
+%     not require that |#| tokens are doubled.  It uses \tn{expanded} primitive.
 %   \item[f] Expanding the first token recursively in a braced token
 %     list.\\ Almost the same as the |x| type except here the token list
 %     is expanded fully until the first unexpandable token is found and

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1025,14 +1025,12 @@
 %   \begin{syntax}
 %     \cs{use:e} \Arg{expandable tokens}
 %   \end{syntax}
-%   Fully expands the \meta{token list} in an \texttt{x}-type manner,
-%   \emph{but} the function remains fully expandable, and parameter
-%   character (usually~|#|) need not be doubled.
+%   Fully expands the \meta{token list} in an \texttt{e}-type manner,
+%   in which parameter character (usually~|#|) need not be doubled, \emph{and}
+%   the function remains fully expandable.
 %   \begin{texnote}
-%     \cs{use:e} is a wrapper around the primitive \tn{expanded}
-%     where it is available:
-%     it requires two expansions to complete its action.
-%     When \tn{expanded} is not available this function is very slow.
+%     \cs{use:e} is a wrapper around the primitive \tn{expanded}.
+%     It requires two expansions to complete its action.
 %   \end{texnote}
 % \end{function}
 %

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -222,12 +222,8 @@
 %
 % The |e| type expands all tokens fully, starting from the first.  More
 % precisely the expansion is identical to that of \TeX{}'s \tn{message}
-% (in particular |#| needs not be doubled).  It was added in May 2018.
-% In recent enough engines (starting around 2019) it relies on the
-% primitive \tn{expanded} hence is fast.  In older engines it is very
-% much slower.  As a result it should only be used in performance
-% critical code if typical users will have a recent installation of the
-% \TeX{} ecosystem.
+% (in particular |#| needs not be doubled).  It relies on the
+% primitive \tn{expanded} hence is fast.
 %
 % The |x| type expands all tokens fully, starting from the first.  In
 % contrast to |e|, all macro parameter characters |#| must be doubled,
@@ -306,11 +302,7 @@
 %   \item
 %     In contrast, |e|~expansion (full expansion, almost like~|x| except
 %     for the treatment of~|#|) does not prevent variants from being
-%     expandable (if the base function is).  The drawback is that
-%     |e|~expansion is very much slower in old engines (before 2019).
-%     Consider using |f|~expansion if that type of expansion is
-%     sufficient to perform the required expansion, or |x|~expansion if
-%     the variant will not itself need to be expandable.
+%     expandable (if the base function is).
 %   \item
 %     Finally |f|~expansion only expands the front of the token list,
 %     stopping at the first non-expandable token.  This may fail to
@@ -404,13 +396,6 @@
 %   \emph{after} reinsertion of the \meta{function}.
 %   Thus the \meta{function} may take more
 %   than one argument: all others are left unchanged.
-%   \begin{texnote}
-%     This relies on the \tn{expanded} primitive when available (in
-%     \LuaTeX{} and starting around 2019 in other engines).  Otherwise
-%     it uses some fall-back code that is very much slower.  As a result
-%     it should only be used in performance-critical code if typical
-%     users have a recent installation of the \TeX{} ecosystem.
-%   \end{texnote}
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_args:Nf}


### PR DESCRIPTION
Do we want to leave one copy of "more precisely in non-LuaTeX engines older than 2019" and even add a note about "`\expanded` is required since `l3kernel` 2023-05-15 release" in the doc?

Marked as draft because I hope to check over it tomorrow to avoid any missing.
