### PR TITLE
Disambiguate docs for `.undefine:` property

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -176,8 +176,9 @@
 %       keyname .code:n           = Some~code~using~#1
 %     }
 % \end{verbatim}
-% Note that with the exception of the special |.undefine:| property, all
-% key properties define the key within the current \TeX{} scope.
+% Note that all key properties define the key within the current \TeX{} group,
+% with an exception that the special |.undefine:| property \emph{undefines} the
+% key within the current \TeX{} group.
 %
 % \begin{function}[updated = 2013-07-08]
 %   {.bool_set:N, .bool_set:c, .bool_gset:N, .bool_gset:c}
@@ -513,7 +514,7 @@
 %   \begin{syntax}
 %     \meta{key} .undefine:
 %   \end{syntax}
-%   Removes the definition of the \meta{key} within the current scope.
+%   Removes the definition of the \meta{key} within the current \TeX{} group.
 % \end{function}
 %
 % \begin{function}[added = 2015-07-14]{.value_forbidden:n}
@@ -2969,7 +2970,7 @@
 %   }
 % \begin{macro}{\@@_set_selective:}
 %   A shared system once again. First, set the current path and add a
-%   default if needed. There are then checks to see if the a value is
+%   default if needed. There are then checks to see if a value is
 %   required or forbidden. If everything passes, move on to execute the
 %   code.
 %    \begin{macrocode}


### PR DESCRIPTION
This piece of doc mentioned `.undefine:` property is more or less ambiguity:

> Note that with the exception of the special `.undefine:` property, all key properties define the key within the current TeX scope.
https://github.com/latex3/latex3/blob/79b071a88cd7bf91943b296779959185b81b3d1b/l3kernel/l3keys.dtx#L179-L180

- First understanding (wrong): All properties acts locally, but `.undefine:` acts globally.
- Second understanding (desired): All properties define keys locally, but `.undefine:` undefines keys locally.

This PR resolves the ambiguity and uses the phrase "within the current \TeX{} group" consistently

```
$ grep -rn 'within the current' l3kernel/*.dtx
l3kernel/l3fp.dtx:758:%   \texttt{division_by_zero}) within the current
l3kernel/l3keys.dtx:180:% key properties define the key within the current \TeX{} scope.
l3kernel/l3keys.dtx:516:%   Removes the definition of the \meta{key} within the current scope.
l3kernel/l3prop.dtx:264:%     variable} is set within the current \TeX{} group. See also
l3kernel/l3regex.dtx:607:%   Sets \meta{int var} within the current \TeX{} group level
l3kernel/l3token.dtx:237:%   The setting applies within the current \TeX{} group. In general, the
l3kernel/l3token.dtx:276:%   The setting applies within the current \TeX{} group.
l3kernel/l3token.dtx:313:%   The setting applies within the current \TeX{} group.
```