### PR TITLE
Refine titlecasing

### DIFF
--- a/l3kernel/doc/l3obsolete.txt
+++ b/l3kernel/doc/l3obsolete.txt
@@ -53,6 +53,10 @@ Function                            Date deprecated
 \seq_indexed_map_inline:Nn               2020-06-18
 \seq_indexed_map_function:NN             2020-06-18
 \sys_load_deprecation:                   2021-01-11
+\text_titlecase:n                        2023-07-08
+\text_titlecase:nn                       2023-07-08
+\text_titlecase_first:n                  2023-07-08
+\text_titlecase_first:nn                 2023-07-08
 \tl_case:cn                              2023-05-23
 \tl_case:cnF                             2023-05-23
 \tl_case:cnT                             2023-05-23

--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -549,6 +549,27 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \subsection{Deprecated \pkg{l3text} functions}
+%
+% \begin{macro}[EXP]{\text_titlecase:n, \text_titlecase_first:n}
+% \begin{macro}[EXP]{\text_titlecase:nn, \text_titlecase_first:nn}
+%    \begin{macrocode}
+\__kernel_patch_deprecation:nnNNpn { 2023-07-08 } { \text_titlecase_once:n }
+\cs_gset:Npn \text_titlecase:n #1
+  { \text_titlecase_once:n { \text_lowercase:n {#1} } }
+\__kernel_patch_deprecation:nnNNpn { 2023-07-08 } { \text_titlecase_once:n }
+\cs_gset:Npn \text_titlecase:n #1
+  { \text_titlecase_once:n {#1} }
+\__kernel_patch_deprecation:nnNNpn { 2023-07-08 } { \text_titlecase_once:nn }
+\cs_gset:Npn \text_titlecase:nn #1#2
+  { \text_titlecase_once:nn {#1} { \text_lowercase:n {#2} } }
+\__kernel_patch_deprecation:nnNNpn { 2023-07-08 } { \text_titlecase_once:nn }
+\cs_gset:Npn \text_titlecase_first:nn #1#2
+  { \text_titlecase_once:nn {#1} {#2} }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
 % \subsection{Deprecated \pkg{l3tl} functions}
 %
 %    \begin{macrocode}

--- a/l3kernel/l3text-case.dtx
+++ b/l3kernel/l3text-case.dtx
@@ -97,7 +97,7 @@
 \cs_new:Npn \text_titlecase:n #1
   { \@@_change_case:nnn { title } { } {#1} }
 \cs_new:Npn \text_titlecase_first:n #1
-  { \@@_change_case:nnn { titleonly } { } {#1} }
+  { \@@_change_case:nnn { title } { } {#1} }
 \cs_new:Npn \text_lowercase:nn #1#2
   { \@@_change_case:nnn { lower } {#1} {#2} }
 \cs_new:Npn \text_uppercase:nn #1#2
@@ -105,7 +105,7 @@
 \cs_new:Npn \text_titlecase:nn #1#2
   { \@@_change_case:nnn { title } {#1} {#2} }
 \cs_new:Npn \text_titlecase_first:nn #1#2
-  { \@@_change_case:nnn { titleonly } {#1} {#2} }
+  { \@@_change_case:nnn { title } {#1} {#2} }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -159,40 +159,32 @@
 %   {
 %     \@@_change_case_switch_lower:nnNnnnn ,
 %     \@@_change_case_switch_upper:nnNnnnn ,
-%     \@@_change_case_switch_title:nnNnnnn ,
-%     \@@_change_case_switch_titleonly:nnNnnnn
+%     \@@_change_case_switch_title:nnNnnnn
 %   }
 % \begin{macro}[EXP]
 %   {
 %     \@@_change_case_letterlike_lower:nnN ,
 %     \@@_change_case_letterlike_upper:nnN ,
-%     \@@_change_case_letterlike_title:nnN ,
-%     \@@_change_case_letterlike_titleonly:nnN
+%     \@@_change_case_letterlike_title:nnN
 %   }
 % \begin{macro}[EXP]{\@@_change_case_letterlike:nnnnN}
 % \begin{macro}[EXP]
 %   {
 %     \@@_change_case_custom_lower:nnn ,
 %     \@@_change_case_custom_title:nnn ,
-%     \@@_change_case_custom_upper:nnn ,
-%     \@@_change_case_custom_titleonly:nnn
+%     \@@_change_case_custom_upper:nnn
 %   }
 % \begin{macro}[EXP]{\@@_change_case_custom:nnn}
 % \begin{macro}[EXP]
 %   {
 %     \@@_change_case_codepoint_lower:nnn ,
 %     \@@_change_case_codepoint_upper:nnn ,
-%     \@@_change_case_codepoint_title:nnn ,
-%     \@@_change_case_codepoint_titleonly:nnn
+%     \@@_change_case_codepoint_title:nnn
 %   }
 % \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnn}
 % \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnw}
 % \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnN}
-% \begin{macro}[EXP]
-%   {
-%     \@@_change_case_codepoint_title:nn     ,
-%     \@@_change_case_codepoint_titleonly:nn
-%   }
+% \begin{macro}[EXP]{\@@_change_case_codepoint_title:nn}
 % \begin{macro}[EXP]{\@@_change_case_codepoint_title:nnnn}
 % \begin{macro}[EXP]
 %   {\@@_change_case_codepoint:nnnn, \@@_change_case_codepoint_aux:nnnn}
@@ -205,10 +197,9 @@
 %   }
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_next_lower:nn     ,
-%     \@@_change_case_next_upper:nn     ,
-%     \@@_change_case_next_title:nn     ,
-%     \@@_change_case_next_titleonly:nn ,
+%     \@@_change_case_next_lower:nn ,
+%     \@@_change_case_next_upper:nn ,
+%     \@@_change_case_next_title:nn ,
 %     \@@_change_case_next_end:nn
 %   }
 %   As for the expansion code, the business end of case changing is the
@@ -330,18 +321,6 @@
 \cs_new_eq:NN \@@_change_case_group_upper:nnn
   \@@_change_case_group_lower:nnn
 \cs_new:Npn \@@_change_case_group_title:nnn #1#2#3
-  {
-    \@@_change_case_store:o
-      {
-        \exp_after:wN
-          {
-            \exp:w
-            \@@_change_case_auxii:nnn {#3} {#1} {#2}
-          }
-      }
-    \@@_change_case_loop:nnw { lower } {#2}
-  }
-\cs_new:Npn \@@_change_case_group_titleonly:nnn #1#2#3
   {
     \@@_change_case_store:o
       {
@@ -536,11 +515,6 @@
 \cs_new:Npn \@@_change_case_switch_title:nnNnnnn #1#2#3#4#5#6#7
   {
     \@@_change_case_store:n {#7}
-    \@@_change_case_loop:nnw {#1} {#2}
-  }
-\cs_new:Npn \@@_change_case_switch_titleonly:nnNnnnn #1#2#3#4#5#6#7
-  {
-    \@@_change_case_store:n {#7}
     \@@_change_case_break:w
   }
 %    \end{macrocode}
@@ -555,8 +529,6 @@
 \cs_new_eq:NN \@@_change_case_letterlike_upper:nnN
   \@@_change_case_letterlike_lower:nnN
 \cs_new:Npn \@@_change_case_letterlike_title:nnN #1#2#3
-  { \@@_change_case_letterlike:nnnnN { upper } { lower } {#1} {#2} #3 }
-\cs_new:Npn \@@_change_case_letterlike_titleonly:nnN #1#2#3
   { \@@_change_case_letterlike:nnnnN { upper } { end } {#1} {#2} #3 }
 \cs_new:Npn \@@_change_case_letterlike:nnnnN #1#2#3#4#5
   {
@@ -596,8 +568,6 @@
           { \use:c { @@_change_case_codepoint_ #1 :nnn } {#1} {#2} {#3} }
       }
   }
-\cs_new_eq:NN \@@_change_case_custom_titleonly:nnn
-  \@@_change_case_custom_title:nnn
 \cs_new:Npn \@@_change_case_custom:nnnnn #1#2#3#4#5
   {
     \tl_if_exist:cTF { l_@@_ #1 case _ \tl_to_str:n {#3} _ #2 _tl }
@@ -697,11 +667,7 @@
       { \use:c { @@_change_case_codepoint_ #1 :nn } }
         {#2} {#3}
   }
-\cs_new_eq:NN \@@_change_case_codepoint_titleonly:nnn
-  \@@_change_case_codepoint_title:nnn
 \cs_new:Npn \@@_change_case_codepoint_title:nn #1#2
-  { \@@_change_case_codepoint_title:nnnn { title } { lower } {#1} {#2} }
-\cs_new:Npn \@@_change_case_codepoint_titleonly:nn #1#2
   { \@@_change_case_codepoint_title:nnnn { title } { end } {#1} {#2} }
 \cs_new:Npn \@@_change_case_codepoint_title:nnnn #1#2#3#4
   {
@@ -804,8 +770,6 @@
 \cs_new_eq:NN \@@_change_case_next_upper:nn
   \@@_change_case_next_lower:nn
 \cs_new_eq:NN \@@_change_case_next_title:nn
-  \@@_change_case_next_lower:nn
-\cs_new_eq:NN \@@_change_case_next_titleonly:nn
   \@@_change_case_next_lower:nn
 \cs_new:Npn \@@_change_case_next_end:nn #1#2
   { \@@_change_case_break:w }

--- a/l3kernel/l3text-case.dtx
+++ b/l3kernel/l3text-case.dtx
@@ -128,66 +128,68 @@
 % \begin{macro}[EXP]{\@@_change_case_store:nw}
 % \begin{macro}[EXP]{\@@_change_case_result:n} 
 % \begin{macro}[EXP]{\@@_change_case_end:w}
-% \begin{macro}[EXP]{\@@_change_case_loop:nnw}
+% \begin{macro}[EXP]{\@@_change_case_loop:nnnw}
 % \begin{macro}[EXP]{\@@_change_case_break:w}
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_group_lower:nnn     ,
-%     \@@_change_case_group_upper:nnn     ,
-%     \@@_change_case_group_title:nnn     ,
-%     \@@_change_case_group_titleonly:nnn
+%     \@@_change_case_group_lower:nnnn ,
+%     \@@_change_case_group_upper:nnnn ,
+%     \@@_change_case_group_title:nnnn
 %   }
-% \begin{macro}[EXP]{\@@_change_case_space:nnw}
+% \begin{macro}[EXP]{\@@_change_case_space:nnnw}
 % \begin{macro}[EXP]
-%   {\@@_change_case_N_type:nnN, \@@_change_case_N_type_aux:nnN}
-% \begin{macro}[EXP]{\@@_change_case_N_type:nnnN}
-% \begin{macro}[EXP]{\@@_change_case_math_search:nnNNN}
-% \begin{macro}[EXP]{\@@_change_case_math_loop:nnNw}
-% \begin{macro}[EXP]{\@@_change_case_math_N_type:nnNN}
-% \begin{macro}[EXP]{\@@_change_case_math_group:nnNn}
-% \begin{macro}[EXP]{\@@_change_case_math_space:nnNw}
-% \begin{macro}[EXP]{\@@_change_case_cs_check:nnN}
-% \begin{macro}[EXP]{\@@_change_case_exclude:nnN}
+%   {\@@_change_case_N_type:nnnN, \@@_change_case_N_type_aux:nnnN}
+% \begin{macro}[EXP]{\@@_change_case_N_type:nnnnN}
+% \begin{macro}[EXP]{\@@_change_case_math_search:nnnNNN}
+% \begin{macro}[EXP]{\@@_change_case_math_loop:nnnNw}
+% \begin{macro}[EXP]{\@@_change_case_math_N_type:nnnNN}
+% \begin{macro}[EXP]{\@@_change_case_math_group:nnnNn}
+% \begin{macro}[EXP]{\@@_change_case_math_space:nnnNw}
+% \begin{macro}[EXP]{\@@_change_case_cs_check:nnnN}
 % \begin{macro}[EXP]{\@@_change_case_exclude:nnnN}
-% \begin{macro}[EXP]{\@@_change_case_exclude:nnNN}
-% \begin{macro}[EXP]{\@@_change_case_exclude:nnNw}
-% \begin{macro}[EXP]{\@@_change_case_exclude:nnNnn}
-% \begin{macro}[EXP]{\@@_change_case_replace:nnN}
-% \begin{macro}[EXP]{\@@_change_case_replace:nnn, \@@_change_case_replace:vnn}
-% \begin{macro}[EXP]{\@@_change_case_switch:nnN}
+% \begin{macro}[EXP]{\@@_change_case_exclude:nnnnN}
+% \begin{macro}[EXP]{\@@_change_case_exclude:nnnNN}
+% \begin{macro}[EXP]{\@@_change_case_exclude:nnnNw}
+% \begin{macro}[EXP]{\@@_change_case_exclude:nnnNnn}
+% \begin{macro}[EXP]{\@@_change_case_replace:nnnN}
+% \begin{macro}[EXP]{\@@_change_case_replace:nnnn, \@@_change_case_replace:vnnn}
+% \begin{macro}[EXP]{\@@_change_case_switch:nnnN}
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_switch_lower:nnNnnnn ,
-%     \@@_change_case_switch_upper:nnNnnnn ,
-%     \@@_change_case_switch_title:nnNnnnn
+%     \@@_change_case_switch_lower:nnnNnnnn ,
+%     \@@_change_case_switch_upper:nnnNnnnn ,
+%     \@@_change_case_switch_title:nnnNnnnn
 %   }
+% \begin{macro}[EXP]{\@@_change_case_skip:nnw}
+% \begin{macro}[EXP]{\@@_change_case_skip_N_type:nnN}
+% \begin{macro}[EXP]{\@@_change_case_skip_group:nnn}
+% \begin{macro}[EXP]{\@@_change_case_skip_space:nnw}
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_letterlike_lower:nnN ,
-%     \@@_change_case_letterlike_upper:nnN ,
-%     \@@_change_case_letterlike_title:nnN
+%     \@@_change_case_letterlike_lower:nnnN ,
+%     \@@_change_case_letterlike_upper:nnnN ,
+%     \@@_change_case_letterlike_title:nnnN
 %   }
-% \begin{macro}[EXP]{\@@_change_case_letterlike:nnnnN}
+% \begin{macro}[EXP]{\@@_change_case_letterlike:nnnnnN}
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_custom_lower:nnn ,
-%     \@@_change_case_custom_title:nnn ,
-%     \@@_change_case_custom_upper:nnn
+%     \@@_change_case_custom_lower:nnnn ,
+%     \@@_change_case_custom_title:nnnn ,
+%     \@@_change_case_custom_upper:nnnn
 %   }
-% \begin{macro}[EXP]{\@@_change_case_custom:nnn}
+% \begin{macro}[EXP]{\@@_change_case_custom:nnnnn}
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_codepoint_lower:nnn ,
-%     \@@_change_case_codepoint_upper:nnn ,
-%     \@@_change_case_codepoint_title:nnn
+%     \@@_change_case_codepoint_lower:nnnn ,
+%     \@@_change_case_codepoint_upper:nnnn ,
+%     \@@_change_case_codepoint_title:nnnn
 %   }
-% \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnn}
-% \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnw}
-% \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnN}
-% \begin{macro}[EXP]{\@@_change_case_codepoint_title:nn}
-% \begin{macro}[EXP]{\@@_change_case_codepoint_title:nnnn}
-% \begin{macro}[EXP]
-%   {\@@_change_case_codepoint:nnnn, \@@_change_case_codepoint_aux:nnnn}
+% \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnnn}
+% \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnnw}
+% \begin{macro}[EXP]{\@@_change_case_lower_sigma:nnnnN}
+% \begin{macro}[EXP]{\@@_change_case_codepoint_title:nnn}
+% \begin{macro}[EXP]{\@@_change_case_codepoint_title:nnnnn}
+% \begin{macro}[EXP]{\@@_change_case_codepoint:nnnnn}
 % \begin{macro}[EXP]{\@@_change_case_codepoint:nn}
 % \begin{macro}[EXP]
 %   {
@@ -195,12 +197,15 @@
 %     \@@_change_case_codepoint:fnn ,
 %     \@@_change_case_codepoint_aux:nnn
 %   }
+% \begin{macro}[EXP]{\@@_change_case_codepoint_aux:nnn}
+% \begin{macro}[EXP]{\@@_change_case_codepoint_aux:nn}
+% \begin{macro}[EXP]{\@@_change_case_catcode:nn}
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_next_lower:nn ,
-%     \@@_change_case_next_upper:nn ,
-%     \@@_change_case_next_title:nn ,
-%     \@@_change_case_next_end:nn
+%     \@@_change_case_next_lower:nnn ,
+%     \@@_change_case_next_upper:nnn ,
+%     \@@_change_case_next_title:nnn ,
+%     \@@_change_case_next_end:nnn
 %   }
 %   As for the expansion code, the business end of case changing is the
 %   handling of \texttt{N}-type tokens. First, we expand the input fully
@@ -248,10 +253,10 @@
   { \@@_change_case_BCP:nnnnw {#1} {#2} {#4} {#3} #3 - - \q_@@_stop }
 \cs_new:Npn \@@_change_case_BCP:nnnnw #1#2#3#4#5 - #6 - #7 \q_@@_stop
   {
-    \cs_if_exist:cTF { @@_change_case_ #2 _ #5 -x- #3 :nnnn }
+    \cs_if_exist:cTF { @@_change_case_ #2 _ #5 -x- #3 :nnnnn }
       { \@@_change_case_auxii:nnn {#1} {#2} { #5 -x- #3 } }
       {
-        \cs_if_exist:cTF { @@_change_case_ #2 _ #5 :nnnn }
+        \cs_if_exist:cTF { @@_change_case_ #2 _ #5 :nnnnn }
           { \@@_change_case_auxii:nnn {#1} {#2} {#5} }
           { \@@_change_case_auxii:nnn {#1} {#2} {#4} }
       }
@@ -259,8 +264,8 @@
 \cs_new:Npn \@@_change_case_auxii:nnn #1#2#3
   {
     \group_align_safe_begin:
-    \cs_if_exist_use:c { @@_change_case_boundary_ #2 _ #3 :Nnnw }
-    \@@_change_case_loop:nnw {#2} {#3} #1
+    \cs_if_exist_use:c { @@_change_case_boundary_ #2 _ #3 :Nnnnw }
+    \@@_change_case_loop:nnnw {#2} {#2} {#3} #1
       \q_@@_recursion_tail \q_@@_recursion_stop
     \@@_change_case_result:n { }
   }
@@ -281,16 +286,16 @@
 %    \end{macrocode}
 %   The main loop is the standard \texttt{tl action} type.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_loop:nnw #1#2#3 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_loop:nnnw #1#2#3#4 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#3}
-      { \@@_change_case_N_type:nnN }
+    \tl_if_head_is_N_type:nTF {#4}
+      { \@@_change_case_N_type:nnnN }
       {
-        \tl_if_head_is_group:nTF {#3}
-          { \use:c { @@_change_case_group_ #1 :nnn } }
-          { \@@_change_case_space:nnw }
+        \tl_if_head_is_group:nTF {#4}
+          { \use:c { @@_change_case_group_ #1 :nnnn } }
+          { \@@_change_case_space:nnnw }
       }
-    {#1} {#2} #3 \q_@@_recursion_stop
+    {#1} {#2} {#3} #4 \q_@@_recursion_stop
   }
 \cs_new:Npn \@@_change_case_break:w #1 \q_@@_recursion_tail \q_@@_recursion_stop
   {
@@ -306,40 +311,40 @@
 %   having too much testing, we use a two-step process here to allow the
 %   titlecase functions to be separate.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_group_lower:nnn #1#2#3
+\cs_new:Npn \@@_change_case_group_lower:nnnn #1#2#3#4
   {
     \@@_change_case_store:o
       {
         \exp_after:wN
           {
             \exp:w
-            \@@_change_case_auxii:nnn {#3} {#1} {#2}
+            \@@_change_case_auxii:nnn {#4} {#1} {#3}
           }
       }
-    \@@_change_case_loop:nnw {#1} {#2}
+    \@@_change_case_loop:nnnw {#1} {#2} {#3}
   }
-\cs_new_eq:NN \@@_change_case_group_upper:nnn
-  \@@_change_case_group_lower:nnn
-\cs_new:Npn \@@_change_case_group_title:nnn #1#2#3
+\cs_new_eq:NN \@@_change_case_group_upper:nnnn
+  \@@_change_case_group_lower:nnnn
+\cs_new:Npn \@@_change_case_group_title:nnnn #1#2#3#4
   {
     \@@_change_case_store:o
       {
         \exp_after:wN
           {
             \exp:w
-            \@@_change_case_auxii:nnn {#3} {#1} {#2}
+            \@@_change_case_auxii:nnn {#4} {#1} {#3}
           }
       }
     \@@_change_case_break:w
   }
 \use:x
   {
-    \cs_new:Npn \exp_not:N \@@_change_case_space:nnw ##1##2 \c_space_tl
+    \cs_new:Npn \exp_not:N \@@_change_case_space:nnnw ##1##2##3 \c_space_tl
   }
   {
     \@@_change_case_store:n { ~ }
-    \cs_if_exist_use:c { @@_change_case_boundary_ #1 _ #2 :Nnnw }
-    \@@_change_case_loop:nnw {#1} {#2}
+    \cs_if_exist_use:c { @@_change_case_boundary_ #1 _ #3 :Nnnnw }
+    \@@_change_case_loop:nnnw {#2} {#2} {#3}
   }
 %    \end{macrocode}
 %   The first step of handling \texttt{N}-type tokens is to filter out the
@@ -350,85 +355,85 @@
 %   (i.e.~there is no assumption of \enquote{well-behaved} input in terms of
 %   math mode).
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_N_type:nnN #1#2#3
-  {
-    \@@_if_q_recursion_tail_stop_do:Nn #3
-      { \@@_change_case_end:w }
-    \@@_change_case_N_type_aux:nnN {#1} {#2} #3
-  }
-\cs_new:Npn \@@_change_case_N_type_aux:nnN #1#2#3
-  {
-    \exp_args:NV \@@_change_case_N_type:nnnN
-      \l_text_math_delims_tl {#1} {#2} #3
-  }
 \cs_new:Npn \@@_change_case_N_type:nnnN #1#2#3#4
   {
-    \@@_change_case_math_search:nnNNN {#2} {#3} #4 #1
+    \@@_if_q_recursion_tail_stop_do:Nn #4
+      { \@@_change_case_end:w }
+    \@@_change_case_N_type_aux:nnnN {#1} {#2} {#3} #4
+  }
+\cs_new:Npn \@@_change_case_N_type_aux:nnnN #1#2#3#4
+  {
+    \exp_args:NV \@@_change_case_N_type:nnnnN
+      \l_text_math_delims_tl {#1} {#2} {#3} #4
+  }
+\cs_new:Npn \@@_change_case_N_type:nnnnN #1#2#3#4#5
+  {
+    \@@_change_case_math_search:nnnNNN {#2} {#3} {#4} #5 #1
       \q_@@_recursion_tail \q_@@_recursion_tail
       \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_math_search:nnNNN #1#2#3#4#5
+\cs_new:Npn \@@_change_case_math_search:nnnNNN #1#2#3#4#5#6
   {
-    \@@_if_q_recursion_tail_stop_do:Nn #4
-      { \@@_change_case_cs_check:nnN {#1} {#2} #3 }
-    \token_if_eq_meaning:NNTF #3 #4
+    \@@_if_q_recursion_tail_stop_do:Nn #5
+      { \@@_change_case_cs_check:nnnN {#1} {#2} {#3} #4 }
+    \token_if_eq_meaning:NNTF #4 #5
       {
         \@@_use_i_delimit_by_q_recursion_stop:nw
            {
-             \@@_change_case_store:n {#3}
-             \@@_change_case_math_loop:nnNw {#1} {#2} #5
+             \@@_change_case_store:n {#4}
+             \@@_change_case_math_loop:nnnNw {#1} {#2} {#3} #6
            }
       }
-      { \@@_change_case_math_search:nnNNN {#1} {#2} #3 }
+      { \@@_change_case_math_search:nnnNNN {#1} {#2} {#3} #4 }
   }
-\cs_new:Npn \@@_change_case_math_loop:nnNw #1#2#3#4 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_math_loop:nnnNw #1#2#3#4#5 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#4}
-      { \@@_change_case_math_N_type:nnNN }
+    \tl_if_head_is_N_type:nTF {#5}
+      { \@@_change_case_math_N_type:nnnNN }
       {
-        \tl_if_head_is_group:nTF {#4}
-          { \@@_change_case_math_group:nnNn }
-          { \@@_change_case_math_space:nnNw }
+        \tl_if_head_is_group:nTF {#5}
+          { \@@_change_case_math_group:nnnNn }
+          { \@@_change_case_math_space:nnnNw }
       }
-    {#1} {#2} #3 #4 \q_@@_recursion_stop
+    {#1} {#2} {#3} #4 #5 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_math_N_type:nnNN #1#2#3#4
+\cs_new:Npn \@@_change_case_math_N_type:nnnNN #1#2#3#4#5
   {
-    \@@_if_q_recursion_tail_stop_do:Nn #4
+    \@@_if_q_recursion_tail_stop_do:Nn #5
       { \@@_change_case_end:w }
-    \@@_change_case_store:n {#4}
-    \token_if_eq_meaning:NNTF #4 #3
-      { \@@_change_case_loop:nnw {#1} {#2} }
-      { \@@_change_case_math_loop:nnNw {#1} {#2} #3 }
+    \@@_change_case_store:n {#5}
+    \token_if_eq_meaning:NNTF #5 #4
+      { \@@_change_case_loop:nnnw {#1} {#2} {#3} }
+      { \@@_change_case_math_loop:nnnNw {#1} {#2} {#3} #4 }
   }
-\cs_new:Npn \@@_change_case_math_group:nnNn #1#2#3#4
+\cs_new:Npn \@@_change_case_math_group:nnnNn #1#2#3#4#5
   {
-    \@@_change_case_store:n { {#4} }
-    \@@_change_case_math_loop:nnNw {#1} {#2} #3
+    \@@_change_case_store:n { {#5} }
+    \@@_change_case_math_loop:nnnNw {#1} {#2} {#3} #4
   }
 \use:x
   {
-    \cs_new:Npn \exp_not:N \@@_change_case_math_space:nnNw ##1##2##3
+    \cs_new:Npn \exp_not:N \@@_change_case_math_space:nnnNw ##1##2##3##4
       \c_space_tl
   }
   {
     \@@_change_case_store:n { ~ }
-    \@@_change_case_math_loop:nnNw {#1} {#2} #3
+    \@@_change_case_math_loop:nnnNw {#1} {#2} {#3} #4
   }
 %    \end{macrocode}
 %   Once potential math-mode cases are filtered out the next stage is to
 %   test if the token grabbed is a control sequence: the two routes the code
 %   may take are then very different.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_cs_check:nnN #1#2#3
+\cs_new:Npn \@@_change_case_cs_check:nnnN #1#2#3#4
   {
-    \token_if_cs:NTF #3
-      { \@@_change_case_exclude:nnN {#1} {#2} }
+    \token_if_cs:NTF #4
+      { \@@_change_case_exclude:nnnN {#1} {#2} {#3} }
       {
         \@@_codepoint_process:nN
-          { \use:c { @@_change_case_custom_ #1 :nnn } {#1} {#2} }
+          { \use:c { @@_change_case_custom_ #1 :nnnn } {#1} {#2} {#3} }
       }
-        #3
+        #4
   }
 %    \end{macrocode}
 %   To deal with a control sequence there is first a need to test if it is
@@ -436,87 +441,115 @@
 %   done using a loop as for the other special cases. If a hit is found then
 %   the argument is grabbed and passed through as-is.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_exclude:nnN #1#2#3
+\cs_new:Npn \@@_change_case_exclude:nnnN #1#2#3#4
   {
-    \exp_args:Ne \@@_change_case_exclude:nnnN
+    \exp_args:Ne \@@_change_case_exclude:nnnnN
       {
         \exp_not:V \l_text_math_arg_tl
         \exp_not:V \l_text_case_exclude_arg_tl
       }
-      {#1} {#2} #3
+      {#1} {#2} {#3} #4
   }
-\cs_new:Npn \@@_change_case_exclude:nnnN #1#2#3#4
+\cs_new:Npn \@@_change_case_exclude:nnnnN #1#2#3#4#5
   {
-    \@@_change_case_exclude:nnNN {#2} {#3} #4 #1 
+    \@@_change_case_exclude:nnnNN {#2} {#3} {#4} #5 #1 
       \q_@@_recursion_tail \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_exclude:nnNN #1#2#3#4
+\cs_new:Npn \@@_change_case_exclude:nnnNN #1#2#3#4#5
   {
-    \@@_if_q_recursion_tail_stop_do:Nn #4
-      { \@@_change_case_replace:nnN {#1} {#2} #3 }
-    \str_if_eq:nnTF {#3} {#4}
+    \@@_if_q_recursion_tail_stop_do:Nn #5
+      { \@@_change_case_replace:nnnN {#1} {#2} {#3} #4 }
+    \str_if_eq:nnTF {#4} {#5}
       {
         \@@_use_i_delimit_by_q_recursion_stop:nw
-          { \@@_change_case_exclude:nnNw {#1} {#2} #3 }
+          { \@@_change_case_exclude:nnnNw {#1} {#2} {#3} #4 }
       }
-      { \@@_change_case_exclude:nnNN {#1} {#2} #3 }
+      { \@@_change_case_exclude:nnnNN {#1} {#2} {#3} #4 }
   }
-\cs_new:Npn \@@_change_case_exclude:nnNw #1#2#3#4#
-  { \@@_change_case_exclude:nnNnn {#1} {#2} {#3} {#4} }
-\cs_new:Npn \@@_change_case_exclude:nnNnn #1#2#3#4#5
+\cs_new:Npn \@@_change_case_exclude:nnnNw #1#2#3#4#5#
+  { \@@_change_case_exclude:nnnNnn {#1} {#2} {#3} {#4} {#5} }
+\cs_new:Npn \@@_change_case_exclude:nnnNnn #1#2#3#4#5#6
   {
-    \tl_if_blank:nTF {#4}
-       { \@@_change_case_store:n { #3 {#5} } }
+    \tl_if_blank:nTF {#5}
+       { \@@_change_case_store:n { #4 {#6} } }
        {
         \@@_change_case_store:o
           {
-            \exp_after:wN #3
-              \exp:w \@@_change_case_auxii:nnn {#4} {#1} {#2}
-              {#5}
+            \exp_after:wN #4
+              \exp:w \@@_change_case_auxii:nnn {#5} {#1} {#2}
+              {#6}
           }
       }
-    \@@_change_case_loop:nnw {#1} {#2}
+    \@@_change_case_loop:nnnw {#1} {#2} {#3}
   }
 %    \end{macrocode}
 %   Deal with any specialist replacement for case changing.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_replace:nnN #1#2#3
+\cs_new:Npn \@@_change_case_replace:nnnN #1#2#3#4
   {
-    \cs_if_exist:cTF { l_@@_case_ \token_to_str:N #3 _tl }
+    \cs_if_exist:cTF { l_@@_case_ \token_to_str:N #4 _tl }
       {
-        \@@_change_case_replace:vnn
-          { l_@@_case_ \token_to_str:N #3 _tl } {#1} {#2}
+        \@@_change_case_replace:vnnn
+          { l_@@_case_ \token_to_str:N #4 _tl } {#1} {#2} {#3}
       }
-      { \@@_change_case_switch:nnN {#1} {#2} #3 }
+      { \@@_change_case_switch:nnnN {#1} {#2} {#3} #4 }
   }
-\cs_new:Npn \@@_change_case_replace:nnn #1#2#3
-  { \@@_change_case_loop:nnw {#2} {#3} #1 }
-\cs_generate_variant:Nn \@@_change_case_replace:nnn { v }
+\cs_new:Npn \@@_change_case_replace:nnnn #1#2#3#4
+  { \@@_change_case_loop:nnnw {#2} {#3} {#4} #1 }
+\cs_generate_variant:Nn \@@_change_case_replace:nnnn { v }
 %    \end{macrocode}
 %   Allow for manually-controlled case switching.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_switch:nnN #1#2#3
+\cs_new:Npn \@@_change_case_switch:nnnN #1#2#3#4
   {
-    \cs_if_eq:NNTF #3 \text_case_switch:nnnn
-      { \use:c { @@_change_case_switch_ #1 :nnNnnnn  } }
-      { \use:c { @@_change_case_letterlike_ #1 :nnN } }
-        {#1} {#2} #3
+    \cs_if_eq:NNTF #4 \text_case_switch:nnnn
+      { \use:c { @@_change_case_switch_ #1 :nnnNnnnn  } }
+      { \use:c { @@_change_case_letterlike_ #1 :nnnN } }
+        {#1} {#2} {#3} #4
   }
-\cs_new:Npn \@@_change_case_switch_lower:nnNnnnn #1#2#3#4#5#6#7
-  {
-    \@@_change_case_store:n {#6}
-    \@@_change_case_loop:nnw {#1} {#2}
-  }
-\cs_new:Npn \@@_change_case_switch_upper:nnNnnnn #1#2#3#4#5#6#7
-  {
-    \@@_change_case_store:n {#5}
-    \@@_change_case_loop:nnw {#1} {#2}
-  }
-\cs_new:Npn \@@_change_case_switch_title:nnNnnnn #1#2#3#4#5#6#7
+\cs_new:Npn \@@_change_case_switch_lower:nnnNnnnn #1#2#3#4#5#6#7#8
   {
     \@@_change_case_store:n {#7}
-    \@@_change_case_break:w
+    \@@_change_case_loop:nnnw {#1} {#2} {#3}
   }
+\cs_new:Npn \@@_change_case_switch_upper:nnnNnnnn #1#2#3#4#5#6#7#8
+  {
+    \@@_change_case_store:n {#6}
+    \@@_change_case_loop:nnnw {#1} {#2} {#3}
+  }
+\cs_new:Npn \@@_change_case_switch_title:nnnNnnnn #1#2#3#4#5#6#7#8
+  {
+    \@@_change_case_store:n {#8}
+    \@@_change_case_skip:nnw {#2} {#3}
+  }
+%    \end{macrocode}
+%   Skip over material quickly after titlecase-first-only initials
+%    \begin{macrocode}
+\cs_new:Npn \@@_change_case_skip:nnw #1#2#3 \q_@@_recursion_stop
+  {
+    \tl_if_head_is_N_type:nTF {#3}
+      { \@@_change_case_skip_N_type:nnN }
+      {
+        \tl_if_head_is_group:nTF {#3}
+          { \@@_change_case_skip_group:nnn }
+          { \@@_change_case_skip_space:nnw }
+      }
+        {#1} {#2} #3 \q_@@_recursion_stop
+  }
+\cs_new:Npn \@@_change_case_skip_N_type:nnN #1#2#3
+  {
+    \@@_if_q_recursion_tail_stop_do:Nn #3
+      { \@@_change_case_end:w }
+    \@@_change_case_store:n {#3}
+    \@@_change_case_skip:nnw {#1} {#2}
+  }
+\cs_new:Npn \@@_change_case_skip_group:nnn #1#2#3
+  {
+    \@@_change_case_store:n { {#3} }
+    \@@_change_case_skip:nnw {#1} {#2}
+  }
+\cs_new:Npn \@@_change_case_skip_space:nnw #1#2
+  { \@@_change_case_space:nnnw {#1} {#1} {#2} }
 %    \end{macrocode}
 %  Letter-like commands may still be present: they are set up using a simple
 %  lookup approach, so can easily be handled with no loop. If there is no
@@ -524,64 +557,64 @@
 %  are all available only in upper- and lowercase, so titlecasing maps to the
 %  uppercase version.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_letterlike_lower:nnN #1#2#3
-  { \@@_change_case_letterlike:nnnnN {#1} {#1} {#1} {#2} #3 }
-\cs_new_eq:NN \@@_change_case_letterlike_upper:nnN
-  \@@_change_case_letterlike_lower:nnN
-\cs_new:Npn \@@_change_case_letterlike_title:nnN #1#2#3
-  { \@@_change_case_letterlike:nnnnN { upper } { end } {#1} {#2} #3 }
-\cs_new:Npn \@@_change_case_letterlike:nnnnN #1#2#3#4#5
+\cs_new:Npn \@@_change_case_letterlike_lower:nnnN #1#2#3#4
+  { \@@_change_case_letterlike:nnnnnN {#1} {#1} {#1} {#2} {#3} #4 }
+\cs_new_eq:NN \@@_change_case_letterlike_upper:nnnN
+  \@@_change_case_letterlike_lower:nnnN
+\cs_new:Npn \@@_change_case_letterlike_title:nnnN #1#2#3#4
+  { \@@_change_case_letterlike:nnnnnN { upper } { end } {#1} {#2} {#3} #4 }
+\cs_new:Npn \@@_change_case_letterlike:nnnnnN #1#2#3#4#5#6
   {
-    \cs_if_exist:cTF { c_@@_ #1 case_ \token_to_str:N #5 _tl }
+    \cs_if_exist:cTF { c_@@_ #1 case_ \token_to_str:N #6 _tl }
       {
         \@@_change_case_store:v
-          { c_@@_ #1 case_ \token_to_str:N #5 _tl }
-         \use:c { @@_change_case_next_ #2 :nn } {#2} {#4}
+          { c_@@_ #1 case_ \token_to_str:N #6 _tl }
+         \use:c { @@_change_case_next_ #2 :nnn } {#2} {#4} {#5}
       }
       {
-        \@@_change_case_store:n {#5}
+        \@@_change_case_store:n {#6}
         \cs_if_exist:cTF
           {
             c_@@_
             \str_if_eq:nnTF {#1} { lower } { upper } { lower }
-            case_ \token_to_str:N #5 _tl
+            case_ \token_to_str:N #6 _tl
           }
-          { \use:c { @@_change_case_next_ #2 :nn } {#2} {#4} }
-          { \@@_change_case_loop:nnw {#3} {#4} }
+          { \use:c { @@_change_case_next_ #2 :nnn } {#2} {#4} {#5} }
+          { \@@_change_case_loop:nnnw {#3} {#4} {#5} }
       }
   }
 %    \end{macrocode}
 %  Check for a customised codepoint result.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_custom_lower:nnn #1#2#3
+\cs_new:Npn \@@_change_case_custom_lower:nnnn #1#2#3#4
   {
-    \@@_change_case_custom:nnnnn {#1} {#2} {#3} {#1}
-      { \use:c { @@_change_case_codepoint_ #1 :nnn } {#1} {#2} {#3} }
+    \@@_change_case_custom:nnnnnn {#1} {#1} {#2} {#3} {#4}
+      { \use:c { @@_change_case_codepoint_ #1 :nnnn } {#1} {#2} {#3} {#4} }
   }
-\cs_new_eq:NN \@@_change_case_custom_upper:nnn
-  \@@_change_case_custom_lower:nnn
-\cs_new:Npn \@@_change_case_custom_title:nnn #1#2#3
+\cs_new_eq:NN \@@_change_case_custom_upper:nnnn
+  \@@_change_case_custom_lower:nnnn
+\cs_new:Npn \@@_change_case_custom_title:nnnn #1#2#3#4
   {
-    \@@_change_case_custom:nnnnn { title } {#2} {#3} {#1}
+    \@@_change_case_custom:nnnnnn { title } {#1} {#2} {#3} {#4}
       {
-        \@@_change_case_custom:nnnnn { upper } {#2} {#3} {#1}
-          { \use:c { @@_change_case_codepoint_ #1 :nnn } {#1} {#2} {#3} }
+        \@@_change_case_custom:nnnnnn { upper } {#1} {#2} {#3} {#4}
+          { \use:c { @@_change_case_codepoint_ #1 :nnnn } {#1} {#2} {#3} {#4} }
       }
   }
-\cs_new:Npn \@@_change_case_custom:nnnnn #1#2#3#4#5
+\cs_new:Npn \@@_change_case_custom:nnnnnn #1#2#3#4#5#6
   {
-    \tl_if_exist:cTF { l_@@_ #1 case _ \tl_to_str:n {#3} _ #2 _tl }
+    \tl_if_exist:cTF { l_@@_ #1 case _ \tl_to_str:n {#5} _ #4 _tl }
       {
-        \@@_change_case_replace:vnn
-          { l_@@_ #1 case _ \tl_to_str:n {#3} _ #2 _tl } {#4} {#2}
+        \@@_change_case_replace:vnnn
+          { l_@@_ #1 case _ \tl_to_str:n {#5} _ #4 _tl } {#2} {#3} {#4}
       }
       {
-        \tl_if_exist:cTF { l_@@_ #1 case _ \tl_to_str:n {#3} _tl }
+        \tl_if_exist:cTF { l_@@_ #1 case _ \tl_to_str:n {#5} _tl }
           {
-            \@@_change_case_replace:vnn
-              { l_@@_ #1 case _ \tl_to_str:n {#3} _tl } {#4} {#2}
+            \@@_change_case_replace:vnnn
+              { l_@@_ #1 case _ \tl_to_str:n {#5} _tl } {#2} {#3} {#4}
           }
-          {#5}
+          {#6}
       }
   }
 %    \end{macrocode}
@@ -590,17 +623,17 @@
 %   is there the special case of a terminal sigma. If not, then we pass to
 %   a simple codepoint mapping.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_codepoint_lower:nnn #1#2#3
+\cs_new:Npn \@@_change_case_codepoint_lower:nnnn #1#2#3#4
   {
-    \cs_if_exist_use:cF { @@_change_case_lower_ #2 :nnnn }
-      { \@@_change_case_lower_sigma:nnnn }
-        {#1} {#1} {#2} {#3}
+    \cs_if_exist_use:cF { @@_change_case_lower_ #3 :nnnnn }
+      { \@@_change_case_lower_sigma:nnnnn }
+        {#1} {#1} {#2} {#3} {#4}
   }
-\cs_new:Npn \@@_change_case_codepoint_upper:nnn #1#2#3
+\cs_new:Npn \@@_change_case_codepoint_upper:nnnn #1#2#3#4
   {
-    \cs_if_exist_use:cF { @@_change_case_upper_ #2 :nnnn }
-      { \@@_change_case_codepoint:nnnn }
-        {#1} {#1} {#2} {#3}
+    \cs_if_exist_use:cF { @@_change_case_upper_ #3 :nnnnn }
+      { \@@_change_case_codepoint:nnnnn }
+        {#1} {#1} {#2} {#3} {#4}
   }
 %    \end{macrocode}
 %   If the current character is an uppercase sigma, the a check is made on the
@@ -608,87 +641,87 @@
 %   then there is a look-ahead phase: the logic here is simply based on letters
 %   or actives (to cover $8$-bit engines).
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_lower_sigma:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_lower_sigma:nnnnn #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "03A3 }
-      { \@@_change_case_lower_sigma:nnnw {#2} }
-      { \@@_change_case_codepoint:nnnn {#1} {#2} }
-        {#3} {#4}
+    \@@_codepoint_compare:nNnTF {#5} = { "03A3 }
+      { \@@_change_case_lower_sigma:nnnnw {#2} }
+      { \@@_change_case_codepoint:nnnnn {#1} {#2} }
+        {#3} {#4} {#5}
   }
-\cs_new:Npn \@@_change_case_lower_sigma:nnnw #1#2#3#4 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_lower_sigma:nnnnw #1#2#3#4#5 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#4}
-      { \@@_change_case_lower_sigma:nnnN {#3} }
+    \tl_if_head_is_N_type:nTF {#5}
+      { \@@_change_case_lower_sigma:nnnnN {#4} }
       {
         \@@_change_case_store:e
-          { \codepoint_generate:nn { "03C2 } { \@@_char_catcode:N #3 } }
-        \@@_change_case_loop:nnw
+          { \codepoint_generate:nn { "03C2 } { \@@_char_catcode:N #4 } }
+        \@@_change_case_loop:nnnw
       }
-        {#1} {#2} #4 \q_@@_recursion_stop
+        {#1} {#2} {#3} #5 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_lower_sigma:nnnN #1#2#3#4
+\cs_new:Npn \@@_change_case_lower_sigma:nnnnN #1#2#3#4#5
   {
     \@@_change_case_store:e
       {
         \bool_lazy_or:nnTF
-          { \token_if_letter_p:N #4 }
+          { \token_if_letter_p:N #5 }
           {
             \bool_lazy_and_p:nn
-              { \token_if_active_p:N #4 }
-              { \int_compare_p:nNn {`#4} > { "80 } }
+              { \token_if_active_p:N #5 }
+              { \int_compare_p:nNn {`#5} > { "80 } }
           }
           { \codepoint_generate:nn { "03C3 } { \@@_char_catcode:N #1 } }
           { \codepoint_generate:nn { "03C2 } { \@@_char_catcode:N #1 } }
       }
-    \@@_change_case_loop:nnw {#2} {#3} #4
+    \@@_change_case_loop:nnnw {#2} {#3} {#4} #5
   }
 %    \end{macrocode}
 %   For titlecasing, we need to fully expand the new character to see if it
 %   is a letter (or active).
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_codepoint_title:nnn #1#2#3
+\cs_new:Npn \@@_change_case_codepoint_title:nnnn #1#2#3#4
   {
     \bool_if:NTF \l_text_titlecase_check_letter_bool
       {
-        \tl_if_single:nTF {#3}
+        \tl_if_single:nTF {#4}
           {
             \bool_lazy_or:nnTF
-              { \token_if_letter_p:N #3 }
+              { \token_if_letter_p:N #4 }
               {
                 \bool_lazy_and_p:nn
-                  { \token_if_active_p:N #3 }
-                  { ! \int_compare_p:nNn {`#3} < { "80 } }
+                  { \token_if_active_p:N #4 }
+                  { ! \int_compare_p:nNn {`#4} < { "80 } }
               }
-              { \use:c { @@_change_case_codepoint_ #1 :nn } }
-              { \@@_change_case_codepoint_title:nnnn { title } {#1} }
+              { \use:c { @@_change_case_codepoint_ #1 :nnn } }
+              { \@@_change_case_codepoint_title:nnnnn { title } {#1} }
           }
-          { \use:c { @@_change_case_codepoint_ #1 :nn } }
+          { \use:c { @@_change_case_codepoint_ #1 :nnn } }
       }
-      { \use:c { @@_change_case_codepoint_ #1 :nn } }
-        {#2} {#3}
+      { \use:c { @@_change_case_codepoint_ #1 :nnn } }
+        {#2} {#3} {#4}
   }
-\cs_new:Npn \@@_change_case_codepoint_title:nn #1#2
-  { \@@_change_case_codepoint_title:nnnn { title } { end } {#1} {#2} }
-\cs_new:Npn \@@_change_case_codepoint_title:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_codepoint_title:nnn #1#2#3
+  { \@@_change_case_codepoint_title:nnnnn { title } { end } {#1} {#2} {#3} }
+\cs_new:Npn \@@_change_case_codepoint_title:nnnnn #1#2#3#4#5
   {
-    \cs_if_exist_use:cF { @@_change_case_title_ #3 :nnnn }
+    \cs_if_exist_use:cF { @@_change_case_title_ #4 :nnnnn }
       {
-        \cs_if_exist_use:cF { @@_change_case_upper_ #3 :nnnn }
-          { \@@_change_case_codepoint:nnnn }
+        \cs_if_exist_use:cF { @@_change_case_upper_ #4 :nnnnn }
+          { \@@_change_case_codepoint:nnnnn }
       }
-        {#1} {#2} {#3} {#4}
+        {#1} {#2} {#3} {#4} {#5}
   }
-\cs_new:Npn \@@_change_case_codepoint:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_codepoint:nnnnn #1#2#3#4#5
   {
     \bool_lazy_and:nnTF
-      { \tl_if_single_p:n {#4} }
-      { \token_if_active_p:N #4 }
-      { \@@_change_case_store:n {#4} }
+      { \tl_if_single_p:n {#5} }
+      { \token_if_active_p:N #5 }
+      { \@@_change_case_store:n {#5} }
       {
         \@@_change_case_store:e
-          { \@@_change_case_codepoint:nn {#1} {#4} }
+          { \@@_change_case_codepoint:nn {#1} {#5} }
       }
-    \use:c { @@_change_case_next_ #2 :nn } {#2} {#3}
+    \use:c { @@_change_case_next_ #2 :nnn } {#2} {#3} {#4}
   }
 \cs_new:Npn \@@_change_case_codepoint:nn #1#2
   {
@@ -765,15 +798,22 @@
           }
       }
   }
-\cs_new:Npn \@@_change_case_next_lower:nn #1#2
-  { \@@_change_case_loop:nnw {#1} {#2} }
-\cs_new_eq:NN \@@_change_case_next_upper:nn
-  \@@_change_case_next_lower:nn
-\cs_new_eq:NN \@@_change_case_next_title:nn
-  \@@_change_case_next_lower:nn
-\cs_new:Npn \@@_change_case_next_end:nn #1#2
-  { \@@_change_case_break:w }
+\cs_new:Npn \@@_change_case_next_lower:nnn #1#2#3
+  { \@@_change_case_loop:nnnw {#1} {#2} {#3} }
+\cs_new_eq:NN \@@_change_case_next_upper:nnn
+  \@@_change_case_next_lower:nnn
+\cs_new_eq:NN \@@_change_case_next_title:nnn
+  \@@_change_case_next_lower:nnn
+\cs_new:Npn \@@_change_case_next_end:nnn #1#2#3
+  { \@@_change_case_skip:nnw {#2} {#3} }
 %    \end{macrocode}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+% \end{macro}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 % \end{macro}
@@ -908,55 +948,58 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]
-%   {\@@_change_case_upper_de-x-eszett:nnnn, \@@_change_case_upper_de-alt:nnnn}
+%   {
+%      \@@_change_case_upper_de-x-eszett:nnnnn,
+%      \@@_change_case_upper_de-alt:nnnnn
+%   }
 %   A simple alternative version for German.
 %    \begin{macrocode}
-\cs_new:cpn { @@_change_case_upper_de-x-eszett:nnnn } #1#2#3#4
+\cs_new:cpn { @@_change_case_upper_de-x-eszett:nnnnn } #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "00DF }
+    \@@_codepoint_compare:nNnTF {#5} = { "00DF }
       {
         \@@_change_case_store:e
          {
            \codepoint_generate:nn { "1E9E }
-             { \@@_change_case_catcode:nn {#4} { "1E9E } }
+             { \@@_change_case_catcode:nn {#5} { "1E9E } }
          }
-        \use:c { @@_change_case_next_ #2 :nn }
-          {#2} {#3}
+        \use:c { @@_change_case_next_ #2 :nnn }
+          {#2} {#3} {#4}
       }
-      { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
   }
-\cs_new_eq:cc { @@_change_case_upper_de-alt:nnnn }
-  { @@_change_case_upper_de-x-eszett:nnnn }
+\cs_new_eq:cc { @@_change_case_upper_de-alt:nnnnn }
+  { @@_change_case_upper_de-x-eszett:nnnnn }
 %    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_upper_el:nnnn     ,
-%     \@@_change_case_upper_el_aux:nnnn ,
-%     \@@_change_case_upper_el-x-iota:nnnn
+%     \@@_change_case_upper_el:nnnnn        ,
+%     \@@_change_case_upper_el-x-iota:nnnnn ,
+%     \@@_change_case_upper_el_aux:nnnnn
 %   }
-% \begin{macro}[EXP]{\@@_change_case_upper_el:nnn}
-% \begin{macro}[EXP]{\@@_change_case_upper_el:nnnw}
+% \begin{macro}[EXP]{\@@_change_case_upper_el:nnnn}
+% \begin{macro}[EXP]{\@@_change_case_upper_el:nnnnw}
 % \begin{macro}[EXP]
-%   {\@@_change_case_upper_el:nnnN, \@@_change_case_upper_el_aux:nnnN}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_ypogegrammeni:nnnnnw}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_ypogegrammeni:nnnnnN}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_ypogegrammeni:nnnnnn}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_dialytika:nnn}
+%   {\@@_change_case_upper_el:nnnnN, \@@_change_case_upper_el_aux:nnnnN}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_ypogegrammeni:nnnnnnw}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_ypogegrammeni:nnnnnnN}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_ypogegrammeni:nnnnnnn}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_dialytika:nnnn}
 % \begin{macro}[EXP]{\@@_change_case_upper_el_dialytika:n}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_hiatus:nnnw}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_hiatus:nnnN}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_hiatus:nnnn}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_hiatus:nnnnw}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_hiatus:nnnnN}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_hiatus:nnnnn}
 % \begin{macro}[EXP]
 %   {
 %     \@@_change_case_upper_el_ypogegrammeni:n        ,
 %     \@@_change_case_upper_el-x-iota_ypogegrammeni:n
 %   }
 % \begin{macro}[EXP]{\@@_change_case_upper_el_stress:nn}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_gobble:nnw}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_gobble:nnN}
-% \begin{macro}[EXP]{\@@_change_case_upper_el_gobble:nnn}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_gobble:nnnw}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_gobble:nnnN}
+% \begin{macro}[EXP]{\@@_change_case_upper_el_gobble:nnnn}
 % \begin{macro}[EXP,noTF]
 %   {
 %     \@@_change_case_if_greek:n                   ,
@@ -981,65 +1024,65 @@
 %   for \pdfTeX{} so is best left unchanged, and the latter has issues concerning
 %   how \texttt{LGR} outputs the input and output (differently!).
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_el:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_el:nnnnn #1#2#3#4#5
   {
     \bool_lazy_and:nnTF
-      { \@@_change_case_if_greek_p:n {#4} }
+      { \@@_change_case_if_greek_p:n {#5} }
       {
         ! \bool_lazy_or_p:nn
-          { \@@_codepoint_compare_p:nNn {#4} = { "0374 } }
-          { \@@_codepoint_compare_p:nNn {#4} = { "037E } }
+          { \@@_codepoint_compare_p:nNn {#5} = { "0374 } }
+          { \@@_codepoint_compare_p:nNn {#5} = { "037E } }
       }
       {
-        \@@_change_case_if_greek_spacing_diacritic:nTF {#4}
+        \@@_change_case_if_greek_spacing_diacritic:nTF {#5}
           {
-            \@@_change_case_store:n {#4}
-            \@@_change_case_loop:nnw
+            \@@_change_case_store:n {#5}
+            \@@_change_case_loop:nnnw
           }
           {
-            \exp_args:Ne \@@_change_case_upper_el:nnn
+            \exp_args:Ne \@@_change_case_upper_el:nnnn
               {
                 \codepoint_to_nfd:n
-                  { \@@_codepoint_from_chars:Nw #4 }
+                  { \@@_codepoint_from_chars:Nw #5 }
               }
           }
-            {#2} {#3}
+            {#2} {#3} {#4}
       }
       {
-        \@@_codepoint_compare:nNnTF {#4} = { "0345 }
+        \@@_codepoint_compare:nNnTF {#5} = { "0345 }
           {
             \@@_change_case_store:e
               {
                 \codepoint_generate:nn { "0399 }
                   { \char_value_catcode:n { "0399 } }
               }
-            \@@_change_case_loop:nnw {#2} {#3}
+            \@@_change_case_loop:nnnw {#2} {#3} {#4}
           }
-          { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+          { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
       }
   }
-\cs_new_eq:cN { @@_change_case_upper_el-x-iota:nnnn }
-  \@@_change_case_upper_el:nnnn
-\cs_new:Npn \@@_change_case_upper_el:nnn #1#2#3
+\cs_new_eq:cN { @@_change_case_upper_el-x-iota:nnnnn }
+  \@@_change_case_upper_el:nnnnn
+\cs_new:Npn \@@_change_case_upper_el:nnnn #1#2#3#4
   {
     \@@_codepoint_process:nN
-      { \@@_change_case_upper_el:nnnw {#2} {#3} } #1
+      { \@@_change_case_upper_el:nnnnw {#2} {#3} {#4} } #1
   }
 %    \end{macrocode}
 %   At this stage we have the first NFD codepoint as |#3|. What we need to know
 %   is whether after that we have another character, either from the NFD or
 %   directly in the input. If not, we store the changed character at this stage.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_el:nnnw #1#2#3#4 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_upper_el:nnnnw #1#2#3#4#5 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#4}
-      { \@@_change_case_upper_el:nnnN {#3} }
+    \tl_if_head_is_N_type:nTF {#5}
+      { \@@_change_case_upper_el:nnnnN {#4} }
       {
         \@@_change_case_store:e
-          { \@@_change_case_codepoint:nn { upper } {#3} }
-        \@@_change_case_loop:nnw
+          { \@@_change_case_codepoint:nn { upper } {#4} }
+        \@@_change_case_loop:nnnw
       }
-        {#1} {#2} #4 \q_@@_recursion_stop
+        {#1} {#2} {#3} #5 \q_@@_recursion_stop
   }
 %    \end{macrocode}
 %   Now, we check the detail of the next codepoint: again we filter out the
@@ -1049,99 +1092,99 @@
 %   to move any ypogegrammeni to after accents (in case the input is not
 %   normalised). The ypogegrammeni itself is handled separately.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_el:nnnN #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_el:nnnnN #1#2#3#4#5
   {
-    \token_if_cs:NTF #4
+    \token_if_cs:NTF #5
       {
         \@@_change_case_store:e
           { \@@_change_case_codepoint:nn { upper } {#1} }
-        \@@_change_case_loop:nnw {#2} {#3} #4
+        \@@_change_case_loop:nnnw {#2} {#3} {#4} #5
       }
       {
         \@@_change_case_if_takes_ypogegrammeni:nTF {#1}
           {
-            \@@_change_case_upper_el_ypogegrammeni:nnnnnw
-              {#1} {#2} {#3} { } { } #4
+            \@@_change_case_upper_el_ypogegrammeni:nnnnnnw
+              {#1} {#2} {#3} {#4} { } { } #5
           }
-          { \@@_change_case_upper_el_aux:nnnN {#1} {#2} {#3} #4 }
+          { \@@_change_case_upper_el_aux:nnnnN {#1} {#2} {#3} {#4} #5 }
       }
   }
-\cs_new:Npn \@@_change_case_upper_el_ypogegrammeni:nnnnnw
-  #1#2#3#4#5#6 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_upper_el_ypogegrammeni:nnnnnnw
+  #1#2#3#4#5#6#7 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#6}
+    \tl_if_head_is_N_type:nTF {#7}
       {
-        \@@_change_case_upper_el_ypogegrammeni:nnnnnN
-          {#1} {#2} {#3} {#4} {#5}
+        \@@_change_case_upper_el_ypogegrammeni:nnnnnnN
+          {#1} {#2} {#3} {#4} {#5} {#6}
       }
-      { \@@_change_case_upper_el_aux:nnnN {#1} {#2} {#3} #4#5 }
-        #6 \q_@@_recursion_stop
+      { \@@_change_case_upper_el_aux:nnnnN {#1} {#2} {#3} {#4} #5#6 }
+        #7 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_upper_el_ypogegrammeni:nnnnnN #1#2#3#4#5#6
+\cs_new:Npn \@@_change_case_upper_el_ypogegrammeni:nnnnnnN #1#2#3#4#5#6#7
   {
-    \token_if_cs:NTF #6
-      { \@@_change_case_upper_el_aux:nnnN {#1} {#2} {#3} #4#5 }
+    \token_if_cs:NTF #7
+      { \@@_change_case_upper_el_aux:nnnnN {#1} {#2} {#3} {#4} #5#6 }
       {
         \@@_codepoint_process:nN
           {
-            \@@_change_case_upper_el_ypogegrammeni:nnnnnn
-              {#1} {#2} {#3} {#4} {#5}
+            \@@_change_case_upper_el_ypogegrammeni:nnnnnnn
+              {#1} {#2} {#3} {#4} {#5} {#6}
           }
       }
-        #6
+        #7
   }
-\cs_new:Npn \@@_change_case_upper_el_ypogegrammeni:nnnnnn #1#2#3#4#5#6
+\cs_new:Npn \@@_change_case_upper_el_ypogegrammeni:nnnnnnn #1#2#3#4#5#6#7
   {
-    \@@_codepoint_compare:nNnTF {#6} = { "0345 }
+    \@@_codepoint_compare:nNnTF {#7} = { "0345 }
       {
-        \@@_change_case_upper_el_ypogegrammeni:nnnnnw
-          {#1} {#2} {#3} {#4} {#6}
+        \@@_change_case_upper_el_ypogegrammeni:nnnnnnw
+          {#1} {#2} {#3} {#4} {#5} {#7}
       }
       {
         \bool_lazy_or:nnTF
-          { \@@_change_case_if_greek_accent_p:n {#6} }
-          { \@@_change_case_if_greek_breathing_p:n {#6} }
+          { \@@_change_case_if_greek_accent_p:n {#7} }
+          { \@@_change_case_if_greek_breathing_p:n {#7} }
           {
-            \@@_change_case_upper_el_ypogegrammeni:nnnnnw
-              {#1} {#2} {#3} {#4#6} {#5}
+            \@@_change_case_upper_el_ypogegrammeni:nnnnnnw
+              {#1} {#2} {#3} {#4} {#5#7} {#6}
           }
-          { \@@_change_case_upper_el_aux:nnnN {#1} {#2} {#3} #4#5 #6 }
+          { \@@_change_case_upper_el_aux:nnnnN {#1} {#2} {#3} {#4} #5#6 #7 }
       }
   }
-\cs_new:Npn \@@_change_case_upper_el_aux:nnnN #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_el_aux:nnnnN #1#2#3#4#5
   {
     \@@_codepoint_process:nN
-      { \@@_change_case_upper_el_aux:nnnn {#1} {#2} {#3} } #4
+      { \@@_change_case_upper_el_aux:nnnnn {#1} {#2} {#3} {#4} } #5
   }
-\cs_new:Npn \@@_change_case_upper_el_aux:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_el_aux:nnnnn #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "0308 }
-      { \@@_change_case_upper_el_dialytika:nnn {#2} {#3} {#1} }
+    \@@_codepoint_compare:nNnTF {#5} = { "0308 }
+      { \@@_change_case_upper_el_dialytika:nnnn {#2} {#3} {#4} {#1} }
       {
-        \@@_change_case_if_greek_accent:nTF {#4}
-          { \@@_change_case_upper_el_hiatus:nnnw {#2} {#3} {#1} }
+        \@@_change_case_if_greek_accent:nTF {#5}
+          { \@@_change_case_upper_el_hiatus:nnnnw {#2} {#3} {#4} {#1} }
           {
-            \@@_change_case_if_greek_breathing:nTF {#4}
-              { \@@_change_case_upper_el:nnn {#1} {#2} {#3} }
+            \@@_change_case_if_greek_breathing:nTF {#5}
+              { \@@_change_case_upper_el:nnnn {#1} {#2} {#3} {#4} }
               {
-                \@@_codepoint_compare:nNnTF {#4} = { "0345 }
+                \@@_codepoint_compare:nNnTF {#5} = { "0345 }
                   {
                     \@@_change_case_store:e
-                      { \use:c { @@_change_case_upper_ #3 _ypogegrammeni:n } {#1} }
-                    \@@_change_case_loop:nnw {#2} {#3}
+                      { \use:c { @@_change_case_upper_ #4 _ypogegrammeni:n } {#1} }
+                    \@@_change_case_loop:nnnw {#2} {#3} {#4}
                   }
                   {
-                    \@@_change_case_if_greek_stress:nTF {#4}
+                    \@@_change_case_if_greek_stress:nTF {#5}
                       {
                         \@@_change_case_store:e
-                          { \@@_change_case_upper_el_stress:nn {#1} {#4} }
-                        \@@_change_case_loop:nnw {#2} {#3}
+                          { \@@_change_case_upper_el_stress:nn {#1} {#5} }
+                        \@@_change_case_loop:nnnw {#2} {#3} {#4}
 
                       }
                       {
                         \@@_change_case_store:e
                           { \@@_change_case_codepoint:nn { upper } {#1} }
-                        \@@_change_case_loop:nnw {#2} {#3} #4
+                        \@@_change_case_loop:nnnw {#2} {#3} {#4} #5
                       }
                   }
               }
@@ -1153,15 +1196,15 @@
 %   We know only two letters take it, so we can shortcut here on the second
 %   part of the tests.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_el_dialytika:nnn #1#2#3
+\cs_new:Npn \@@_change_case_upper_el_dialytika:nnnn #1#2#3#4
   {
-    \@@_change_case_if_takes_dialytika:nTF {#3}
-      { \@@_change_case_upper_el_dialytika:n {#3} }
+    \@@_change_case_if_takes_dialytika:nTF {#4}
+      { \@@_change_case_upper_el_dialytika:n {#4} }
       {
         \@@_change_case_store:e
-          { \@@_change_case_codepoint:nn { upper } {#3} }
+          { \@@_change_case_codepoint:nn { upper } {#4} }
       }
-    \@@_change_case_upper_el_gobble:nnw {#1} {#2}
+    \@@_change_case_upper_el_gobble:nnnw {#1} {#2} {#3}
   }
 \cs_new:Npn \@@_change_case_upper_el_dialytika:n #1
   {
@@ -1184,41 +1227,41 @@
 %   Adding a hiatus needs some of the same ideas, but if there is not one we
 %   skip this code point, hence needing a separate function.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_el_hiatus:nnnw
-  #1#2#3#4 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_upper_el_hiatus:nnnnw
+  #1#2#3#4#5 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#4}
-      { \@@_change_case_upper_el_hiatus:nnnN {#3} }
+    \tl_if_head_is_N_type:nTF {#5}
+      { \@@_change_case_upper_el_hiatus:nnnnN {#4} }
       {
         \@@_change_case_store:e
-          { \@@_change_case_codepoint:nn { upper } {#3} }
-        \@@_change_case_loop:nnw
+          { \@@_change_case_codepoint:nn { upper } {#4} }
+        \@@_change_case_loop:nnnw
       }
-        {#1} {#2} #4 \q_@@_recursion_stop
+        {#1} {#2} {#3} #5 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_upper_el_hiatus:nnnN #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_el_hiatus:nnnnN #1#2#3#4#5
   {
-    \token_if_cs:NTF #4
+    \token_if_cs:NTF #5
       {
         \@@_change_case_store:e
           { \@@_change_case_codepoint:nn { upper } {#1} }
-        \@@_change_case_loop:nnw {#2} {#3} #4
+        \@@_change_case_loop:nnnw {#2} {#3} {#4} #5 
       }
       {
         \@@_codepoint_process:nN
-          { \@@_change_case_upper_el_hiatus:nnnn {#1} {#2} {#3} } #4
+          { \@@_change_case_upper_el_hiatus:nnnnn {#1} {#2} {#3} {#4} } #5
       }
   }
-\cs_new:Npn \@@_change_case_upper_el_hiatus:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_el_hiatus:nnnnn #1#2#3#4#5
   {
-    \@@_change_case_if_takes_dialytika:nTF {#4}
+    \@@_change_case_if_takes_dialytika:nTF {#5}
       {
         \@@_change_case_store:e
           { \@@_change_case_codepoint:nn { upper } {#1} }
-        \@@_change_case_upper_el_dialytika:n {#4}
-        \@@_change_case_upper_el_gobble:nnw {#2} {#3}
+        \@@_change_case_upper_el_dialytika:n {#5}
+        \@@_change_case_upper_el_gobble:nnnw {#2} {#3} {#4}
       }
-      { \@@_change_case_upper_el:nnn {#1} {#2} {#3} #4 }
+      { \@@_change_case_upper_el:nnnn {#1} {#2} {#3} {#4} #5 }
   }
 %    \end{macrocode}
 %   Handling the \emph{ypogegrammeni} output depends on the selected approach
@@ -1287,31 +1330,31 @@
 %   For clearing out trailing combining marks after we have dealt with
 %   the first one.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_el_gobble:nnw
-  #1#2#3 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_upper_el_gobble:nnnw
+  #1#2#3#4 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#3}
-      { \@@_change_case_upper_el_gobble:nnN }
-      { \@@_change_case_loop:nnw }
-        {#1} {#2} #3 \q_@@_recursion_stop
+    \tl_if_head_is_N_type:nTF {#4}
+      { \@@_change_case_upper_el_gobble:nnnN }
+      { \@@_change_case_loop:nnnw }
+        {#1} {#2} {#3} #4 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_upper_el_gobble:nnN #1#2#3
+\cs_new:Npn \@@_change_case_upper_el_gobble:nnnN #1#2#3#4
   {
-    \token_if_cs:NTF #3
-      { \@@_change_case_loop:nnw {#1} {#2} }
+    \token_if_cs:NTF #4
+      { \@@_change_case_loop:nnnw {#1} {#2} {#3} }
       {
         \@@_codepoint_process:nN
-          { \@@_change_case_upper_el_gobble:nnn {#1} {#2} }
+          { \@@_change_case_upper_el_gobble:nnnn {#1} {#2} {#3} }
       }
-        #3
+        #4
   }
-\cs_new:Npn \@@_change_case_upper_el_gobble:nnn #1#2#3
+\cs_new:Npn \@@_change_case_upper_el_gobble:nnnn #1#2#3#4
   {
     \bool_lazy_or:nnTF
-      { \@@_change_case_if_greek_accent_p:n {#3} }
-      { \@@_change_case_if_greek_breathing_p:n {#3} }
-      { \@@_change_case_upper_el_gobble:nnw {#1} {#2} }
-      { \@@_change_case_loop:nnw {#1} {#2} #3 }
+      { \@@_change_case_if_greek_accent_p:n {#4} }
+      { \@@_change_case_if_greek_breathing_p:n {#4} }
+      { \@@_change_case_upper_el_gobble:nnnw {#1} {#2} {#3} }
+      { \@@_change_case_loop:nnnw {#1} {#2} {#3} #4 }
   }
 %    \end{macrocode}
 %   Luckily the Greek range is limited and clear.
@@ -1561,98 +1604,101 @@
 % \end{macro}
 % \end{macro}
 % \begin{macro}[EXP]
-%   {\@@_change_case_boundary_upper_el:Nnnw, \@@_change_case_boundary_upper_el-x-iota:Nnnw}
-% \begin{macro}[EXP]{\@@_change_case_boundary_upper_el:nnN}
-% \begin{macro}[EXP]{\@@_change_case_boundary_upper_el:nnn}
-% \begin{macro}[EXP]{\@@_change_case_boundary_upper_el:nnnw}
+%   {
+%     \@@_change_case_boundary_upper_el:Nnnnw,
+%     \@@_change_case_boundary_upper_el-x-iota:Nnnnw
+%   }
+% \begin{macro}[EXP]{\@@_change_case_boundary_upper_el:nnnN}
+% \begin{macro}[EXP]{\@@_change_case_boundary_upper_el:nnnn}
+% \begin{macro}[EXP]{\@@_change_case_boundary_upper_el:nnnnw}
 %   There is one things that need special treatment at start start of
 %   words in Greek. For an isolated accent \emph{eta},
 %   which is handled by seeing if we have exactly one of the affected
 %   codepoints followed by a space or brace group.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_boundary_upper_el:Nnnw
-  #1#2#3#4 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_boundary_upper_el:Nnnnw
+  #1#2#3#4#5 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#4}
-      { \@@_change_case_boundary_upper_el:nnN }
-      { \@@_change_case_loop:nnw }
-        {#2} {#3} #4 \q_@@_recursion_stop
+    \tl_if_head_is_N_type:nTF {#5}
+      { \@@_change_case_boundary_upper_el:nnnN }
+      { \@@_change_case_loop:nnnw }
+        {#2} {#3} {#4} #5 \q_@@_recursion_stop
   }
-\cs_new_eq:cN { @@_change_case_boundary_upper_el-x-iota:Nnnw }
-  \@@_change_case_boundary_upper_el:Nnnw
-\cs_new:Npn \@@_change_case_boundary_upper_el:nnN #1#2#3
+\cs_new_eq:cN { @@_change_case_boundary_upper_el-x-iota:Nnnnw }
+  \@@_change_case_boundary_upper_el:Nnnnw
+\cs_new:Npn \@@_change_case_boundary_upper_el:nnnN #1#2#3#4
   {
-    \token_if_cs:NTF #3
-      { \@@_change_case_loop:nnw {#1} {#2} }
+    \token_if_cs:NTF #4
+      { \@@_change_case_loop:nnnw {#1} {#2} {#3} }
       {
         \@@_codepoint_process:nN
-          { \@@_change_case_boundary_upper_el:nnn {#1} {#2} }
+          { \@@_change_case_boundary_upper_el:nnnn {#1} {#2} {#3} }
       }
-        #3
+        #4
   }
-\cs_new:Npn \@@_change_case_boundary_upper_el:nnn #1#2#3
+\cs_new:Npn \@@_change_case_boundary_upper_el:nnnn #1#2#3#4
   {
     \bool_lazy_any:nTF
       {
-        { \@@_codepoint_compare_p:nNn {#3} = { "0389 } }
-        { \@@_codepoint_compare_p:nNn {#3} = { "03AE } }
-        { \@@_codepoint_compare_p:nNn {#3} = { "1F22 } }
-        { \@@_codepoint_compare_p:nNn {#3} = { "1F2A } }
+        { \@@_codepoint_compare_p:nNn {#4} = { "0389 } }
+        { \@@_codepoint_compare_p:nNn {#4} = { "03AE } }
+        { \@@_codepoint_compare_p:nNn {#4} = { "1F22 } }
+        { \@@_codepoint_compare_p:nNn {#4} = { "1F2A } }
       }
-      { \@@_change_case_boundary_upper_el:nnnw {#1} {#2} {#3} }
-      { \@@_change_case_breathing:nnn {#1} {#2} {#3} }
+      { \@@_change_case_boundary_upper_el:nnnnw {#1} {#2} {#3} {#4} }
+      { \@@_change_case_breathing:nnnn {#1} {#2} {#3} {#4} }
   }
-\cs_new:Npn \@@_change_case_boundary_upper_el:nnnw
-  #1#2#3#4 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_boundary_upper_el:nnnnw
+  #1#2#3#4#5 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#4}
-      { \@@_change_case_loop:nnw {#1} {#2} #3 }
+    \tl_if_head_is_N_type:nTF {#5}
+      { \@@_change_case_loop:nnnw {#1} {#2} {#3} #4 }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn { "0389 }
-              { \@@_change_case_catcode:nn {#3} { "0389 } }
+              { \@@_change_case_catcode:nn {#4} { "0389 } }
           }
-        \@@_change_case_loop:nnw {#1} {#2}
+        \@@_change_case_loop:nnnw {#1} {#2} {#3}
       }
-        #4 \q_@@_recursion_stop
+        #5 \q_@@_recursion_stop
   }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
 % \end{macro}
 % \end{macro}
-% \begin{macro}[EXP]{\@@_change_case_breathing:nnn}
 % \begin{macro}[EXP]{\@@_change_case_breathing:nnnn}
-% \begin{macro}[EXP]{\@@_change_case_breathing:nnnnw}
+% \begin{macro}[EXP]{\@@_change_case_breathing:nnnnn}
 % \begin{macro}[EXP]{\@@_change_case_breathing:nnnnnw}
-% \begin{macro}[EXP]{\@@_change_case_breathing_aux:nnnnn}
-% \begin{macro}[EXP]{\@@_change_case_breathing_aux:nnnw}
-% \begin{macro}[EXP]{\@@_change_case_breathing_aux:nnN}
-% \begin{macro}[EXP]{\@@_change_case_breathing_dialytika:nnn}
+% \begin{macro}[EXP]{\@@_change_case_breathing:nnnnnnw}
+% \begin{macro}[EXP]{\@@_change_case_breathing_aux:nnnnnn}
+% \begin{macro}[EXP]{\@@_change_case_breathing_aux:nnnnw}
+% \begin{macro}[EXP]{\@@_change_case_breathing_aux:nnnN}
+% \begin{macro}[EXP]{\@@_change_case_breathing_dialytika:nnnn}
 %   In Greek, breathing diacritics are normally dropped when uppercasing:
 %   see the code for the general case. However, for the first character
 %   of a word, if there is a breather \emph{and} the next character takes
 %   a \emph{dialytika}, it needs to be added. We start by checking if
 %   the current codepoint is in the Greek range, then decomposing.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_breathing:nnn #1#2#3
-  {
-    \@@_change_case_if_greek:nTF {#3}
-      {
-        \exp_args:Ne \@@_change_case_breathing:nnnn
-          {
-            \codepoint_to_nfd:n
-              { \@@_codepoint_from_chars:Nw #3 }
-          }
-            {#1} {#2} {#3}
-      }
-      { \@@_change_case_loop:nnw {#1} {#2} #3 }
-  }
 \cs_new:Npn \@@_change_case_breathing:nnnn #1#2#3#4
   {
+    \@@_change_case_if_greek:nTF {#4}
+      {
+        \exp_args:Ne \@@_change_case_breathing:nnnnn
+          {
+            \codepoint_to_nfd:n
+              { \@@_codepoint_from_chars:Nw #4 }
+          }
+            {#1} {#2} {#3} {#4}
+      }
+      { \@@_change_case_loop:nnnw {#1} {#2} {#3} #4 }
+  }
+\cs_new:Npn \@@_change_case_breathing:nnnnn #1#2#3#4#5
+  {
     \@@_codepoint_process:nN
-      { \@@_change_case_breathing:nnnnw {#2} {#3} {#4} }
+      { \@@_change_case_breathing:nnnnnw {#2} {#3} {#4} {#5} }
         #1 \q_mark
   }
 %    \end{macrocode}
@@ -1663,36 +1709,36 @@
 %   and second if the final resulting codepoint is one of the two we
 %   care about.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_breathing:nnnnw #1#2#3#4#5 \q_mark
-  {
-    \tl_if_blank:nTF {#5}
-      { \@@_change_case_loop:nnw {#1} {#2} #3 }
-      {
-        \@@_codepoint_process:nN
-          { \@@_change_case_breathing:nnnnnw {#1} {#2} {#3} {#4} }
-            #5 \q_mark
-      }
-  }
 \cs_new:Npn \@@_change_case_breathing:nnnnnw #1#2#3#4#5#6 \q_mark
   {
     \tl_if_blank:nTF {#6}
+      { \@@_change_case_loop:nnnw {#1} {#2} {#3} #4 }
+      {
+        \@@_codepoint_process:nN
+          { \@@_change_case_breathing:nnnnnnw {#1} {#2} {#3} {#4} {#5} }
+            #6 \q_mark
+      }
+  }
+\cs_new:Npn \@@_change_case_breathing:nnnnnnw #1#2#3#4#5#6#7 \q_mark
+  {
+    \tl_if_blank:nTF {#7}
      {
-       \@@_change_case_breathing_aux:nnnnn
-         {#1} {#2} {#3} {#4} {#5}
+       \@@_change_case_breathing_aux:nnnnnn
+         {#1} {#2} {#3} {#4} {#5} {#6}
      }
      {
        \@@_codepoint_process:nN
-         { \@@_change_case_breathing:nnnnnw {#1} {#2} {#3} {#4} }
-           #6 \q_mark
+         { \@@_change_case_breathing:nnnnnnw {#1} {#2} {#3} {#4} {#5} }
+           #7 \q_mark
      }
   }
-\cs_new:Npn \@@_change_case_breathing_aux:nnnnn #1#2#3#4#5
+\cs_new:Npn \@@_change_case_breathing_aux:nnnnnn #1#2#3#4#5#6
   {
     \bool_lazy_or:nnTF
-      { \@@_codepoint_compare_p:nNn {#5} = { "0313 } }
-      { \@@_codepoint_compare_p:nNn {#5} = { "0314 } }
-      { \@@_change_case_breathing_aux:nnnw {#1} {#2} {#4} }
-      { \@@_change_case_loop:nnw {#1} {#2} #3 }
+      { \@@_codepoint_compare_p:nNn {#6} = { "0313 } }
+      { \@@_codepoint_compare_p:nNn {#6} = { "0314 } }
+      { \@@_change_case_breathing_aux:nnnnw {#1} {#2} {#3} {#5} }
+      { \@@_change_case_loop:nnnw {#1} {#2} {#3} #4 }
   }
 %    \end{macrocode}
 %   Now the lookahead can be fired: check the next codepoint and assess
@@ -1700,29 +1746,29 @@
 %    breathing mark or generate the \emph{dialytika}: the
 %   latter is code shared with the general mechanism.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_breathing_aux:nnnw #1#2#3#4
+\cs_new:Npn \@@_change_case_breathing_aux:nnnnw #1#2#3#4#5
   \q_@@_recursion_stop
   {
     \@@_change_case_store:e
-      { \@@_change_case_codepoint:nn { upper } {#3} }
-    \tl_if_head_is_N_type:nTF {#4}
-      { \@@_change_case_breathing_aux:nnN  }
-      { \@@_change_case_loop:nnw }
-        {#1} {#2} #4 \q_@@_recursion_stop
+      { \@@_change_case_codepoint:nn { upper } {#4} }
+    \tl_if_head_is_N_type:nTF {#5}
+      { \@@_change_case_breathing_aux:nnnN }
+      { \@@_change_case_loop:nnnw }
+        {#1} {#2} {#3} #5 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_breathing_aux:nnN #1#2#3
+\cs_new:Npn \@@_change_case_breathing_aux:nnnN #1#2#3#4
   {
     \@@_codepoint_process:nN
-      { \@@_change_case_breathing_dialytika:nnn {#1} {#2} } #3
+      { \@@_change_case_breathing_dialytika:nnnn {#1} {#2} {#3} } #4
   }
-\cs_new:Npn \@@_change_case_breathing_dialytika:nnn #1#2#3
+\cs_new:Npn \@@_change_case_breathing_dialytika:nnnn #1#2#3#4
   {
-     \@@_change_case_if_takes_dialytika:nTF {#3}
+     \@@_change_case_if_takes_dialytika:nTF {#4}
        {
-         \@@_change_case_upper_el_dialytika:n {#3}
-         \@@_change_case_loop:nnw {#1} {#2}
+         \@@_change_case_upper_el_dialytika:n {#4}
+         \@@_change_case_loop:nnnw {#1} {#2} {#3}
        }
-       { \@@_change_case_loop:nnw {#1} {#2} #3 }
+       { \@@_change_case_loop:nnnw {#1} {#2} {#3} #4 }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1733,88 +1779,88 @@
 % \end{macro}
 % \end{macro}
 % \end{macro}
-% \begin{macro}[EXP]{\@@_change_case_title_el:nnnn}
+% \begin{macro}[EXP]{\@@_change_case_title_el:nnnnn}
 %   Titlecasing retains accents, but to prevent the uppercasing code
 %   from kicking in, there has to be an explicit function here.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_title_el:nnnn #1#2#3#4
-  { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+\cs_new:Npn \@@_change_case_title_el:nnnnn #1#2#3#4#5
+  { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
 %    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case_upper_hy:nnnn        ,
-%     \@@_change_case_title_hy:nnnn        ,
-%     \@@_change_case_upper_hy-x-yiwn:nnnn ,
-%     \@@_change_case_title_hy-x-yiwn:nnnn
+%     \@@_change_case_upper_hy:nnnnn        ,
+%     \@@_change_case_title_hy:nnnnn        ,
+%     \@@_change_case_upper_hy-x-yiwn:nnnnn ,
+%     \@@_change_case_title_hy-x-yiwn:nnnnn
 %   }
 %     See \url{https://www.unicode.org/L2/L2020/20143-armenian-ech-yiwn.pdf}.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_hy:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_hy:nnnnn #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "0587 }
+    \@@_codepoint_compare:nNnTF {#5} = { "0587 }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn { "0535 }
-              { \@@_change_case_catcode:nn {#4} { "0535 } }
+              { \@@_change_case_catcode:nn {#5} { "0535 } }
             \codepoint_generate:nn { "054E }
-              { \@@_change_case_catcode:nn {#4} { "054E } }
+              { \@@_change_case_catcode:nn {#5} { "054E } }
           }
-        \use:c { @@_change_case_next_ #2 :nn }
-          {#2} {#3}
+        \use:c { @@_change_case_next_ #2 :nnn }
+          {#2} {#3} {#4}
       }
-      { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
   }
-\cs_new:Npn \@@_change_case_title_hy:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_title_hy:nnnnn #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "0587 }
+    \@@_codepoint_compare:nNnTF {#5} = { "0587 }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn { "0535 }
-              { \@@_change_case_catcode:nn {#4} { "0535 } }
+              { \@@_change_case_catcode:nn {#5} { "0535 } }
             \codepoint_generate:nn { "057E }
-              { \@@_change_case_catcode:nn {#4} { "057E } }
+              { \@@_change_case_catcode:nn {#5} { "057E } }
           }
-        \use:c { @@_change_case_next_ #2 :nn }
-          {#2} {#3}
+        \use:c { @@_change_case_next_ #2 :nnn }
+          {#2} {#3} {#4}
       }
-      { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
   }
-\cs_new:cpn { @@_change_case_upper_hy-x-yiwn:nnnn } #1#2#3#4
-  { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
-\cs_new_eq:cc { @@_change_case_title_hy-x-yiwn:nnnn }
-  { @@_change_case_upper_hy-x-yiwn:nnnn }
+\cs_new:cpn { @@_change_case_upper_hy-x-yiwn:nnnnn } #1#2#3#4#5
+  { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
+\cs_new_eq:cc { @@_change_case_title_hy-x-yiwn:nnnnn }
+  { @@_change_case_upper_hy-x-yiwn:nnnnn }
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}[EXP]{\@@_change_case_lower_la-x-medieval:nnnn}
-% \begin{macro}[EXP]{\@@_change_case_upper_la-x-medieval:nnnn}
+% \begin{macro}[EXP]{\@@_change_case_lower_la-x-medieval:nnnnn}
+% \begin{macro}[EXP]{\@@_change_case_upper_la-x-medieval:nnnnn}
 %   Simply swaps of characters.
 %    \begin{macrocode}
-\cs_new:cpn { @@_change_case_lower_la-x-medieval:nnnn } #1#2#3#4
+\cs_new:cpn { @@_change_case_lower_la-x-medieval:nnnnn } #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "0056 }
+    \@@_codepoint_compare:nNnTF {#5} = { "0056 }
       {
         \@@_change_case_store:e
-          { \char_generate:nn { "0075 } { \@@_char_catcode:N #4 } }
-        \use:c { @@_change_case_next_ #2 :nn }
-          {#2} {#3}
+          { \char_generate:nn { "0075 } { \@@_char_catcode:N #5 } }
+        \use:c { @@_change_case_next_ #2 :nnn }
+          {#2} {#3} {#4}
       }
-      { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
   }
-\cs_new:cpn { @@_change_case_upper_la-x-medieval:nnnn } #1#2#3#4
+\cs_new:cpn { @@_change_case_upper_la-x-medieval:nnnnn } #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "0075 }
+    \@@_codepoint_compare:nNnTF {#5} = { "0075 }
       {
         \@@_change_case_store:e
-          { \char_generate:nn { "0056 } { \@@_char_catcode:N #4 } }
-        \use:c { @@_change_case_next_ #2 :nn }
-          {#2} {#3}
+          { \char_generate:nn { "0056 } { \@@_char_catcode:N #5 } }
+        \use:c { @@_change_case_next_ #2 :nnn }
+          {#2} {#3} {#4}
       }
-      { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1822,62 +1868,62 @@
 %
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_cases_lower_lt:nnnn      ,
-%     \@@_change_cases_lower_lt_auxi:nnnn ,
-%     \@@_change_cases_lower_lt_auxii:nnnn
+%     \@@_change_cases_lower_lt:nnnnn      ,
+%     \@@_change_cases_lower_lt_auxi:nnnnn ,
+%     \@@_change_cases_lower_lt_auxii:nnnnn
 %   }
-% \begin{macro}[rEXP]{\@@_change_case_lower_lt:nnw}
-% \begin{macro}[rEXP]{\@@_change_case_lower_lt:nnN}
-% \begin{macro}[rEXP]{\@@_change_case_lower_lt:nnn}
+% \begin{macro}[rEXP]{\@@_change_case_lower_lt:nnnw}
+% \begin{macro}[rEXP]{\@@_change_case_lower_lt:nnnN}
+% \begin{macro}[rEXP]{\@@_change_case_lower_lt:nnnn}
 %   For  Lithuanian, the issue to be dealt with is dots over lower case
 %   letters: these should be present if there is another accent. The first step
 %   is a simple match attempt: look for the three uppercase accented letters
 %   which should gain a dot-above char in their lowercase form.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_lower_lt:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_lower_lt:nnnnn #1#2#3#4#5
   {
-    \exp_args:Ne \@@_change_case_lower_lt_auxi:nnnn
+    \exp_args:Ne \@@_change_case_lower_lt_auxi:nnnnn
       {
-        \int_case:nn { \@@_codepoint_from_chars:Nw #4 }
+        \int_case:nn { \@@_codepoint_from_chars:Nw #5 }
           {
             { "00CC } { "0300 }
             { "00CD } { "0301 }
             { "0128 } { "0303 }
           }  
       }
-        {#2} {#3} {#4}
+        {#2} {#3} {#4} {#5}
   }
 %    \end{macrocode}
 %   If there was a hit, output the result with the dot-above and move on.
 %   Otherwise, look for one of the three letters that can take a combining
 %   accent: I, J nd I-ogonek. 
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_lower_lt_auxi:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_lower_lt_auxi:nnnnn #1#2#3#4#5
   {
     \tl_if_blank:nTF {#1}
       {
-        \exp_args:Ne \@@_change_case_lower_lt_auxii:nnnn
+        \exp_args:Ne \@@_change_case_lower_lt_auxii:nnnnn
           {
-            \int_case:nn { \@@_codepoint_from_chars:Nw #4 }
+            \int_case:nn { \@@_codepoint_from_chars:Nw #5 }
               {
                 { "0049 } { "0069 }
                 { "004A } { "006A }
                 { "012E } { "012F }
               }  
           }
-            {#2} {#3} {#4}
+            {#2} {#3} {#4} {#5}
       }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn { "0069 }
-              { \@@_change_case_catcode:nn {#4} { "0069 } }
+              { \@@_change_case_catcode:nn {#5} { "0069 } }
             \codepoint_generate:nn { "0307 }
-              { \@@_change_case_catcode:nn {#4} { "0307 } }
+              { \@@_change_case_catcode:nn {#5} { "0307 } }
             \codepoint_generate:nn {#1}
-              { \@@_change_case_catcode:nn {#4} {#1} }
+              { \@@_change_case_catcode:nn {#5} {#1} }
           }
-        \@@_change_case_loop:nnw {#2} {#3}
+        \@@_change_case_loop:nnnw {#2} {#3} {#4}
       }
   }
 %    \end{macrocode}
@@ -1885,55 +1931,55 @@
 %   then need to look for a combining accent: as usual, we need to be aware of
 %   the loop situation.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_lower_lt_auxii:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_lower_lt_auxii:nnnnn #1#2#3#4#5
   {
     \tl_if_blank:nTF {#1}
-      { \@@_change_case_codepoint:nnnn {#2} {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn {#2} {#2} {#3} {#4} {#5} }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn {#1}
-              { \@@_change_case_catcode:nn {#4} {#1} }
+              { \@@_change_case_catcode:nn {#5} {#1} }
           }
-        \@@_change_case_lower_lt:nnw {#2} {#3}
+        \@@_change_case_lower_lt:nnnw {#2} {#3} {#4}
       }
   }
-\cs_new:Npn \@@_change_case_lower_lt:nnw #1#2#3 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_lower_lt:nnnw #1#2#3#4 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#3}
-      { \@@_change_case_lower_lt:nnN }
-      { \@@_change_case_loop:nnw }
-       {#1} {#2} #3 \q_@@_recursion_stop
+    \tl_if_head_is_N_type:nTF {#4}
+      { \@@_change_case_lower_lt:nnnN }
+      { \@@_change_case_loop:nnnw }
+       {#1} {#2} {#3} #4 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_lower_lt:nnN #1#2#3
+\cs_new:Npn \@@_change_case_lower_lt:nnnN #1#2#3#4
   {
     \@@_codepoint_process:nN
-      { \@@_change_case_lower_lt:nnn {#1} {#2} } #3
+      { \@@_change_case_lower_lt:nnnn {#1} {#2} {#3} } #4
   }
-\cs_new:Npn \@@_change_case_lower_lt:nnn #1#2#3
+\cs_new:Npn \@@_change_case_lower_lt:nnnn #1#2#3#4
   {
     \bool_lazy_and:nnT
       {
         \bool_lazy_or_p:nn
-          { ! \tl_if_single_p:n {#3} }
-          { ! \token_if_cs_p:N #3 }
+          { ! \tl_if_single_p:n {#4} }
+          { ! \token_if_cs_p:N #4 }
       }
       {
         \bool_lazy_any_p:n
           {
-            { \@@_codepoint_compare_p:nNn {#3} = { "0300 } }
-            { \@@_codepoint_compare_p:nNn {#3} = { "0301 } }
-            { \@@_codepoint_compare_p:nNn {#3} = { "0303 } }
+            { \@@_codepoint_compare_p:nNn {#4} = { "0300 } }
+            { \@@_codepoint_compare_p:nNn {#4} = { "0301 } }
+            { \@@_codepoint_compare_p:nNn {#4} = { "0303 } }
           }
       }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn { "0307 }
-              { \@@_change_case_catcode:nn {#3} { "0307 } }
+              { \@@_change_case_catcode:nn {#4} { "0307 } }
           }
       }
-    \@@_change_case_loop:nnw {#1} {#2} #3
+    \@@_change_case_loop:nnnw {#1} {#2} {#3} #4
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1942,64 +1988,64 @@
 % \end{macro}
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_cases_upper_lt:nnnn     ,
-%     \@@_change_cases_upper_lt_aux:nnnn
+%     \@@_change_cases_upper_lt:nnnnn     ,
+%     \@@_change_cases_upper_lt_aux:nnnnn
 %   }
-% \begin{macro}[rEXP]{\@@_change_case_upper_lt:nnw}
-% \begin{macro}[rEXP]{\@@_change_case_upper_lt:nnN}
-% \begin{macro}[rEXP]{\@@_change_case_upper_lt:nnn}
+% \begin{macro}[rEXP]{\@@_change_case_upper_lt:nnnw}
+% \begin{macro}[rEXP]{\@@_change_case_upper_lt:nnnN}
+% \begin{macro}[rEXP]{\@@_change_case_upper_lt:nnnn}
 %   The uppercasing version: first find i/j/i-ogonek, then look for the
 %   combining char: drop it if present.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_lt:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_lt:nnnnn #1#2#3#4#5
  {
-    \exp_args:Ne \@@_change_case_upper_lt_aux:nnnn
+    \exp_args:Ne \@@_change_case_upper_lt_aux:nnnnn
       {
-        \int_case:nn { \@@_codepoint_from_chars:Nw #4 }
+        \int_case:nn { \@@_codepoint_from_chars:Nw #5 }
           {
             { "0069 } { "0049 }
             { "006A } { "004A }
             { "012F } { "012E }
           }  
       }
-        {#2} {#3} {#4}
+        {#2} {#3} {#4} {#5}
   }
-\cs_new:Npn \@@_change_case_upper_lt_aux:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_lt_aux:nnnnn #1#2#3#4#5
   {
     \tl_if_blank:nTF {#1}
-      { \@@_change_case_codepoint:nnnn { upper } {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn { upper } {#2} {#3} {#4} {#5} }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn {#1}
-              { \@@_change_case_catcode:nn {#4} {#1} }
+              { \@@_change_case_catcode:nn {#5} {#1} }
           }
-        \@@_change_case_upper_lt:nnw {#2} {#3}
+        \@@_change_case_upper_lt:nnnw {#2} {#3} {#4}
       }
   }
-\cs_new:Npn \@@_change_case_upper_lt:nnw #1#2#3 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_upper_lt:nnnw #1#2#3#4 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#3}
-      { \@@_change_case_upper_lt:nnN }
-      { \use:c { @@_change_case_next_ #1 :nn } }
-        {#1} {#2} #3 \q_@@_recursion_stop
+    \tl_if_head_is_N_type:nTF {#4}
+      { \@@_change_case_upper_lt:nnnN }
+      { \use:c { @@_change_case_next_ #1 :nnn } }
+        {#1} {#2} {#3} #4 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_upper_lt:nnN #1#2#3
+\cs_new:Npn \@@_change_case_upper_lt:nnnN #1#2#3#4
   {
     \@@_codepoint_process:nN
-      { \@@_change_case_upper_lt:nnn {#1} {#2} } #3
+      { \@@_change_case_upper_lt:nnnn {#1} {#2} {#3} } #4
   }
-\cs_new:Npn \@@_change_case_upper_lt:nnn #1#2#3
+\cs_new:Npn \@@_change_case_upper_lt:nnnn #1#2#3#4
   {
     \bool_lazy_and:nnTF
       {
         \bool_lazy_or_p:nn
-          { ! \tl_if_single_p:n {#3} }
-          { ! \token_if_cs_p:N #3 }
+          { ! \tl_if_single_p:n {#4} }
+          { ! \token_if_cs_p:N #4 }
       }
-      { \@@_codepoint_compare_p:nNn {#3} = { "0307 } }
-      { \use:c { @@_change_case_next_ #1 :nn } {#1} {#2} }
-      { \use:c { @@_change_case_next_ #1 :nn } {#1} {#2} #3 }
+      { \@@_codepoint_compare_p:nNn {#4} = { "0307 } }
+      { \use:c { @@_change_case_next_ #1 :nnn } {#1} {#2} {#3} }
+      { \use:c { @@_change_case_next_ #1 :nnn } {#1} {#2} {#3} #4 }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -2008,84 +2054,84 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]
-%   {\@@_change_case_title_nl:nnnn, \@@_change_case_title_nl_aux:nnnn}
-% \begin{macro}[EXP]{\@@_change_case_title_nl:nnw}
-% \begin{macro}[EXP]{\@@_change_case_title_nl:nnN}
+%   {\@@_change_case_title_nl:nnnnn, \@@_change_case_title_nl_aux:nnnnn}
+% \begin{macro}[EXP]{\@@_change_case_title_nl:nnnw}
+% \begin{macro}[EXP]{\@@_change_case_title_nl:nnnN}
 %   For Dutch, there is a single look-ahead test for \texttt{ij} when
 %   title casing. If the appropriate letters are found, produce \texttt{IJ}
 %   and gobble the \texttt{j}/\texttt{J}.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_title_nl:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_title_nl:nnnnn #1#2#3#4#5
   {
-    \tl_if_single:nTF {#4}
-      { \@@_change_case_title_nl_aux:nnnn }
-      { \@@_change_case_codepoint:nnnn }
-        {#1} {#2} {#3} {#4} 
+    \tl_if_single:nTF {#5}
+      { \@@_change_case_title_nl_aux:nnnnn }
+      { \@@_change_case_codepoint:nnnnn }
+        {#1} {#2} {#3} {#4}  {#5}
   }
-\cs_new:Npn \@@_change_case_title_nl_aux:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_title_nl_aux:nnnnn #1#2#3#4#5
   {
     \bool_lazy_or:nnTF
-      { \int_compare_p:nNn {`#4} = { "0049 } }
-      { \int_compare_p:nNn {`#4} = { "0069 } }
+      { \int_compare_p:nNn {`#5} = { "0049 } }
+      { \int_compare_p:nNn {`#5} = { "0069 } }
       {
         \@@_change_case_store:e
-          { \char_generate:nn { "0049 } { \@@_char_catcode:N #4 } }
-        \@@_change_case_title_nl:nnw {#2} {#3}
+          { \char_generate:nn { "0049 } { \@@_char_catcode:N #5 } }
+        \@@_change_case_title_nl:nnnw {#2} {#3} {#4}
       }
-      { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
   }
-\cs_new:Npn \@@_change_case_title_nl:nnw #1#2#3 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_title_nl:nnnw #1#2#3#4 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#3}
-      { \@@_change_case_title_nl:nnN }
-      { \use:c { @@_change_case_next_ #1 :nn } }
-        {#1} {#2} #3 \q_@@_recursion_stop
+    \tl_if_head_is_N_type:nTF {#4}
+      { \@@_change_case_title_nl:nnnN }
+      { \use:c { @@_change_case_next_ #1 :nnn } }
+        {#1} {#2} {#3} #4 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_title_nl:nnN #1#2#3
+\cs_new:Npn \@@_change_case_title_nl:nnnN #1#2#3#4
   {
     \bool_lazy_and:nnTF
-      { ! \token_if_cs_p:N #3 }
+      { ! \token_if_cs_p:N #4 }
       {
         \bool_lazy_or_p:nn
-          { \int_compare_p:nNn {`#3} = { "004A } }
-          { \int_compare_p:nNn {`#3} = { "006A } }
+          { \int_compare_p:nNn {`#4} = { "004A } }
+          { \int_compare_p:nNn {`#4} = { "006A } }
       }
       {
         \@@_change_case_store:e
-          { \char_generate:nn { "004A } { \@@_char_catcode:N #3 } }
-        \use:c { @@_change_case_next_ #1 :nn } {#1} {#2}
+          { \char_generate:nn { "004A } { \@@_char_catcode:N #4 } }
+        \use:c { @@_change_case_next_ #1 :nnn } {#1} {#2} {#3}
       }
-      { \use:c { @@_change_case_next_ #1 :nn } {#1} {#2} #3 }
+      { \use:c { @@_change_case_next_ #1 :nnn } {#1} {#2} {#3} #4 }
   }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}[EXP]{\@@_change_case_lower_tr:nnnn}
-% \begin{macro}[EXP]{\@@_change_case_lower_tr:nnNw}
-% \begin{macro}[EXP]{\@@_change_case_lower_tr:NnnN}
-% \begin{macro}[EXP]{\@@_change_case_lower_tr:Nnnn}
+% \begin{macro}[EXP]{\@@_change_case_lower_tr:nnnnn}
+% \begin{macro}[EXP]{\@@_change_case_lower_tr:nnnNw}
+% \begin{macro}[EXP]{\@@_change_case_lower_tr:NnnnN}
+% \begin{macro}[EXP]{\@@_change_case_lower_tr:Nnnnn}
 %   The Turkic languages need special treatment for dotted-i and dotless-i.
 %   The lower casing rule can be expressed in terms of searching first for
 %   either a dotless-I or a dotted-I. In the latter case the mapping is
 %   easy, but in the former there is a second stage search.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_lower_tr:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_lower_tr:nnnnn #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "0049 }
-      { \@@_change_case_lower_tr:nnNw {#1} {#3} #4 }
+    \@@_codepoint_compare:nNnTF {#5} = { "0049 }
+      { \@@_change_case_lower_tr:nnnNw {#1} {#3} {#4} #5 }
       {
-        \@@_codepoint_compare:nNnTF {#4} = { "0130 }
+        \@@_codepoint_compare:nNnTF {#5} = { "0130 }
           {
             \@@_change_case_store:e
               {
                 \codepoint_generate:nn { "0069 }
-                  { \@@_change_case_catcode:nn {#4} { "0069 } }
+                  { \@@_change_case_catcode:nn {#5} { "0069 } }
               }
-            \@@_change_case_loop:nnw {#1} {#3}
+            \@@_change_case_loop:nnnw {#1} {#3} {#4}
           }
-          { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+          { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
       }
   }
 %    \end{macrocode}
@@ -2094,41 +2140,41 @@
 %   combination is found both the dotless-I and the dot-above char have to
 %   be removed from the input.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_lower_tr:nnNw #1#2#3#4 \q_@@_recursion_stop
+\cs_new:Npn \@@_change_case_lower_tr:nnnNw #1#2#3#4#5 \q_@@_recursion_stop
   {
-    \tl_if_head_is_N_type:nTF {#4}
-      { \@@_change_case_lower_tr:NnnN  #3 {#1} {#2} }
+    \tl_if_head_is_N_type:nTF {#5}
+      { \@@_change_case_lower_tr:NnnnN  #4 {#1} {#2} {#3} }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn { "0131 }
-              { \@@_change_case_catcode:nn {#3} { "0131 } }
+              { \@@_change_case_catcode:nn {#4} { "0131 } }
           }
-        \@@_change_case_loop:nnw {#1} {#2}
+        \@@_change_case_loop:nnnw {#1} {#2} {#3}
       }
-        #4 \q_@@_recursion_stop
+        #5 \q_@@_recursion_stop
   }
-\cs_new:Npn \@@_change_case_lower_tr:NnnN #1#2#3#4
+\cs_new:Npn \@@_change_case_lower_tr:NnnnN #1#2#3#4#5
   {
     \@@_codepoint_process:nN
-      { \@@_change_case_lower_tr:Nnnn #1 {#2} {#3} } #4
+      { \@@_change_case_lower_tr:Nnnnn #1 {#2} {#3} {#4} } #5
   }
-\cs_new:Npn \@@_change_case_lower_tr:Nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_lower_tr:Nnnnn #1#2#3#4#5
   {
     \bool_lazy_or:nnTF
       {
         \bool_lazy_and_p:nn
-          { \tl_if_single_p:n {#4} }
-          { \token_if_cs_p:N #4 }
+          { \tl_if_single_p:n {#5} }
+          { \token_if_cs_p:N #5 }
       }
-      { ! \@@_codepoint_compare_p:nNn {#4} = { "0307 } }
+      { ! \@@_codepoint_compare_p:nNn {#5} = { "0307 } }
       {
         \@@_change_case_store:e 
           {
             \codepoint_generate:nn { "0131 }
               { \@@_change_case_catcode:nn {#1} { "0131 } }
           }
-        \@@_change_case_loop:nnw {#2} {#3} #4
+        \@@_change_case_loop:nnnw {#2} {#3} {#4} #5
       }
       {
         \@@_change_case_store:e
@@ -2136,7 +2182,7 @@
             \codepoint_generate:nn { "0069 }
               { \@@_change_case_catcode:nn {#1} { "0069 } }
           }
-        \@@_change_case_loop:nnw {#2} {#3}
+        \@@_change_case_loop:nnnw {#2} {#3} {#4}
       }
   }
 %    \end{macrocode}
@@ -2144,33 +2190,33 @@
 % \end{macro}
 % \end{macro}
 % \end{macro}
-% \begin{macro}[EXP]{\@@_change_case_upper_tr:nnnn}
+% \begin{macro}[EXP]{\@@_change_case_upper_tr:nnnnn}
 %   Uppercasing is easier: just one exception with no context.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case_upper_tr:nnnn #1#2#3#4
+\cs_new:Npn \@@_change_case_upper_tr:nnnnn #1#2#3#4#5
   {
-    \@@_codepoint_compare:nNnTF {#4} = { "0069 }
+    \@@_codepoint_compare:nNnTF {#5} = { "0069 }
       {
         \@@_change_case_store:e
           {
             \codepoint_generate:nn { "0130 }
-              { \@@_change_case_catcode:nn {#4} { "0130 } }
+              { \@@_change_case_catcode:nn {#5} { "0130 } }
           }
-        \use:c { @@_change_case_next_ #2 :nn } {#2} {#3}
+        \use:c { @@_change_case_next_ #2 :nnn } {#2} {#3} {#4}
       }
-      { \@@_change_case_codepoint:nnnn {#1} {#2} {#3} {#4} }
+      { \@@_change_case_codepoint:nnnnn {#1} {#2} {#3} {#4} {#5} }
   }
 %    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}[EXP]
-%   {\@@_change_case_lower_az:nnnn, \@@_change_case_upper_az:nnnn}
+%   {\@@_change_case_lower_az:nnnnn, \@@_change_case_upper_az:nnnnn}
 %   Straight copies.
 %    \begin{macrocode}
-\cs_new_eq:NN \@@_change_case_lower_az:nnnn
-  \@@_change_case_lower_tr:nnnn
-\cs_new_eq:NN \@@_change_case_upper_az:nnnn
-  \@@_change_case_upper_tr:nnnn
+\cs_new_eq:NN \@@_change_case_lower_az:nnnnn
+  \@@_change_case_lower_tr:nnnnn
+\cs_new_eq:NN \@@_change_case_upper_az:nnnnn
+  \@@_change_case_upper_tr:nnnnn
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3text-case.dtx
+++ b/l3kernel/l3text-case.dtx
@@ -77,16 +77,17 @@
 %   {
 %     \text_lowercase:n,
 %     \text_uppercase:n,
-%     \text_titlecase:n,
-%     \text_titlecase_first:n
+%     \text_titlecase_all:n,
+%     \text_titlecase_once:n
 %   }
 % \begin{macro}[EXP]
 %   {
 %     \text_lowercase:nn,
 %     \text_uppercase:nn,
-%     \text_titlecase:nn,
-%     \text_titlecase_first:nn
+%     \text_titlecase_all:nn,
+%     \text_titlecase_once:nn
 %   }
+% \begin{macro}[EXP]{\@@_change_case:nnn}
 %   The user level functions here are all wrappers around the internal
 %   functions for case changing.
 %    \begin{macrocode}
@@ -94,31 +95,34 @@
   { \@@_change_case:nnn { lower } { } {#1} }
 \cs_new:Npn \text_uppercase:n #1
   { \@@_change_case:nnn { upper } { } {#1} }
-\cs_new:Npn \text_titlecase:n #1
+\cs_new:Npn \text_titlecase_all:n #1
   { \@@_change_case:nnn { title } { } {#1} }
-\cs_new:Npn \text_titlecase_first:n #1
-  { \@@_change_case:nnn { title } { } {#1} }
+\cs_new:Npn \text_titlecase_once:n #1
+  { \@@_change_case:nnnn { title } { break } { } {#1} }
 \cs_new:Npn \text_lowercase:nn #1#2
   { \@@_change_case:nnn { lower } {#1} {#2} }
 \cs_new:Npn \text_uppercase:nn #1#2
   { \@@_change_case:nnn { upper } {#1} {#2} }
-\cs_new:Npn \text_titlecase:nn #1#2
+\cs_new:Npn \text_titlecase_all:nn #1#2
   { \@@_change_case:nnn { title } {#1} {#2} }
-\cs_new:Npn \text_titlecase_first:nn #1#2
-  { \@@_change_case:nnn { title } {#1} {#2} }
+\cs_new:Npn \text_titlecase_once:nn #1#2
+  { \@@_change_case:nnnn { title } { break } {#1} {#2} }
+\cs_new:Npn \@@_change_case:nnn #1#2#3
+  { \@@_change_case:nnnn {#1} {#1} {#2} {#3} }
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 %
 % \begin{macro}[EXP]
 %   {
-%     \@@_change_case:nnn      ,
-%     \@@_change_case_auxi:nnn ,
-%     \@@_change_case_auxii:nnn
+%     \@@_change_case:nnnn       ,
+%     \@@_change_case_auxi:nnnn  ,
+%     \@@_change_case_auxii:nnnn
 %   }
-% \begin{macro}[EXP]{\@@_change_case_BCP:nnn}
-% \begin{macro}[EXP]{\@@_change_case_BCP:nnw}
+% \begin{macro}[EXP]{\@@_change_case_BCP:nnnn}
 % \begin{macro}[EXP]{\@@_change_case_BCP:nnnnw}
+% \begin{macro}[EXP]{\@@_change_case_BCP:nnnnnw}
 % \begin{macro}[EXP]
 %   {
 %     \@@_change_case_store:n, \@@_change_case_store:o,
@@ -136,7 +140,8 @@
 %     \@@_change_case_group_upper:nnnn ,
 %     \@@_change_case_group_title:nnnn
 %   }
-% \begin{macro}[EXP]{\@@_change_case_space:nnnw}
+% \begin{macro}[EXP]
+%   {\@@_change_case_space:nnnw, \@@_change_case_space_break:nnnw}
 % \begin{macro}[EXP]
 %   {\@@_change_case_N_type:nnnN, \@@_change_case_N_type_aux:nnnN}
 % \begin{macro}[EXP]{\@@_change_case_N_type:nnnnN}
@@ -227,45 +232,48 @@
 %   wrap the entire result in exactly one \cs{exp_not:n}, or rather in the
 %   kernel version.
 %    \begin{macrocode}
-\cs_new:Npn \@@_change_case:nnn #1#2#3
+\cs_new:Npn \@@_change_case:nnnn #1#2#3#4
   {
      \__kernel_exp_not:w \exp_after:wN
       {
         \exp:w
-        \exp_args:Ne \@@_change_case_auxi:nnn
-          { \text_expand:n {#3} }
-          {#1} {#2}
+        \exp_args:Ne \@@_change_case_auxi:nnnn
+          { \text_expand:n {#4} }
+          {#1} {#2} {#3}
       }
   }
-\cs_new:Npn \@@_change_case_auxi:nnn #1#2#3
-  { \exp_args:No \@@_change_case_BCP:nnn { \tl_to_str:n {#3} } {#1} {#2} }
-\cs_new:Npx \@@_change_case_BCP:nnn #1#2#3
+\cs_new:Npn \@@_change_case_auxi:nnnn #1#2#3#4
   {
-    \exp_not:N \@@_change_case_BCP:nnw
-      {#2} {#3} #1 \tl_to_str:n { -x- -x- } \exp_not:N \q_@@_stop
+    \exp_args:No \@@_change_case_BCP:nnnn
+      { \tl_to_str:n {#4} } {#1} {#2} {#3}
+  }
+\cs_new:Npx \@@_change_case_BCP:nnnn #1#2#3#4
+  {
+    \exp_not:N \@@_change_case_BCP:nnnw
+      {#2} {#3} {#4} #1 \tl_to_str:n { -x- -x- } \exp_not:N \q_@@_stop
   }
 \use:x
   {
-    \cs_new:Npn \exp_not:N \@@_change_case_BCP:nnw
-      ##1##2##3 \tl_to_str:n { -x- } ##4 \tl_to_str:n { -x- } ##5
+    \cs_new:Npn \exp_not:N \@@_change_case_BCP:nnnw
+      ##1##2##3##4 \tl_to_str:n { -x- } ##5 \tl_to_str:n { -x- } ##6
       \exp_not:N \q_@@_stop
   }
-  { \@@_change_case_BCP:nnnnw {#1} {#2} {#4} {#3} #3 - - \q_@@_stop }
-\cs_new:Npn \@@_change_case_BCP:nnnnw #1#2#3#4#5 - #6 - #7 \q_@@_stop
+  { \@@_change_case_BCP:nnnnnnw {#1} {#2} {#3} {#5} {#4} #4 - \q_@@_stop }
+\cs_new:Npn \@@_change_case_BCP:nnnnnnw #1#2#3#4#5#6 - #7 \q_@@_stop
   {
-    \cs_if_exist:cTF { @@_change_case_ #2 _ #5 -x- #3 :nnnnn }
-      { \@@_change_case_auxii:nnn {#1} {#2} { #5 -x- #3 } }
+    \cs_if_exist:cTF { @@_change_case_ #2 _ #6 -x- #4 :nnnnn }
+      { \@@_change_case_auxii:nnnn {#1} {#2} {#3} { #6 -x- #4 } }
       {
-        \cs_if_exist:cTF { @@_change_case_ #2 _ #5 :nnnnn }
-          { \@@_change_case_auxii:nnn {#1} {#2} {#5} }
-          { \@@_change_case_auxii:nnn {#1} {#2} {#4} }
+        \cs_if_exist:cTF { @@_change_case_ #2 _ #6 :nnnnn }
+          { \@@_change_case_auxii:nnnn {#1} {#2} {#3} {#6} }
+          { \@@_change_case_auxii:nnnn {#1} {#2} {#3} {#5} }
       }
   }
-\cs_new:Npn \@@_change_case_auxii:nnn #1#2#3
+\cs_new:Npn \@@_change_case_auxii:nnnn #1#2#3#4
   {
     \group_align_safe_begin:
-    \cs_if_exist_use:c { @@_change_case_boundary_ #2 _ #3 :Nnnnw }
-    \@@_change_case_loop:nnnw {#2} {#2} {#3} #1
+    \cs_if_exist_use:c { @@_change_case_boundary_ #2 _ #4 :Nnnnw }
+    \@@_change_case_loop:nnnw {#2} {#3} {#4} #1
       \q_@@_recursion_tail \q_@@_recursion_stop
     \@@_change_case_result:n { }
   }
@@ -318,7 +326,7 @@
         \exp_after:wN
           {
             \exp:w
-            \@@_change_case_auxii:nnn {#4} {#1} {#3}
+            \@@_change_case_auxii:nnnn {#4} {#1} {#2} {#3}
           }
       }
     \@@_change_case_loop:nnnw {#1} {#2} {#3}
@@ -332,10 +340,10 @@
         \exp_after:wN
           {
             \exp:w
-            \@@_change_case_auxii:nnn {#4} {#1} {#3}
+            \@@_change_case_auxii:nnnn {#4} {#1} {#2} {#3}
           }
       }
-    \@@_change_case_break:w
+    \@@_change_case_skip:nnw {#2} {#3}
   }
 \use:x
   {
@@ -343,9 +351,15 @@
   }
   {
     \@@_change_case_store:n { ~ }
-    \cs_if_exist_use:c { @@_change_case_boundary_ #1 _ #3 :Nnnnw }
-    \@@_change_case_loop:nnnw {#2} {#2} {#3}
+    \cs_if_exist_use:cF { @@_change_case_space_ #2 :nnn }
+      {
+        \cs_if_exist_use:c { @@_change_case_boundary_ #1 _ #3 :Nnnnw }
+        \@@_change_case_loop:nnnw
+      }
+        {#2} {#2} {#3}
   }
+\cs_new:Npn \@@_change_case_space_break:nnn #1#2#3
+  { \@@_change_case_break:w }
 %    \end{macrocode}
 %   The first step of handling \texttt{N}-type tokens is to filter out the
 %   end-of-loop. That has to be done separately from the first real step
@@ -476,7 +490,7 @@
         \@@_change_case_store:o
           {
             \exp_after:wN #4
-              \exp:w \@@_change_case_auxii:nnn {#5} {#1} {#2}
+              \exp:w \@@_change_case_auxii:nnnn {#5} {#1} {#2} {#3}
               {#6}
           }
       }

--- a/l3kernel/l3text.dtx
+++ b/l3kernel/l3text.dtx
@@ -94,12 +94,12 @@
 %
 % \section{Case changing}
 %
-% \begin{function}[EXP, added = 2019-11-20, updated = 2022-10-13]
+% \begin{function}[EXP, added = 2019-11-20, updated = 2023-07-08]
 %   {
-%     \text_lowercase:n,  \text_uppercase:n,  \text_titlecase:n,
-%       \text_titlecase_first:n,
-%     \text_lowercase:nn, \text_uppercase:nn, \text_titlecase:nn,
-%       \text_titlecase_first:nn
+%     \text_lowercase:n,  \text_uppercase:n,  \text_titlecase_all:n,
+%       \text_titlecase_once:n,
+%     \text_lowercase:nn, \text_uppercase:nn, \text_titlecase_all:nn,
+%       \text_titlecase_once:nn
 %   }
 %   \begin{syntax}
 %     \cs{text_uppercase:n}  \Arg{tokens}
@@ -115,11 +115,13 @@
 %
 %   Upper- and lowercase have the obvious meanings. Titlecasing may be regarded
 %   informally as converting the first character of the \meta{tokens} to
-%   uppercase and the rest to lowercase. However, the process is more complex
+%   uppercase. However, the process is more complex
 %   than this as there are some situations where a single lowercase character
 %   maps to a special form, for example \texttt{ij} in Dutch which becomes
-%   \texttt{IJ}. The \texttt{titlecase_first} variant does not attempt
-%   any case changing at all after the first letter has been processed.
+%   \texttt{IJ}. There are two functions available for titlecasing: one which
+%   applies the change to each \enquote{word} and a second which only applies
+%   at the start of the input. (Here, \enquote{word} boundaries are spaces:
+%   at present full Unicode word breaking is not attempted.)
 %
 %   Importantly, notice that these functions are intended for working with
 %   user \emph{text for typesetting}. For case changing programmatic data see
@@ -190,11 +192,7 @@
 %       available using \pdfTeX{}.
 %   \end{itemize}
 %
-%  For titlecasing, note that there are two functions available. The
-%  function \cs{text_titlecase:n} applies (broadly) uppercasing to the first
-%  letter of the input, then lowercasing to the remainder. In contrast,
-%  \cs{text_titlecase_first:n} \emph{only} carries out the uppercasing operation,
-%  and leaves the balance of the input unchanged. Determining whether
+%  Determining whether
 %  non-letter characters at the start of text should switch from upper- to
 %  lowercasing is controllable. When \cs{l_text_titlecase_check_letter_bool} is
 %  \texttt{true}, characters which are not letters (category code~$11$) are

--- a/l3kernel/testfiles/m3text002.luatex.tlg
+++ b/l3kernel/testfiles/m3text002.luatex.tlg
@@ -7,14 +7,14 @@ TEST 1: Basic case changing
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
 Hello World \par With \ERROR &##
-Hello World \par With \ERROR &##
+Hello world \par with \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
 ============================================================
 {hello} world \par with \ERROR &##
 {HELLO} WORLD \par WITH \ERROR &##
-{Hello} world \par with \ERROR &##
+{Hello} World \par With \ERROR &##
 {Hello} world \par with \ERROR &##
 ============================================================
 ============================================================
@@ -23,45 +23,45 @@ TEST 3: Case change exclusions
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
 Some Text \cite {WithFun}
-Some Text \cite {WithFun}
+Some text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
 Hello World
-Hello World
+Hello world
 HELLO WORLD
 HELLO WORLD
 " Hello World"
-" Hello World"
+" hello world"
 " HELLO WORLD"
 " HELLO WORLD"
-{H}ello world
+{H}ello World
 {H}ello world
 {H}ELLO WORLD
 {H}ELLO WORLD
+{}hello World
 {}hello world
-{}hello world
-{}hello world
+{}hello World
 {}hello world
 ============================================================
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
 `Hic Sunt Leones'
-`Hic Sunt Leones'
+`Hic sunt leones'
 ``Hic Sunt Leones''
-``Hic Sunt Leones''
+``Hic sunt leones''
 ([Hic Sunt Leones])
-([Hic Sunt Leones])
+([Hic sunt leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
 `Hic SUNT Leones'
-`Hic SUNT Leones'
+`Hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -69,9 +69,9 @@ E PLURIBUS UNUM
 TEST 7: Titlecase control
 ============================================================
 `hic SUNT Leones'
-`hic SUNT Leones'
+`hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -81,11 +81,11 @@ TEST 8: Language based case changing but nothing
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -133,7 +133,7 @@ TEST 13: Cyrillic
 доклады академии наук
 ДОКЛАДЫ АКАДЕМИИ НАУК
 Доклады Академии Наук
-Доклады Академии Наук
+Доклады Академии наук
 ============================================================
 ============================================================
 TEST 14: BCP47 parts
@@ -300,7 +300,7 @@ FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
-\emph {BAR} {BAZ}
+\emph {BAR} BAZ
 ============================================================
 ============================================================
 TEST 24: Expanding content
@@ -308,27 +308,27 @@ TEST 24: Expanding content
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
 Some Text \cs_tmp:w 
-Some Text \cs_tmp:w 
+Some text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
-\cs_tmp:w  Sometext
+\cs_tmp:w  sometext
 ============================================================
 ============================================================
 TEST 25: Math-mode escape
@@ -336,15 +336,15 @@ TEST 25: Math-mode escape
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
 Some Text $y = mx + c$
-Some Text $y = mx + c$
+Some text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
-$y = mx + c$ Text
+$y = mx + c$ text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
 Opps Not Close Token In $y = mx + c
-Opps Not Close Token In $y = mx + c
+Opps not close token in $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -399,7 +399,7 @@ Title
 WORDS lower
 words UPPER
 Words Title
-Words Title
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.luatex.tlg
+++ b/l3kernel/testfiles/m3text002.luatex.tlg
@@ -6,8 +6,8 @@ TEST 1: Basic case changing
 ============================================================
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
-Hello world \par with \ERROR &##
-Hello world \par with \ERROR &##
+Hello World \par With \ERROR &##
+Hello World \par With \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
@@ -22,18 +22,18 @@ TEST 3: Case change exclusions
 ============================================================
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
-Some text \cite {WithFun}
-Some text \cite {WithFun}
+Some Text \cite {WithFun}
+Some Text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
-Hello world
-Hello world
+Hello World
+Hello World
 HELLO WORLD
 HELLO WORLD
-" Hello world"
-" Hello world"
+" Hello World"
+" Hello World"
 " HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
@@ -48,30 +48,30 @@ HELLO WORLD
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
-`Hic sunt leones'
-`Hic sunt leones'
-``Hic sunt leones''
-``Hic sunt leones''
-([Hic sunt leones])
-([Hic sunt leones])
+`Hic Sunt Leones'
+`Hic Sunt Leones'
+``Hic Sunt Leones''
+``Hic Sunt Leones''
+([Hic Sunt Leones])
+([Hic Sunt Leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic SUNT leones'
-`Hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`Hic SUNT Leones'
+`Hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic SUNT leones'
-`hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`hic SUNT Leones'
+`hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -80,12 +80,12 @@ TEST 8: Language based case changing but nothing
 ============================================================
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -132,8 +132,8 @@ TEST 13: Cyrillic
 ============================================================
 доклады академии наук
 ДОКЛАДЫ АКАДЕМИИ НАУК
-Доклады Академии наук
-Доклады Академии наук
+Доклады Академии Наук
+Доклады Академии Наук
 ============================================================
 ============================================================
 TEST 14: BCP47 parts
@@ -307,24 +307,24 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
-Some text \cs_tmp:w 
-Some text \cs_tmp:w 
+Some Text \cs_tmp:w 
+Some Text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
@@ -335,16 +335,16 @@ TEST 25: Math-mode escape
 ============================================================
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
-Some text $y = mx + c$
-Some text $y = mx + c$
+Some Text $y = mx + c$
+Some Text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
 $y = mx + c$ Text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
-Opps not close token in $y = mx + c
-Opps not close token in $y = mx + c
+Opps Not Close Token In $y = mx + c
+Opps Not Close Token In $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -398,8 +398,8 @@ Title
 Title
 WORDS lower
 words UPPER
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
+Words Title
+Words Title
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.luatex.tlg
+++ b/l3kernel/testfiles/m3text002.luatex.tlg
@@ -30,15 +30,15 @@ TEST 4: Titlecase basics
 ============================================================
 Hello world
 Hello world
-Hello world
+HELLO WORLD
 HELLO WORLD
 " Hello world"
 " Hello world"
-" Hello world"
+" HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
 {H}ello world
-{H}ello world
+{H}ELLO WORLD
 {H}ELLO WORLD
 {}hello world
 {}hello world
@@ -58,21 +58,21 @@ TEST 5: Titlecase skipping chars
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic sunt leones'
 `Hic SUNT leones'
-`Hic sunt leones'
+`Hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic sunt leones'
 `hic SUNT leones'
-`hic sunt leones'
+`hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
@@ -92,7 +92,7 @@ TEST 9: (u)pTeX-based tests
 ============================================================
 abc^^e8日本語
 ABC^^c8日本語
-Abc^^e8日本語
+ABC^^c8日本語
 ABC^^c8日本語
 一级标题
 一级标题
@@ -104,7 +104,7 @@ TEST 10: Unicode case changing
 ============================================================
 ^^e5^^e9^^ee^^f8ὥдαɛ
 ^^c5^^c9^^ce^^d8ὭДΑƐ
-^^c5^^e9^^ee^^f8ὥдαɛ
+^^c5^^e9^^ee^^f8ὭдαƐ
 ^^c5^^e9^^ee^^f8ὭдαƐ
 ============================================================
 ============================================================
@@ -120,11 +120,11 @@ TEST 12: The final sigma rule
 ============================================================
 ὀδυσσεύς (ὀδυσσεύς) ὀδυσσεύς, ὀδυσσεύς{} ὀδυσσεύς\noop 
 ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
-Ὀδυσσεύς (ὀδυσσεύς) ὀδυσσεύς, ὀδυσσεύς{} ὀδυσσεύς\noop 
+ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
 ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
 ὀδυσσεύς
 ὈΔΥΣΣΕΎΣ
-Ὀδυσσεύς
+ὈΔΥΣΣΕΎΣ
 ὈΔΥΣΣΕΎΣ
 ============================================================
 ============================================================
@@ -132,7 +132,7 @@ TEST 13: Cyrillic
 ============================================================
 доклады академии наук
 ДОКЛАДЫ АКАДЕМИИ НАУК
-Доклады академии наук
+Доклады Академии наук
 Доклады Академии наук
 ============================================================
 ============================================================
@@ -193,8 +193,8 @@ TEST 17: Greek
 ΤΟ ΕΝΑ Ή ΤΟ ΑΛΛΟ.
 ΡΩΜΈΙΚΑ
 ΡΩΜΕΪΚΑ
-Ὀδυσσεύς
-Ὀδυσσεύς
+ὈΔΥΣΣΕΎΣ
+ὈΔΥΣΣΕΎΣ
 ΉΙ
 ῌ
 ΗΙ
@@ -243,10 +243,10 @@ ragıp hul^^fbsi ^^f6zdem
 ragip hul^^fbsi̇ ^^f6zdem
 RAGIP HUL^^dbSİ ^^d6ZDEM
 RAGIP HUL^^dbSI ^^d6ZDEM
-Ragıp hul^^fbsi ^^f6zdem
-Ragıp hul^^fbsi ^^f6zdem
-Ip hul^^fbsi ^^f6zdem
-Ip hul^^fbsi ^^f6zdem
+Ragıp Hul^^fbsi ^^d6zdem
+Ragıp Hul^^fbsi ^^d6zdem
+Ip Hul^^fbsi ^^d6zdem
+Ip Hul^^fbsi ^^d6zdem
 ============================================================
 ============================================================
 TEST 19: Lithuanian
@@ -255,9 +255,9 @@ i̇̀i̇́i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃
 ^^ec^^edĩìíĩj̀j́j̃į̀į́į̃
 ÌÌĨÌÍĨJ̀J́J̃Į̀Į́Į̃
 İ̀İ̀İ̃İ̀İ́İ̃J̇̀J̇́J̇̃Į̇̀Į̇́Į̇̃
-^^cci̇́i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃
+^^cc^^cdĨÌÍĨJ̀J́J̃Į̀Į́Į̃
 Ìi̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃
-^^cc^^edĩìíĩj̀j́j̃į̀į́į̃
+^^cc^^cdĨÌÍĨJ̀J́J̃Į̀Į́Į̃
 İ̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃
 ============================================================
 ============================================================
@@ -280,7 +280,7 @@ Ijsselmeer
 IJsselmeer
 Ijsselmeer
 IJsselmeer
-Ijsselmeer
+IJsselmeer
 Im
 Im
 ============================================================
@@ -295,11 +295,11 @@ TEST 23: Case changing braced arguments
 ============================================================
 foo \emph {BAR} {baz}
 FOO \emph {BAR} {BAZ}
-Foo \emph {BAR} {baz}
+FOO \emph {BAR} {BAZ}
 FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
-\emph {BAR} {Baz}
+\emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
 ============================================================
 ============================================================
@@ -307,7 +307,7 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -315,7 +315,7 @@ Hello sometext
 Hello sometext
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -359,7 +359,7 @@ TEST 27: Letter-like commands
 ============================================================
 \aa \aa \ae \dh \ss \l \o 
 \AA \AA \AE \DH \SS \L \O 
-\AA \aa \ae \dh \ss \l \o 
+\AA \aa \ae \dh \ss \l \O 
 \AA \aa \ae \dh \ss \l \O 
 ============================================================
 ============================================================
@@ -398,7 +398,7 @@ Title
 Title
 WORDS lower
 words UPPER
-Words UPPER
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================

--- a/l3kernel/testfiles/m3text002.lvt
+++ b/l3kernel/testfiles/m3text002.lvt
@@ -18,9 +18,9 @@
       \NEWLINE
       \text_uppercase:n {#1}
       \NEWLINE
-      \text_titlecase:n {#1}
+      \text_titlecase_all:n {#1}
       \NEWLINE
-      \text_titlecase_first:n {#1}
+      \text_titlecase_once:n {#1}
     }
   \cs_set:Npn \test:nn #1#2
     {
@@ -28,9 +28,9 @@
       \NEWLINE
       \text_uppercase:nn {#1} {#2}
       \NEWLINE
-      \text_titlecase:nn {#1} {#2}
+      \text_titlecase_all:nn {#1} {#2}
       \NEWLINE
-      \text_titlecase_first:nn {#1} {#2}
+      \text_titlecase_once:nn {#1} {#2}
     }
 \TIMO
 
@@ -52,9 +52,9 @@
 \OMIT
   \cs_set:Npn \testii:n #1
     {
-      \text_titlecase:n {#1}
+      \text_titlecase_all:n {#1}
       \NEWLINE
-      \text_titlecase_first:n {#1}
+      \text_titlecase_once:n {#1}
     }
 \TIMO
 
@@ -64,13 +64,13 @@
     \NEWLINE
     \testii:n { HELLO~WORLD }
     \NEWLINE
-    "\text_titlecase:n { ~hello~world }"
+    "\text_titlecase_all:n { ~hello~world }"
     \NEWLINE
-    "\text_titlecase_first:n { ~hello~world }"
+    "\text_titlecase_once:n { ~hello~world }"
     \NEWLINE
-    "\text_titlecase:n { ~HELLO~WORLD }"
+    "\text_titlecase_all:n { ~HELLO~WORLD }"
     \NEWLINE
-    "\text_titlecase_first:n { ~HELLO~WORLD }"
+    "\text_titlecase_once:n { ~HELLO~WORLD }"
     \NEWLINE
     \testii:n { {h}ello~world }
     \NEWLINE
@@ -155,12 +155,12 @@
 
 \TESTEXP { Armenian }
   {
-    \text_uppercase:n                { Երևան } \NEWLINE
-    \text_uppercase:nn { hy }        { Երևան } \NEWLINE
-    \text_uppercase:nn { hy-x-yiwn } { Երևան } \NEWLINE
-    \text_titlecase:n                { Երևան } \NEWLINE
-    \text_titlecase:nn { hy }        { ևան } \NEWLINE
-    \text_titlecase:nn { hy-x-yiwn } { ևան }
+    \text_uppercase:n                    { Երևան } \NEWLINE
+    \text_uppercase:nn { hy }            { Երևան } \NEWLINE
+    \text_uppercase:nn { hy-x-yiwn }     { Երևան } \NEWLINE
+    \text_titlecase_all:n                { Երևան } \NEWLINE
+    \text_titlecase_all:nn { hy }        { ևան } \NEWLINE
+    \text_titlecase_all:nn { hy-x-yiwn } { ևան }
   }
 
 \TESTEXP { German-alternative }
@@ -202,8 +202,8 @@
     \greektest:n { Μαΐου,~τρόλεϊ }                        \NEWLINE
     \greektest:n { Το~ένα~ή~το~άλλο. }                    \NEWLINE
     \greektest:n { ρωμέικα }                              \NEWLINE
-    \text_titlecase:n         { ὈΔΥΣΣΕΎΣ } \NEWLINE
-    \text_titlecase:nn { el } { ὈΔΥΣΣΕΎΣ } \NEWLINE
+    \text_titlecase_all:n         { ὈΔΥΣΣΕΎΣ } \NEWLINE
+    \text_titlecase_all:nn { el } { ὈΔΥΣΣΕΎΣ } \NEWLINE
     % Taken from luaotfload tests
     \greektest:n { ῄ }                                    \NEWLINE
     \text_uppercase:nn { el-x-iota } { ῄ }                \NEWLINE
@@ -237,11 +237,11 @@
     \text_uppercase:nn { tr } { Ragıp~Hulûsi~Özdem } \NEWLINE
     \text_uppercase:n         { Ragıp~Hulûsi~Özdem }
     \NEWLINE
-    \text_titlecase:nn { tr } { Ragıp~Hulûsi~Özdem } \NEWLINE
-    \text_titlecase:n         { Ragıp~Hulûsi~Özdem }
+    \text_titlecase_all:nn { tr } { Ragıp~Hulûsi~Özdem } \NEWLINE
+    \text_titlecase_all:n         { Ragıp~Hulûsi~Özdem }
     \NEWLINE
-    \text_titlecase:nn { tr } { ıp~Hulûsi~Özdem } \NEWLINE
-    \text_titlecase:n         { ıp~Hulûsi~Özdem }
+    \text_titlecase_all:nn { tr } { ıp~Hulûsi~Özdem } \NEWLINE
+    \text_titlecase_all:n         { ıp~Hulûsi~Özdem }
   }
 
 \TESTEXP { Lithuanian }
@@ -252,10 +252,10 @@
     \text_uppercase:nn { lt } { i̇̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃ } \NEWLINE
     \text_uppercase:n         { i̇̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃ }
     \NEWLINE
-    \text_titlecase:nn { lt } { ÌÍĨÌÍĨJ̀J́J̃Į̀Į́Į̃ } \NEWLINE
-    \text_titlecase:nn { lt } { i̇̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃ } \NEWLINE
-    \text_titlecase:n         { ÌÍĨÌÍĨJ̀J́J̃Į̀Į́Į̃ } \NEWLINE
-    \text_titlecase:n         { i̇̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃ }
+    \text_titlecase_all:nn { lt } { ÌÍĨÌÍĨJ̀J́J̃Į̀Į́Į̃ } \NEWLINE
+    \text_titlecase_all:nn { lt } { i̇̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃ } \NEWLINE
+    \text_titlecase_all:n         { ÌÍĨÌÍĨJ̀J́J̃Į̀Į́Į̃ } \NEWLINE
+    \text_titlecase_all:n         { i̇̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃ }
   }
 
 \TESTEXP { Medieval~Latin }
@@ -275,24 +275,24 @@
     \text_uppercase:nn { nl } { ijsselmeer } \NEWLINE
     \text_uppercase:n         { ijsselmeer }
     \NEWLINE
-    \text_titlecase:nn { nl } { ijsselmeer } \NEWLINE
-    \text_titlecase:n         { ijsselmeer }
+    \text_titlecase_all:nn { nl } { ijsselmeer } \NEWLINE
+    \text_titlecase_all:n         { ijsselmeer }
     \NEWLINE
-    \text_titlecase:nn { nl } { Ijsselmeer } \NEWLINE
-    \text_titlecase:n         { Ijsselmeer }
+    \text_titlecase_all:nn { nl } { Ijsselmeer } \NEWLINE
+    \text_titlecase_all:n         { Ijsselmeer }
     \NEWLINE
-    \text_titlecase:nn { nl } { IJsselmeer } \NEWLINE
-    \text_titlecase:n         { IJsselmeer }
+    \text_titlecase_all:nn { nl } { IJsselmeer } \NEWLINE
+    \text_titlecase_all:n         { IJsselmeer }
     \NEWLINE
-    \text_titlecase:nn { nl } { im } \NEWLINE
-    \text_titlecase:n         { im }
+    \text_titlecase_all:nn { nl } { im } \NEWLINE
+    \text_titlecase_all:n         { im }
   }
 
 \TESTEXP { Titlecase~exceptions }
   {
-    \text_titlecase:n { ßoo }
+    \text_titlecase_all:n { ßoo }
     \NEWLINE
-    \text_titlecase:n { ǅ! }
+    \text_titlecase_all:n { ǅ! }
     \NEWLINE
   }
 
@@ -388,8 +388,8 @@
   {
     \text_uppercase:n {#1} \NEWLINE
     \text_lowercase:n {#1} \NEWLINE
-    \text_titlecase:n {#1} \NEWLINE
-    \text_titlecase_first:n {#1} \NEWLINE
+    \text_titlecase_all:n {#1} \NEWLINE
+    \text_titlecase_once:n {#1} \NEWLINE
   }
 
 \TESTEXP { Case~change~switching }
@@ -417,12 +417,12 @@
       {
         \text_lowercase:n { ǰ }
         \text_uppercase:n { ǰ }
-        \text_titlecase:n { ǰ }
-        \text_titlecase:n { xǰ }
+        \text_titlecase_all:n { ǰ }
+        \text_titlecase_all:n { xǰ }
         \text_lowercase:nn { xx } { ǰ }
         \text_uppercase:nn { xx } { ǰ }
-        \text_titlecase:nn { xx } { ǰ }
-        \text_titlecase:nn { xx } { xǰ }
+        \text_titlecase_all:nn { xx } { ǰ }
+        \text_titlecase_all:nn { xx } { xǰ }
       }
   }
 

--- a/l3kernel/testfiles/m3text002.ptex.tlg
+++ b/l3kernel/testfiles/m3text002.ptex.tlg
@@ -6,8 +6,8 @@ TEST 1: Basic case changing
 ============================================================
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
-Hello world \par with \ERROR &##
-Hello world \par with \ERROR &##
+Hello World \par With \ERROR &##
+Hello World \par With \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
@@ -22,18 +22,18 @@ TEST 3: Case change exclusions
 ============================================================
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
-Some text \cite {WithFun}
-Some text \cite {WithFun}
+Some Text \cite {WithFun}
+Some Text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
-Hello world
-Hello world
+Hello World
+Hello World
 HELLO WORLD
 HELLO WORLD
-" Hello world"
-" Hello world"
+" Hello World"
+" Hello World"
 " HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
@@ -48,30 +48,30 @@ HELLO WORLD
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
-`Hic sunt leones'
-`Hic sunt leones'
-``Hic sunt leones''
-``Hic sunt leones''
-([Hic sunt leones])
-([Hic sunt leones])
+`Hic Sunt Leones'
+`Hic Sunt Leones'
+``Hic Sunt Leones''
+``Hic Sunt Leones''
+([Hic Sunt Leones])
+([Hic Sunt Leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic SUNT leones'
-`Hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`Hic SUNT Leones'
+`Hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic SUNT leones'
-`hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`hic SUNT Leones'
+`hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -80,12 +80,12 @@ TEST 8: Language based case changing but nothing
 ============================================================
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -307,24 +307,24 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
-Some text \cs_tmp:w 
-Some text \cs_tmp:w 
+Some Text \cs_tmp:w 
+Some Text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
@@ -335,16 +335,16 @@ TEST 25: Math-mode escape
 ============================================================
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
-Some text $y = mx + c$
-Some text $y = mx + c$
+Some Text $y = mx + c$
+Some Text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
 $y = mx + c$ Text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
-Opps not close token in $y = mx + c
-Opps not close token in $y = mx + c
+Opps Not Close Token In $y = mx + c
+Opps Not Close Token In $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -398,8 +398,8 @@ Title
 Title
 WORDS lower
 words UPPER
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
+Words Title
+Words Title
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.ptex.tlg
+++ b/l3kernel/testfiles/m3text002.ptex.tlg
@@ -7,14 +7,14 @@ TEST 1: Basic case changing
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
 Hello World \par With \ERROR &##
-Hello World \par With \ERROR &##
+Hello world \par with \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
 ============================================================
 {hello} world \par with \ERROR &##
 {HELLO} WORLD \par WITH \ERROR &##
-{Hello} world \par with \ERROR &##
+{Hello} World \par With \ERROR &##
 {Hello} world \par with \ERROR &##
 ============================================================
 ============================================================
@@ -23,45 +23,45 @@ TEST 3: Case change exclusions
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
 Some Text \cite {WithFun}
-Some Text \cite {WithFun}
+Some text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
 Hello World
-Hello World
+Hello world
 HELLO WORLD
 HELLO WORLD
 " Hello World"
-" Hello World"
+" hello world"
 " HELLO WORLD"
 " HELLO WORLD"
-{H}ello world
+{H}ello World
 {H}ello world
 {H}ELLO WORLD
 {H}ELLO WORLD
+{}hello World
 {}hello world
-{}hello world
-{}hello world
+{}hello World
 {}hello world
 ============================================================
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
 `Hic Sunt Leones'
-`Hic Sunt Leones'
+`Hic sunt leones'
 ``Hic Sunt Leones''
-``Hic Sunt Leones''
+``Hic sunt leones''
 ([Hic Sunt Leones])
-([Hic Sunt Leones])
+([Hic sunt leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
 `Hic SUNT Leones'
-`Hic SUNT Leones'
+`Hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -69,9 +69,9 @@ E PLURIBUS UNUM
 TEST 7: Titlecase control
 ============================================================
 `hic SUNT Leones'
-`hic SUNT Leones'
+`hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -81,11 +81,11 @@ TEST 8: Language based case changing but nothing
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -133,7 +133,7 @@ TEST 13: Cyrillic
 Доклады Акад^^ea^^9f^^97мии наук
 ^^ea^^9e^^a4окл^^ea^^9f^^90ды ^^ea^^9e^^a0к^^ea^^9f^^90демии н^^ea^^9f^^90ук
 ^^ea^^9e^^a4окл^^ea^^9f^^90ды ^^ea^^9e^^a0к^^ea^^9f^^90демии н^^ea^^9f^^90ук
-^^ea^^9e^^a4окл^^ea^^9f^^90ды ^^ea^^9e^^a0к^^ea^^9f^^90демии н^^ea^^9f^^90ук
+^^ea^^9e^^a4окл^^ea^^9f^^90ды Академии наук
 ============================================================
 ============================================================
 TEST 14: BCP47 parts
@@ -300,7 +300,7 @@ FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
-\emph {BAR} {BAZ}
+\emph {BAR} BAZ
 ============================================================
 ============================================================
 TEST 24: Expanding content
@@ -308,27 +308,27 @@ TEST 24: Expanding content
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
 Some Text \cs_tmp:w 
-Some Text \cs_tmp:w 
+Some text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
-\cs_tmp:w  Sometext
+\cs_tmp:w  sometext
 ============================================================
 ============================================================
 TEST 25: Math-mode escape
@@ -336,15 +336,15 @@ TEST 25: Math-mode escape
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
 Some Text $y = mx + c$
-Some Text $y = mx + c$
+Some text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
-$y = mx + c$ Text
+$y = mx + c$ text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
 Opps Not Close Token In $y = mx + c
-Opps Not Close Token In $y = mx + c
+Opps not close token in $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -399,7 +399,7 @@ Title
 WORDS lower
 words UPPER
 Words Title
-Words Title
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.ptex.tlg
+++ b/l3kernel/testfiles/m3text002.ptex.tlg
@@ -30,15 +30,15 @@ TEST 4: Titlecase basics
 ============================================================
 Hello world
 Hello world
-Hello world
+HELLO WORLD
 HELLO WORLD
 " Hello world"
 " Hello world"
-" Hello world"
+" HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
 {H}ello world
-{H}ello world
+{H}ELLO WORLD
 {H}ELLO WORLD
 {}hello world
 {}hello world
@@ -58,21 +58,21 @@ TEST 5: Titlecase skipping chars
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic sunt leones'
 `Hic SUNT leones'
-`Hic sunt leones'
+`Hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic sunt leones'
 `hic SUNT leones'
-`hic sunt leones'
+`hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
@@ -92,7 +92,7 @@ TEST 9: (u)pTeX-based tests
 ============================================================
 abc^^c3^^a8日本語
 ABC^^c3^^88日本語
-Abc^^c3^^a8日本語
+ABC^^c3^^88日本語
 ABC^^c3^^88日本語
 一^^e7^^ba^^a7^^e6^^a0^^87^^e9^^a2^^98
 一^^e7^^ba^^a7^^e6^^a0^^87^^e9^^a2^^98
@@ -104,7 +104,7 @@ TEST 10: Unicode case changing
 ============================================================
 ^^c3^^a5^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^a5дα^^c9^^9b
 ^^c3^^85^^c3^^89^^c3^^8e^^c3^^98^^e1^^bd^^adдα^^c6^^90
-^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^a5дα^^c9^^9b
+^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^adдα^^c6^^90
 ^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^adдα^^c6^^90
 ============================================================
 ============================================================
@@ -120,11 +120,11 @@ TEST 12: The final sigma rule
 ============================================================
 ^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ (^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ) ^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ, ^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ{} ^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ\noop 
 ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ (^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ) ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ, ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ{} ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ\noop 
-^^e1^^bd^^88ΔΥΣΣΕ^^cf^^8dΣ (^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ) ^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ, ^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ{} ^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ\noop 
+^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ (^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ) ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ, ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ{} ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ\noop 
 ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ (^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ) ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ, ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ{} ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ\noop 
 ^^e1^^bd^^80ΔΥΣΣΕ^^cf^^8dΣ
 ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ
-^^e1^^bd^^88ΔΥΣΣΕ^^cf^^8dΣ
+^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ
 ^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ
 ============================================================
 ============================================================
@@ -193,8 +193,8 @@ TEST 17: Greek
 Το ^^ce^^95να ^^ce^^89 το ^^ce^^91λλο.
 ρωμ^^ce^^88ικα
 ρωμ^^ce^^95ικα
-^^e1^^bd^^88ΔΥΣΣΕ^^cf^^8dΣ
-^^e1^^bd^^88ΔΥΣΣΕ^^cf^^8dΣ
+^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ
+^^e1^^bd^^88ΔΥΣΣΕ^^ce^^8eΣ
 ^^ce^^89^^ce^^99
 ^^e1^^bf^^8c
 ^^ce^^97^^ce^^99
@@ -243,10 +243,10 @@ rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
 ragip hul^^c3^^bbsi^^cc^^87 ^^c3^^b6zdem
 RAGIP HUL^^c3^^9bS^^c4^^b0 ^^c3^^96ZDEM
 RAGIP HUL^^c3^^9bSI ^^c3^^96ZDEM
-Rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
-Rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
-Ip hul^^c3^^bbsi ^^c3^^b6zdem
-Ip hul^^c3^^bbsi ^^c3^^b6zdem
+Rag^^c4^^b1p Hul^^c3^^bbsi ^^c3^^96zdem
+Rag^^c4^^b1p Hul^^c3^^bbsi ^^c3^^96zdem
+Ip Hul^^c3^^bbsi ^^c3^^96zdem
+Ip Hul^^c3^^bbsi ^^c3^^96zdem
 ============================================================
 ============================================================
 TEST 19: Lithuanian
@@ -255,9 +255,9 @@ i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83i^^cc^^87^^cc^^80i^^cc^^87^^c
 ^^c3^^ac^^c3^^ad^^c4^^a9i^^cc^^80i^^cc^^81i^^cc^^83j^^cc^^80j^^cc^^81j^^cc^^83^^c4^^af^^cc^^80^^c4^^af^^cc^^81^^c4^^af^^cc^^83
 I^^cc^^80I^^cc^^80I^^cc^^83I^^cc^^80I^^cc^^81I^^cc^^83J^^cc^^80J^^cc^^81J^^cc^^83^^c4^^ae^^cc^^80^^c4^^ae^^cc^^81^^c4^^ae^^cc^^83
 I^^cc^^87^^cc^^80I^^cc^^87^^cc^^80I^^cc^^87^^cc^^83I^^cc^^87^^cc^^80I^^cc^^87^^cc^^81I^^cc^^87^^cc^^83J^^cc^^87^^cc^^80J^^cc^^87^^cc^^81J^^cc^^87^^cc^^83^^c4^^ae^^cc^^87^^cc^^80^^c4^^ae^^cc^^87^^cc^^81^^c4^^ae^^cc^^87^^cc^^83
-^^c3^^8ci^^cc^^87^^cc^^81i^^cc^^87^^cc^^83i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83j^^cc^^87^^cc^^80j^^cc^^87^^cc^^81j^^cc^^87^^cc^^83^^c4^^af^^cc^^87^^cc^^80^^c4^^af^^cc^^87^^cc^^81^^c4^^af^^cc^^87^^cc^^83
+^^c3^^8c^^c3^^8d^^c4^^a8I^^cc^^80I^^cc^^81I^^cc^^83J^^cc^^80J^^cc^^81J^^cc^^83^^c4^^ae^^cc^^80^^c4^^ae^^cc^^81^^c4^^ae^^cc^^83
 I^^cc^^80i^^cc^^87^^cc^^80i^^cc^^87^^cc^^83i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83j^^cc^^87^^cc^^80j^^cc^^87^^cc^^81j^^cc^^87^^cc^^83^^c4^^af^^cc^^87^^cc^^80^^c4^^af^^cc^^87^^cc^^81^^c4^^af^^cc^^87^^cc^^83
-^^c3^^8c^^c3^^ad^^c4^^a9i^^cc^^80i^^cc^^81i^^cc^^83j^^cc^^80j^^cc^^81j^^cc^^83^^c4^^af^^cc^^80^^c4^^af^^cc^^81^^c4^^af^^cc^^83
+^^c3^^8c^^c3^^8d^^c4^^a8I^^cc^^80I^^cc^^81I^^cc^^83J^^cc^^80J^^cc^^81J^^cc^^83^^c4^^ae^^cc^^80^^c4^^ae^^cc^^81^^c4^^ae^^cc^^83
 I^^cc^^87^^cc^^80i^^cc^^87^^cc^^80i^^cc^^87^^cc^^83i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83j^^cc^^87^^cc^^80j^^cc^^87^^cc^^81j^^cc^^87^^cc^^83^^c4^^af^^cc^^87^^cc^^80^^c4^^af^^cc^^87^^cc^^81^^c4^^af^^cc^^87^^cc^^83
 ============================================================
 ============================================================
@@ -280,7 +280,7 @@ Ijsselmeer
 IJsselmeer
 Ijsselmeer
 IJsselmeer
-Ijsselmeer
+IJsselmeer
 Im
 Im
 ============================================================
@@ -295,11 +295,11 @@ TEST 23: Case changing braced arguments
 ============================================================
 foo \emph {BAR} {baz}
 FOO \emph {BAR} {BAZ}
-Foo \emph {BAR} {baz}
+FOO \emph {BAR} {BAZ}
 FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
-\emph {BAR} {Baz}
+\emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
 ============================================================
 ============================================================
@@ -307,7 +307,7 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -315,7 +315,7 @@ Hello sometext
 Hello sometext
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -359,7 +359,7 @@ TEST 27: Letter-like commands
 ============================================================
 \aa \aa \ae \dh \ss \l \o 
 \AA \AA \AE \DH \SS \L \O 
-\AA \aa \ae \dh \ss \l \o 
+\AA \aa \ae \dh \ss \l \O 
 \AA \aa \ae \dh \ss \l \O 
 ============================================================
 ============================================================
@@ -398,7 +398,7 @@ Title
 Title
 WORDS lower
 words UPPER
-Words UPPER
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================

--- a/l3kernel/testfiles/m3text002.tlg
+++ b/l3kernel/testfiles/m3text002.tlg
@@ -7,14 +7,14 @@ TEST 1: Basic case changing
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
 Hello World \par With \ERROR &##
-Hello World \par With \ERROR &##
+Hello world \par with \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
 ============================================================
 {hello} world \par with \ERROR &##
 {HELLO} WORLD \par WITH \ERROR &##
-{Hello} world \par with \ERROR &##
+{Hello} World \par With \ERROR &##
 {Hello} world \par with \ERROR &##
 ============================================================
 ============================================================
@@ -23,45 +23,45 @@ TEST 3: Case change exclusions
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
 Some Text \cite {WithFun}
-Some Text \cite {WithFun}
+Some text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
 Hello World
-Hello World
+Hello world
 HELLO WORLD
 HELLO WORLD
 " Hello World"
-" Hello World"
+" hello world"
 " HELLO WORLD"
 " HELLO WORLD"
-{H}ello world
+{H}ello World
 {H}ello world
 {H}ELLO WORLD
 {H}ELLO WORLD
+{}hello World
 {}hello world
-{}hello world
-{}hello world
+{}hello World
 {}hello world
 ============================================================
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
 `Hic Sunt Leones'
-`Hic Sunt Leones'
+`Hic sunt leones'
 ``Hic Sunt Leones''
-``Hic Sunt Leones''
+``Hic sunt leones''
 ([Hic Sunt Leones])
-([Hic Sunt Leones])
+([Hic sunt leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
 `Hic SUNT Leones'
-`Hic SUNT Leones'
+`Hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -69,9 +69,9 @@ E PLURIBUS UNUM
 TEST 7: Titlecase control
 ============================================================
 `hic SUNT Leones'
-`hic SUNT Leones'
+`hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -81,11 +81,11 @@ TEST 8: Language based case changing but nothing
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -133,7 +133,7 @@ TEST 13: Cyrillic
 ^^d0^^b4^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^b0^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
 ^^d0^^94^^d0^^9e^^d0^^9a^^d0^^9b^^d0^^90^^d0^^94^^d0^^ab ^^d0^^90^^d0^^9a^^d0^^90^^d0^^94^^d0^^95^^d0^^9c^^d0^^98^^d0^^98 ^^d0^^9d^^d0^^90^^d0^^a3^^d0^^9a
 ^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^9d^^d0^^b0^^d1^^83^^d0^^ba
-^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^9d^^d0^^b0^^d1^^83^^d0^^ba
+^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
 ============================================================
 ============================================================
 TEST 14: BCP47 parts
@@ -300,7 +300,7 @@ FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
-\emph {BAR} {BAZ}
+\emph {BAR} BAZ
 ============================================================
 ============================================================
 TEST 24: Expanding content
@@ -308,27 +308,27 @@ TEST 24: Expanding content
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
 Some Text \cs_tmp:w 
-Some Text \cs_tmp:w 
+Some text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
-\cs_tmp:w  Sometext
+\cs_tmp:w  sometext
 ============================================================
 ============================================================
 TEST 25: Math-mode escape
@@ -336,15 +336,15 @@ TEST 25: Math-mode escape
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
 Some Text $y = mx + c$
-Some Text $y = mx + c$
+Some text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
-$y = mx + c$ Text
+$y = mx + c$ text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
 Opps Not Close Token In $y = mx + c
-Opps Not Close Token In $y = mx + c
+Opps not close token in $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -399,7 +399,7 @@ Title
 WORDS lower
 words UPPER
 Words Title
-Words Title
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.tlg
+++ b/l3kernel/testfiles/m3text002.tlg
@@ -30,15 +30,15 @@ TEST 4: Titlecase basics
 ============================================================
 Hello world
 Hello world
-Hello world
+HELLO WORLD
 HELLO WORLD
 " Hello world"
 " Hello world"
-" Hello world"
+" HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
 {H}ello world
-{H}ello world
+{H}ELLO WORLD
 {H}ELLO WORLD
 {}hello world
 {}hello world
@@ -58,21 +58,21 @@ TEST 5: Titlecase skipping chars
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic sunt leones'
 `Hic SUNT leones'
-`Hic sunt leones'
+`Hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic sunt leones'
 `hic SUNT leones'
-`hic sunt leones'
+`hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
@@ -92,7 +92,7 @@ TEST 9: (u)pTeX-based tests
 ============================================================
 abc^^c3^^a8^^e6^^97^^a5^^e6^^9c^^ac^^e8^^aa^^9e
 ABC^^c3^^88^^e6^^97^^a5^^e6^^9c^^ac^^e8^^aa^^9e
-Abc^^c3^^a8^^e6^^97^^a5^^e6^^9c^^ac^^e8^^aa^^9e
+ABC^^c3^^88^^e6^^97^^a5^^e6^^9c^^ac^^e8^^aa^^9e
 ABC^^c3^^88^^e6^^97^^a5^^e6^^9c^^ac^^e8^^aa^^9e
 ^^e4^^b8^^80^^e7^^ba^^a7^^e6^^a0^^87^^e9^^a2^^98
 ^^e4^^b8^^80^^e7^^ba^^a7^^e6^^a0^^87^^e9^^a2^^98
@@ -104,7 +104,7 @@ TEST 10: Unicode case changing
 ============================================================
 ^^c3^^a5^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^a5^^d0^^b4^^ce^^b1^^c9^^9b
 ^^c3^^85^^c3^^89^^c3^^8e^^c3^^98^^e1^^bd^^ad^^d0^^94^^ce^^91^^c6^^90
-^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^a5^^d0^^b4^^ce^^b1^^c9^^9b
+^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^ad^^d0^^b4^^ce^^b1^^c6^^90
 ^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^ad^^d0^^b4^^ce^^b1^^c6^^90
 ============================================================
 ============================================================
@@ -120,11 +120,11 @@ TEST 12: The final sigma rule
 ============================================================
 ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82 (^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82) ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82, ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82{} ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82\noop 
 ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3 (^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3) ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3, ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3{} ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3\noop 
-^^e1^^bd^^88^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82 (^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82) ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82, ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82{} ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82\noop 
+^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3 (^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3) ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3, ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3{} ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3\noop 
 ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3 (^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3) ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3, ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3{} ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3\noop 
 ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82
 ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3
-^^e1^^bd^^88^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82
+^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3
 ^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3
 ============================================================
 ============================================================
@@ -132,7 +132,7 @@ TEST 13: Cyrillic
 ============================================================
 ^^d0^^b4^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^b0^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
 ^^d0^^94^^d0^^9e^^d0^^9a^^d0^^9b^^d0^^90^^d0^^94^^d0^^ab ^^d0^^90^^d0^^9a^^d0^^90^^d0^^94^^d0^^95^^d0^^9c^^d0^^98^^d0^^98 ^^d0^^9d^^d0^^90^^d0^^a3^^d0^^9a
-^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^b0^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
+^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
 ^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
 ============================================================
 ============================================================
@@ -193,8 +193,8 @@ TEST 17: Greek
 ^^ce^^a4^^ce^^9f ^^ce^^95^^ce^^9d^^ce^^91 ^^ce^^89 ^^ce^^a4^^ce^^9f ^^ce^^91^^ce^^9b^^ce^^9b^^ce^^9f.
 ^^ce^^a1^^ce^^a9^^ce^^9c^^ce^^88^^ce^^99^^ce^^9a^^ce^^91
 ^^ce^^a1^^ce^^a9^^ce^^9c^^ce^^95^^ce^^aa^^ce^^9a^^ce^^91
-^^e1^^bd^^88^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82
-^^e1^^bd^^88^^ce^^b4^^cf^^85^^cf^^83^^cf^^83^^ce^^b5^^cf^^8d^^cf^^82
+^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3
+^^e1^^bd^^88^^ce^^94^^ce^^a5^^ce^^a3^^ce^^a3^^ce^^95^^ce^^8e^^ce^^a3
 ^^ce^^89^^ce^^99
 ^^e1^^bf^^8c
 ^^ce^^97^^ce^^99
@@ -243,10 +243,10 @@ rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
 ragip hul^^c3^^bbsi^^cc^^87 ^^c3^^b6zdem
 RAGIP HUL^^c3^^9bS^^c4^^b0 ^^c3^^96ZDEM
 RAGIP HUL^^c3^^9bSI ^^c3^^96ZDEM
-Rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
-Rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
-Ip hul^^c3^^bbsi ^^c3^^b6zdem
-Ip hul^^c3^^bbsi ^^c3^^b6zdem
+Rag^^c4^^b1p Hul^^c3^^bbsi ^^c3^^96zdem
+Rag^^c4^^b1p Hul^^c3^^bbsi ^^c3^^96zdem
+Ip Hul^^c3^^bbsi ^^c3^^96zdem
+Ip Hul^^c3^^bbsi ^^c3^^96zdem
 ============================================================
 ============================================================
 TEST 19: Lithuanian
@@ -255,9 +255,9 @@ i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83i^^cc^^87^^cc^^80i^^cc^^87^^c
 ^^c3^^ac^^c3^^ad^^c4^^a9i^^cc^^80i^^cc^^81i^^cc^^83j^^cc^^80j^^cc^^81j^^cc^^83^^c4^^af^^cc^^80^^c4^^af^^cc^^81^^c4^^af^^cc^^83
 I^^cc^^80I^^cc^^80I^^cc^^83I^^cc^^80I^^cc^^81I^^cc^^83J^^cc^^80J^^cc^^81J^^cc^^83^^c4^^ae^^cc^^80^^c4^^ae^^cc^^81^^c4^^ae^^cc^^83
 I^^cc^^87^^cc^^80I^^cc^^87^^cc^^80I^^cc^^87^^cc^^83I^^cc^^87^^cc^^80I^^cc^^87^^cc^^81I^^cc^^87^^cc^^83J^^cc^^87^^cc^^80J^^cc^^87^^cc^^81J^^cc^^87^^cc^^83^^c4^^ae^^cc^^87^^cc^^80^^c4^^ae^^cc^^87^^cc^^81^^c4^^ae^^cc^^87^^cc^^83
-^^c3^^8ci^^cc^^87^^cc^^81i^^cc^^87^^cc^^83i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83j^^cc^^87^^cc^^80j^^cc^^87^^cc^^81j^^cc^^87^^cc^^83^^c4^^af^^cc^^87^^cc^^80^^c4^^af^^cc^^87^^cc^^81^^c4^^af^^cc^^87^^cc^^83
+^^c3^^8c^^c3^^8d^^c4^^a8I^^cc^^80I^^cc^^81I^^cc^^83J^^cc^^80J^^cc^^81J^^cc^^83^^c4^^ae^^cc^^80^^c4^^ae^^cc^^81^^c4^^ae^^cc^^83
 I^^cc^^80i^^cc^^87^^cc^^80i^^cc^^87^^cc^^83i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83j^^cc^^87^^cc^^80j^^cc^^87^^cc^^81j^^cc^^87^^cc^^83^^c4^^af^^cc^^87^^cc^^80^^c4^^af^^cc^^87^^cc^^81^^c4^^af^^cc^^87^^cc^^83
-^^c3^^8c^^c3^^ad^^c4^^a9i^^cc^^80i^^cc^^81i^^cc^^83j^^cc^^80j^^cc^^81j^^cc^^83^^c4^^af^^cc^^80^^c4^^af^^cc^^81^^c4^^af^^cc^^83
+^^c3^^8c^^c3^^8d^^c4^^a8I^^cc^^80I^^cc^^81I^^cc^^83J^^cc^^80J^^cc^^81J^^cc^^83^^c4^^ae^^cc^^80^^c4^^ae^^cc^^81^^c4^^ae^^cc^^83
 I^^cc^^87^^cc^^80i^^cc^^87^^cc^^80i^^cc^^87^^cc^^83i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83j^^cc^^87^^cc^^80j^^cc^^87^^cc^^81j^^cc^^87^^cc^^83^^c4^^af^^cc^^87^^cc^^80^^c4^^af^^cc^^87^^cc^^81^^c4^^af^^cc^^87^^cc^^83
 ============================================================
 ============================================================
@@ -280,7 +280,7 @@ Ijsselmeer
 IJsselmeer
 Ijsselmeer
 IJsselmeer
-Ijsselmeer
+IJsselmeer
 Im
 Im
 ============================================================
@@ -295,11 +295,11 @@ TEST 23: Case changing braced arguments
 ============================================================
 foo \emph {BAR} {baz}
 FOO \emph {BAR} {BAZ}
-Foo \emph {BAR} {baz}
+FOO \emph {BAR} {BAZ}
 FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
-\emph {BAR} {Baz}
+\emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
 ============================================================
 ============================================================
@@ -307,7 +307,7 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -315,7 +315,7 @@ Hello sometext
 Hello sometext
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -359,7 +359,7 @@ TEST 27: Letter-like commands
 ============================================================
 \aa \aa \ae \dh \ss \l \o 
 \AA \AA \AE \DH \SS \L \O 
-\AA \aa \ae \dh \ss \l \o 
+\AA \aa \ae \dh \ss \l \O 
 \AA \aa \ae \dh \ss \l \O 
 ============================================================
 ============================================================
@@ -398,7 +398,7 @@ Title
 Title
 WORDS lower
 words UPPER
-Words UPPER
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================

--- a/l3kernel/testfiles/m3text002.tlg
+++ b/l3kernel/testfiles/m3text002.tlg
@@ -6,8 +6,8 @@ TEST 1: Basic case changing
 ============================================================
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
-Hello world \par with \ERROR &##
-Hello world \par with \ERROR &##
+Hello World \par With \ERROR &##
+Hello World \par With \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
@@ -22,18 +22,18 @@ TEST 3: Case change exclusions
 ============================================================
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
-Some text \cite {WithFun}
-Some text \cite {WithFun}
+Some Text \cite {WithFun}
+Some Text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
-Hello world
-Hello world
+Hello World
+Hello World
 HELLO WORLD
 HELLO WORLD
-" Hello world"
-" Hello world"
+" Hello World"
+" Hello World"
 " HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
@@ -48,30 +48,30 @@ HELLO WORLD
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
-`Hic sunt leones'
-`Hic sunt leones'
-``Hic sunt leones''
-``Hic sunt leones''
-([Hic sunt leones])
-([Hic sunt leones])
+`Hic Sunt Leones'
+`Hic Sunt Leones'
+``Hic Sunt Leones''
+``Hic Sunt Leones''
+([Hic Sunt Leones])
+([Hic Sunt Leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic SUNT leones'
-`Hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`Hic SUNT Leones'
+`Hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic SUNT leones'
-`hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`hic SUNT Leones'
+`hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -80,12 +80,12 @@ TEST 8: Language based case changing but nothing
 ============================================================
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -132,8 +132,8 @@ TEST 13: Cyrillic
 ============================================================
 ^^d0^^b4^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^b0^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
 ^^d0^^94^^d0^^9e^^d0^^9a^^d0^^9b^^d0^^90^^d0^^94^^d0^^ab ^^d0^^90^^d0^^9a^^d0^^90^^d0^^94^^d0^^95^^d0^^9c^^d0^^98^^d0^^98 ^^d0^^9d^^d0^^90^^d0^^a3^^d0^^9a
-^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
-^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^bd^^d0^^b0^^d1^^83^^d0^^ba
+^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^9d^^d0^^b0^^d1^^83^^d0^^ba
+^^d0^^94^^d0^^be^^d0^^ba^^d0^^bb^^d0^^b0^^d0^^b4^^d1^^8b ^^d0^^90^^d0^^ba^^d0^^b0^^d0^^b4^^d0^^b5^^d0^^bc^^d0^^b8^^d0^^b8 ^^d0^^9d^^d0^^b0^^d1^^83^^d0^^ba
 ============================================================
 ============================================================
 TEST 14: BCP47 parts
@@ -307,24 +307,24 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
-Some text \cs_tmp:w 
-Some text \cs_tmp:w 
+Some Text \cs_tmp:w 
+Some Text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
@@ -335,16 +335,16 @@ TEST 25: Math-mode escape
 ============================================================
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
-Some text $y = mx + c$
-Some text $y = mx + c$
+Some Text $y = mx + c$
+Some Text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
 $y = mx + c$ Text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
-Opps not close token in $y = mx + c
-Opps not close token in $y = mx + c
+Opps Not Close Token In $y = mx + c
+Opps Not Close Token In $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -398,8 +398,8 @@ Title
 Title
 WORDS lower
 words UPPER
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
+Words Title
+Words Title
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.uptex.tlg
+++ b/l3kernel/testfiles/m3text002.uptex.tlg
@@ -30,15 +30,15 @@ TEST 4: Titlecase basics
 ============================================================
 Hello world
 Hello world
-Hello world
+HELLO WORLD
 HELLO WORLD
 " Hello world"
 " Hello world"
-" Hello world"
+" HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
 {H}ello world
-{H}ello world
+{H}ELLO WORLD
 {H}ELLO WORLD
 {}hello world
 {}hello world
@@ -58,21 +58,21 @@ TEST 5: Titlecase skipping chars
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic sunt leones'
 `Hic SUNT leones'
-`Hic sunt leones'
+`Hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic sunt leones'
 `hic SUNT leones'
-`hic sunt leones'
+`hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
@@ -92,7 +92,7 @@ TEST 9: (u)pTeX-based tests
 ============================================================
 abc^^c3^^a8日本語
 ABC^^c3^^88日本語
-Abc^^c3^^a8日本語
+ABC^^c3^^88日本語
 ABC^^c3^^88日本語
 一级标题
 一级标题
@@ -104,7 +104,7 @@ TEST 10: Unicode case changing
 ============================================================
 ^^c3^^a5^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^a5дα^^c9^^9b
 ^^c3^^85^^c3^^89^^c3^^8e^^c3^^98Ὥ^^d0^^94^^ce^^91^^c6^^90
-^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8^^e1^^bd^^a5дα^^c9^^9b
+^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8Ὥдα^^c6^^90
 ^^c3^^85^^c3^^a9^^c3^^ae^^c3^^b8Ὥдα^^c6^^90
 ============================================================
 ============================================================
@@ -120,7 +120,7 @@ TEST 12: The final sigma rule
 ============================================================
 ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^82^^cf^^82^^ce^^b5^^cf^^8d^^cf^^82 (^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^82^^cf^^82^^ce^^b5^^cf^^8d^^cf^^82) ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^82^^cf^^82^^ce^^b5^^cf^^8d^^cf^^82, ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^82^^cf^^82^^ce^^b5^^cf^^8d^^cf^^82{} ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^82^^cf^^82^^ce^^b5^^cf^^8d^^cf^^82\noop 
 ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
-ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^82^^cf^^82^^ce^^b5^^cf^^8d^^cf^^82\noop 
+ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
 ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
 ^^e1^^bd^^80^^ce^^b4^^cf^^85^^cf^^82^^cf^^82^^ce^^b5^^cf^^8d^^cf^^82
 ὈΔΥΣΣΕΎΣ
@@ -243,10 +243,10 @@ rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
 ragip hul^^c3^^bbsi^^cc^^87 ^^c3^^b6zdem
 RAGIP HUL^^c3^^9bS^^c4^^b0 ^^c3^^96ZDEM
 RAGIP HUL^^c3^^9bSI ^^c3^^96ZDEM
-Rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
-Rag^^c4^^b1p hul^^c3^^bbsi ^^c3^^b6zdem
-Ip hul^^c3^^bbsi ^^c3^^b6zdem
-Ip hul^^c3^^bbsi ^^c3^^b6zdem
+Rag^^c4^^b1p Hul^^c3^^bbsi ^^c3^^96zdem
+Rag^^c4^^b1p Hul^^c3^^bbsi ^^c3^^96zdem
+Ip Hul^^c3^^bbsi ^^c3^^96zdem
+Ip Hul^^c3^^bbsi ^^c3^^96zdem
 ============================================================
 ============================================================
 TEST 19: Lithuanian
@@ -255,9 +255,9 @@ i^^cc^^87^^cc^^80i^^cc^^87^^cc^^81i^^cc^^87^^cc^^83i^^cc^^87̀i^^cc^^87́i^^cc^^
 ^^c3^^ac^^c3^^ad^^c4^^a9ìíĩj̀j́j̃^^c4^^af̀^^c4^^af́^^c4^^af̃
 ÌÌĨÌÍĨJ̀J́J̃^^c4^^aè^^c4^^aé^^c4^^aẽ
 İ̀İ̀İ̃İ̀İ́İ̃J̇̀J̇́J̇̃^^c4^^aė̀^^c4^^aė́^^c4^^aė̃
-^^c3^^8ci^^cc^^87^^cc^^81i^^cc^^87^^cc^^83i^^cc^^87̀i^^cc^^87́i^^cc^^87̃j^^cc^^87̀j^^cc^^87́j^^cc^^87̃^^c4^^af^^cc^^87̀^^c4^^af^^cc^^87́^^c4^^af^^cc^^87̃
+^^c3^^8c^^c3^^8d^^c4^^a8ÌÍĨJ̀J́J̃^^c4^^aè^^c4^^aé^^c4^^aẽ
 Ìi̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃^^c4^^aḟ̀^^c4^^aḟ́^^c4^^aḟ̃
-^^c3^^8c^^c3^^ad^^c4^^a9ìíĩj̀j́j̃^^c4^^af̀^^c4^^af́^^c4^^af̃
+^^c3^^8c^^c3^^8d^^c4^^a8ÌÍĨJ̀J́J̃^^c4^^aè^^c4^^aé^^c4^^aẽ
 İ̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃^^c4^^aḟ̀^^c4^^aḟ́^^c4^^aḟ̃
 ============================================================
 ============================================================
@@ -280,7 +280,7 @@ Ijsselmeer
 IJsselmeer
 Ijsselmeer
 IJsselmeer
-Ijsselmeer
+IJsselmeer
 Im
 Im
 ============================================================
@@ -295,11 +295,11 @@ TEST 23: Case changing braced arguments
 ============================================================
 foo \emph {BAR} {baz}
 FOO \emph {BAR} {BAZ}
-Foo \emph {BAR} {baz}
+FOO \emph {BAR} {BAZ}
 FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
-\emph {BAR} {Baz}
+\emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
 ============================================================
 ============================================================
@@ -307,7 +307,7 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -315,7 +315,7 @@ Hello sometext
 Hello sometext
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -359,7 +359,7 @@ TEST 27: Letter-like commands
 ============================================================
 \aa \aa \ae \dh \ss \l \o 
 \AA \AA \AE \DH \SS \L \O 
-\AA \aa \ae \dh \ss \l \o 
+\AA \aa \ae \dh \ss \l \O 
 \AA \aa \ae \dh \ss \l \O 
 ============================================================
 ============================================================
@@ -398,7 +398,7 @@ Title
 Title
 WORDS lower
 words UPPER
-Words UPPER
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================

--- a/l3kernel/testfiles/m3text002.uptex.tlg
+++ b/l3kernel/testfiles/m3text002.uptex.tlg
@@ -6,8 +6,8 @@ TEST 1: Basic case changing
 ============================================================
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
-Hello world \par with \ERROR &##
-Hello world \par with \ERROR &##
+Hello World \par With \ERROR &##
+Hello World \par With \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
@@ -22,18 +22,18 @@ TEST 3: Case change exclusions
 ============================================================
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
-Some text \cite {WithFun}
-Some text \cite {WithFun}
+Some Text \cite {WithFun}
+Some Text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
-Hello world
-Hello world
+Hello World
+Hello World
 HELLO WORLD
 HELLO WORLD
-" Hello world"
-" Hello world"
+" Hello World"
+" Hello World"
 " HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
@@ -48,30 +48,30 @@ HELLO WORLD
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
-`Hic sunt leones'
-`Hic sunt leones'
-``Hic sunt leones''
-``Hic sunt leones''
-([Hic sunt leones])
-([Hic sunt leones])
+`Hic Sunt Leones'
+`Hic Sunt Leones'
+``Hic Sunt Leones''
+``Hic Sunt Leones''
+([Hic Sunt Leones])
+([Hic Sunt Leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic SUNT leones'
-`Hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`Hic SUNT Leones'
+`Hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic SUNT leones'
-`hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`hic SUNT Leones'
+`hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -80,12 +80,12 @@ TEST 8: Language based case changing but nothing
 ============================================================
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -307,24 +307,24 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
-Some text \cs_tmp:w 
-Some text \cs_tmp:w 
+Some Text \cs_tmp:w 
+Some Text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
@@ -335,16 +335,16 @@ TEST 25: Math-mode escape
 ============================================================
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
-Some text $y = mx + c$
-Some text $y = mx + c$
+Some Text $y = mx + c$
+Some Text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
 $y = mx + c$ Text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
-Opps not close token in $y = mx + c
-Opps not close token in $y = mx + c
+Opps Not Close Token In $y = mx + c
+Opps Not Close Token In $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -398,8 +398,8 @@ Title
 Title
 WORDS lower
 words UPPER
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
+Words Title
+Words Title
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.uptex.tlg
+++ b/l3kernel/testfiles/m3text002.uptex.tlg
@@ -7,14 +7,14 @@ TEST 1: Basic case changing
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
 Hello World \par With \ERROR &##
-Hello World \par With \ERROR &##
+Hello world \par with \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
 ============================================================
 {hello} world \par with \ERROR &##
 {HELLO} WORLD \par WITH \ERROR &##
-{Hello} world \par with \ERROR &##
+{Hello} World \par With \ERROR &##
 {Hello} world \par with \ERROR &##
 ============================================================
 ============================================================
@@ -23,45 +23,45 @@ TEST 3: Case change exclusions
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
 Some Text \cite {WithFun}
-Some Text \cite {WithFun}
+Some text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
 Hello World
-Hello World
+Hello world
 HELLO WORLD
 HELLO WORLD
 " Hello World"
-" Hello World"
+" hello world"
 " HELLO WORLD"
 " HELLO WORLD"
-{H}ello world
+{H}ello World
 {H}ello world
 {H}ELLO WORLD
 {H}ELLO WORLD
+{}hello World
 {}hello world
-{}hello world
-{}hello world
+{}hello World
 {}hello world
 ============================================================
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
 `Hic Sunt Leones'
-`Hic Sunt Leones'
+`Hic sunt leones'
 ``Hic Sunt Leones''
-``Hic Sunt Leones''
+``Hic sunt leones''
 ([Hic Sunt Leones])
-([Hic Sunt Leones])
+([Hic sunt leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
 `Hic SUNT Leones'
-`Hic SUNT Leones'
+`Hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -69,9 +69,9 @@ E PLURIBUS UNUM
 TEST 7: Titlecase control
 ============================================================
 `hic SUNT Leones'
-`hic SUNT Leones'
+`hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -81,11 +81,11 @@ TEST 8: Language based case changing but nothing
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -133,7 +133,7 @@ TEST 13: Cyrillic
 ^^d0^^b4оклады ^^d0^^b0кадемии наук
 Д^^d0^^9e^^d0^^9a^^d0^^9b^^d0^^90^^d0^^94^^d0^^ab А^^d0^^9a^^d0^^90^^d0^^94^^d0^^95^^d0^^9c^^d0^^98^^d0^^98 ^^d0^^9d^^d0^^90^^d0^^a3^^d0^^9a
 Д^^d0^^9e^^d0^^9a^^d0^^9b^^d0^^90^^d0^^94^^d0^^ab А^^d0^^9a^^d0^^90^^d0^^94^^d0^^95^^d0^^9c^^d0^^98^^d0^^98 ^^d0^^9d^^d0^^90^^d0^^a3^^d0^^9a
-Д^^d0^^9e^^d0^^9a^^d0^^9b^^d0^^90^^d0^^94^^d0^^ab А^^d0^^9a^^d0^^90^^d0^^94^^d0^^95^^d0^^9c^^d0^^98^^d0^^98 ^^d0^^9d^^d0^^90^^d0^^a3^^d0^^9a
+Д^^d0^^9e^^d0^^9a^^d0^^9b^^d0^^90^^d0^^94^^d0^^ab Академии наук
 ============================================================
 ============================================================
 TEST 14: BCP47 parts
@@ -300,7 +300,7 @@ FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
-\emph {BAR} {BAZ}
+\emph {BAR} BAZ
 ============================================================
 ============================================================
 TEST 24: Expanding content
@@ -308,27 +308,27 @@ TEST 24: Expanding content
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
 Some Text \cs_tmp:w 
-Some Text \cs_tmp:w 
+Some text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
-\cs_tmp:w  Sometext
+\cs_tmp:w  sometext
 ============================================================
 ============================================================
 TEST 25: Math-mode escape
@@ -336,15 +336,15 @@ TEST 25: Math-mode escape
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
 Some Text $y = mx + c$
-Some Text $y = mx + c$
+Some text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
-$y = mx + c$ Text
+$y = mx + c$ text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
 Opps Not Close Token In $y = mx + c
-Opps Not Close Token In $y = mx + c
+Opps not close token in $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -399,7 +399,7 @@ Title
 WORDS lower
 words UPPER
 Words Title
-Words Title
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.xetex.tlg
+++ b/l3kernel/testfiles/m3text002.xetex.tlg
@@ -7,14 +7,14 @@ TEST 1: Basic case changing
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
 Hello World \par With \ERROR &##
-Hello World \par With \ERROR &##
+Hello world \par with \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
 ============================================================
 {hello} world \par with \ERROR &##
 {HELLO} WORLD \par WITH \ERROR &##
-{Hello} world \par with \ERROR &##
+{Hello} World \par With \ERROR &##
 {Hello} world \par with \ERROR &##
 ============================================================
 ============================================================
@@ -23,45 +23,45 @@ TEST 3: Case change exclusions
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
 Some Text \cite {WithFun}
-Some Text \cite {WithFun}
+Some text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
 Hello World
-Hello World
+Hello world
 HELLO WORLD
 HELLO WORLD
 " Hello World"
-" Hello World"
+" hello world"
 " HELLO WORLD"
 " HELLO WORLD"
-{H}ello world
+{H}ello World
 {H}ello world
 {H}ELLO WORLD
 {H}ELLO WORLD
+{}hello World
 {}hello world
-{}hello world
-{}hello world
+{}hello World
 {}hello world
 ============================================================
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
 `Hic Sunt Leones'
-`Hic Sunt Leones'
+`Hic sunt leones'
 ``Hic Sunt Leones''
-``Hic Sunt Leones''
+``Hic sunt leones''
 ([Hic Sunt Leones])
-([Hic Sunt Leones])
+([Hic sunt leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
 `Hic SUNT Leones'
-`Hic SUNT Leones'
+`Hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -69,9 +69,9 @@ E PLURIBUS UNUM
 TEST 7: Titlecase control
 ============================================================
 `hic SUNT Leones'
-`hic SUNT Leones'
+`hic SUNT leones'
 `HIC SUNT Leones'
-`HIC SUNT Leones'
+`HIC SUNT leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -81,11 +81,11 @@ TEST 8: Language based case changing but nothing
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 no problems
 NO PROBLEMS
 No Problems
-No Problems
+No problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -133,7 +133,7 @@ TEST 13: Cyrillic
 доклады академии наук
 ДОКЛАДЫ АКАДЕМИИ НАУК
 Доклады Академии Наук
-Доклады Академии Наук
+Доклады Академии наук
 ============================================================
 ============================================================
 TEST 14: BCP47 parts
@@ -300,7 +300,7 @@ FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
-\emph {BAR} {BAZ}
+\emph {BAR} BAZ
 ============================================================
 ============================================================
 TEST 24: Expanding content
@@ -308,27 +308,27 @@ TEST 24: Expanding content
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text hello
 SOME TEXT HELLO
 Some Text Hello
-Some Text Hello
+Some text Hello
 hello sometext
 HELLO SOMETEXT
 Hello Sometext
-Hello Sometext
+Hello sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
 Some Text \cs_tmp:w 
-Some Text \cs_tmp:w 
+Some text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
-\cs_tmp:w  Sometext
+\cs_tmp:w  sometext
 ============================================================
 ============================================================
 TEST 25: Math-mode escape
@@ -336,15 +336,15 @@ TEST 25: Math-mode escape
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
 Some Text $y = mx + c$
-Some Text $y = mx + c$
+Some text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
-$y = mx + c$ Text
+$y = mx + c$ text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
 Opps Not Close Token In $y = mx + c
-Opps Not Close Token In $y = mx + c
+Opps not close token in $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -399,7 +399,7 @@ Title
 WORDS lower
 words UPPER
 Words Title
-Words Title
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.xetex.tlg
+++ b/l3kernel/testfiles/m3text002.xetex.tlg
@@ -6,8 +6,8 @@ TEST 1: Basic case changing
 ============================================================
 hello world \par with \ERROR &##
 HELLO WORLD \par WITH \ERROR &##
-Hello world \par with \ERROR &##
-Hello world \par with \ERROR &##
+Hello World \par With \ERROR &##
+Hello World \par With \ERROR &##
 ============================================================
 ============================================================
 TEST 2: Case changes in braces
@@ -22,18 +22,18 @@ TEST 3: Case change exclusions
 ============================================================
 some text \cite {WithFun}
 SOME TEXT \cite {WithFun}
-Some text \cite {WithFun}
-Some text \cite {WithFun}
+Some Text \cite {WithFun}
+Some Text \cite {WithFun}
 ============================================================
 ============================================================
 TEST 4: Titlecase basics
 ============================================================
-Hello world
-Hello world
+Hello World
+Hello World
 HELLO WORLD
 HELLO WORLD
-" Hello world"
-" Hello world"
+" Hello World"
+" Hello World"
 " HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
@@ -48,30 +48,30 @@ HELLO WORLD
 ============================================================
 TEST 5: Titlecase skipping chars
 ============================================================
-`Hic sunt leones'
-`Hic sunt leones'
-``Hic sunt leones''
-``Hic sunt leones''
-([Hic sunt leones])
-([Hic sunt leones])
+`Hic Sunt Leones'
+`Hic Sunt Leones'
+``Hic Sunt Leones''
+``Hic Sunt Leones''
+([Hic Sunt Leones])
+([Hic Sunt Leones])
 ============================================================
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic SUNT leones'
-`Hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`Hic SUNT Leones'
+`Hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic SUNT leones'
-`hic SUNT leones'
-`HIC SUNT leones'
-`HIC SUNT leones'
+`hic SUNT Leones'
+`hic SUNT Leones'
+`HIC SUNT Leones'
+`HIC SUNT Leones'
 E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
@@ -80,12 +80,12 @@ TEST 8: Language based case changing but nothing
 ============================================================
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 no problems
 NO PROBLEMS
-No problems
-No problems
+No Problems
+No Problems
 ============================================================
 ============================================================
 TEST 9: (u)pTeX-based tests
@@ -132,8 +132,8 @@ TEST 13: Cyrillic
 ============================================================
 доклады академии наук
 ДОКЛАДЫ АКАДЕМИИ НАУК
-Доклады Академии наук
-Доклады Академии наук
+Доклады Академии Наук
+Доклады Академии Наук
 ============================================================
 ============================================================
 TEST 14: BCP47 parts
@@ -307,24 +307,24 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text hello
 SOME TEXT HELLO
-Some text Hello
-Some text Hello
+Some Text Hello
+Some Text Hello
 hello sometext
 HELLO SOMETEXT
-Hello sometext
-Hello sometext
+Hello Sometext
+Hello Sometext
 some text \cs_tmp:w 
 SOME TEXT \cs_tmp:w 
-Some text \cs_tmp:w 
-Some text \cs_tmp:w 
+Some Text \cs_tmp:w 
+Some Text \cs_tmp:w 
 \cs_tmp:w  sometext
 \cs_tmp:w  SOMETEXT
 \cs_tmp:w  Sometext
@@ -335,16 +335,16 @@ TEST 25: Math-mode escape
 ============================================================
 some text $y = mx + c$
 SOME TEXT $y = mx + c$
-Some text $y = mx + c$
-Some text $y = mx + c$
+Some Text $y = mx + c$
+Some Text $y = mx + c$
 $y = mx + c$ text
 $y = mx + c$ TEXT
 $y = mx + c$ Text
 $y = mx + c$ Text
 opps not close token in $y = mx + c
 OPPS NOT CLOSE TOKEN IN $y = mx + c
-Opps not close token in $y = mx + c
-Opps not close token in $y = mx + c
+Opps Not Close Token In $y = mx + c
+Opps Not Close Token In $y = mx + c
 ============================================================
 ============================================================
 TEST 26: Nesting
@@ -398,8 +398,8 @@ Title
 Title
 WORDS lower
 words UPPER
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
-Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
+Words Title
+Words Title
 ============================================================
 ============================================================
 TEST 32: Case change replacements

--- a/l3kernel/testfiles/m3text002.xetex.tlg
+++ b/l3kernel/testfiles/m3text002.xetex.tlg
@@ -30,15 +30,15 @@ TEST 4: Titlecase basics
 ============================================================
 Hello world
 Hello world
-Hello world
+HELLO WORLD
 HELLO WORLD
 " Hello world"
 " Hello world"
-" Hello world"
+" HELLO WORLD"
 " HELLO WORLD"
 {H}ello world
 {H}ello world
-{H}ello world
+{H}ELLO WORLD
 {H}ELLO WORLD
 {}hello world
 {}hello world
@@ -58,21 +58,21 @@ TEST 5: Titlecase skipping chars
 ============================================================
 TEST 6: Titlecase first
 ============================================================
-`Hic sunt leones'
 `Hic SUNT leones'
-`Hic sunt leones'
+`Hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
 TEST 7: Titlecase control
 ============================================================
-`hic sunt leones'
 `hic SUNT leones'
-`hic sunt leones'
+`hic SUNT leones'
 `HIC SUNT leones'
-E pluribus unum
+`HIC SUNT leones'
+E PLURIBUS UNUM
 E PLURIBUS UNUM
 ============================================================
 ============================================================
@@ -92,7 +92,7 @@ TEST 9: (u)pTeX-based tests
 ============================================================
 abc^^e8日本語
 ABC^^c8日本語
-Abc^^e8日本語
+ABC^^c8日本語
 ABC^^c8日本語
 一级标题
 一级标题
@@ -104,7 +104,7 @@ TEST 10: Unicode case changing
 ============================================================
 ^^e5^^e9^^ee^^f8ὥдαɛ
 ^^c5^^c9^^ce^^d8ὭДΑƐ
-^^c5^^e9^^ee^^f8ὥдαɛ
+^^c5^^e9^^ee^^f8ὭдαƐ
 ^^c5^^e9^^ee^^f8ὭдαƐ
 ============================================================
 ============================================================
@@ -120,11 +120,11 @@ TEST 12: The final sigma rule
 ============================================================
 ὀδυσσεύς (ὀδυσσεύς) ὀδυσσεύς, ὀδυσσεύς{} ὀδυσσεύς\noop 
 ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
-Ὀδυσσεύς (ὀδυσσεύς) ὀδυσσεύς, ὀδυσσεύς{} ὀδυσσεύς\noop 
+ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
 ὈΔΥΣΣΕΎΣ (ὈΔΥΣΣΕΎΣ) ὈΔΥΣΣΕΎΣ, ὈΔΥΣΣΕΎΣ{} ὈΔΥΣΣΕΎΣ\noop 
 ὀδυσσεύς
 ὈΔΥΣΣΕΎΣ
-Ὀδυσσεύς
+ὈΔΥΣΣΕΎΣ
 ὈΔΥΣΣΕΎΣ
 ============================================================
 ============================================================
@@ -132,7 +132,7 @@ TEST 13: Cyrillic
 ============================================================
 доклады академии наук
 ДОКЛАДЫ АКАДЕМИИ НАУК
-Доклады академии наук
+Доклады Академии наук
 Доклады Академии наук
 ============================================================
 ============================================================
@@ -193,8 +193,8 @@ TEST 17: Greek
 ΤΟ ΕΝΑ Ή ΤΟ ΑΛΛΟ.
 ΡΩΜΈΙΚΑ
 ΡΩΜΕΪΚΑ
-Ὀδυσσεύς
-Ὀδυσσεύς
+ὈΔΥΣΣΕΎΣ
+ὈΔΥΣΣΕΎΣ
 ΉΙ
 ῌ
 ΗΙ
@@ -243,10 +243,10 @@ ragıp hul^^fbsi ^^f6zdem
 ragip hul^^fbsi̇ ^^f6zdem
 RAGIP HUL^^dbSİ ^^d6ZDEM
 RAGIP HUL^^dbSI ^^d6ZDEM
-Ragıp hul^^fbsi ^^f6zdem
-Ragıp hul^^fbsi ^^f6zdem
-Ip hul^^fbsi ^^f6zdem
-Ip hul^^fbsi ^^f6zdem
+Ragıp Hul^^fbsi ^^d6zdem
+Ragıp Hul^^fbsi ^^d6zdem
+Ip Hul^^fbsi ^^d6zdem
+Ip Hul^^fbsi ^^d6zdem
 ============================================================
 ============================================================
 TEST 19: Lithuanian
@@ -255,9 +255,9 @@ i̇̀i̇́i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃
 ^^ec^^edĩìíĩj̀j́j̃į̀į́į̃
 ÌÌĨÌÍĨJ̀J́J̃Į̀Į́Į̃
 İ̀İ̀İ̃İ̀İ́İ̃J̇̀J̇́J̇̃Į̇̀Į̇́Į̇̃
-^^cci̇́i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃
+^^cc^^cdĨÌÍĨJ̀J́J̃Į̀Į́Į̃
 Ìi̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃
-^^cc^^edĩìíĩj̀j́j̃į̀į́į̃
+^^cc^^cdĨÌÍĨJ̀J́J̃Į̀Į́Į̃
 İ̀i̇̀i̇̃i̇̀i̇́i̇̃j̇̀j̇́j̇̃į̇̀į̇́į̇̃
 ============================================================
 ============================================================
@@ -280,7 +280,7 @@ Ijsselmeer
 IJsselmeer
 Ijsselmeer
 IJsselmeer
-Ijsselmeer
+IJsselmeer
 Im
 Im
 ============================================================
@@ -295,11 +295,11 @@ TEST 23: Case changing braced arguments
 ============================================================
 foo \emph {BAR} {baz}
 FOO \emph {BAR} {BAZ}
-Foo \emph {BAR} {baz}
+FOO \emph {BAR} {BAZ}
 FOO \emph {BAR} {BAZ}
 \emph {BAR} {baz}
 \emph {BAR} {BAZ}
-\emph {BAR} {Baz}
+\emph {BAR} {BAZ}
 \emph {BAR} {BAZ}
 ============================================================
 ============================================================
@@ -307,7 +307,7 @@ TEST 24: Expanding content
 ============================================================
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -315,7 +315,7 @@ Hello sometext
 Hello sometext
 some text hello
 SOME TEXT HELLO
-Some text hello
+Some text Hello
 Some text Hello
 hello sometext
 HELLO SOMETEXT
@@ -359,7 +359,7 @@ TEST 27: Letter-like commands
 ============================================================
 \aa \aa \ae \dh \ss \l \o 
 \AA \AA \AE \DH \SS \L \O 
-\AA \aa \ae \dh \ss \l \o 
+\AA \aa \ae \dh \ss \l \O 
 \AA \aa \ae \dh \ss \l \O 
 ============================================================
 ============================================================
@@ -398,7 +398,7 @@ Title
 Title
 WORDS lower
 words UPPER
-Words UPPER
+Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 Words \text_case_switch:nnnn {normal}{lower}{UPPER}{Title}
 ============================================================
 ============================================================


### PR DESCRIPTION
Follows from discussion in https://github.com/latex3/latex3/pull/1240. Here, a clearer split occurs between titlecasing one an multiple words without any additional naming needed. It also avoids any change to formal behaviour of the existing functions: note though that the new functions do _not_ lowercase the remainder of their input.