### PR TITLE
Fix typo in CHANGELOG

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -8,7 +8,8 @@ this project uses date-based 'snapshot' version identifiers.
 ## [Unreleased]
 
 ### Added
-- `\tex_XeTeXhyphenatablelength:D`, `\tex_XeTeXhyphenatablelength:D`, `\tex_XeTeXhyphenatablelength:D`
+- `\tex_XeTeXhyphenatablelength:D`, `\tex_XeTeXinterwordspaceshaping:D`,
+  `\tex_XeTeXselectorcode:D`
 
 ### Changed
 - `\tex_protrudechars:D` now defined for xetex (to `\XeTeXprotrudechars`)


### PR DESCRIPTION
introduced in 41c4d369c7560296d484c468d42b3dc0ce4734b8

Pointed out by @mbertucci47 in https://github.com/latex3/latex3/commit/41c4d369c7560296d484c468d42b3dc0ce4734b8#r120959892.