### PR TITLE
Fix unpaired `macrocode` envs

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -3751,7 +3751,7 @@
 %    \begin{macrocode}
     \tex_endinput:D
   }
-%    \begin{macrocode}
+%    \end{macrocode}
 %
 %   Now define the actual error message:
 %    \begin{macrocode}

--- a/l3kernel/l3fp-logic.dtx
+++ b/l3kernel/l3fp-logic.dtx
@@ -404,7 +404,7 @@
       \exp:w \exp_end_continue_f:w \@@_parse:n {#3}
   }
 \cs_generate_variant:Nn \fp_step_function:nnnN { nnnc }
-%      \end{macrocode}
+%    \end{macrocode}
 %   Only floating point numbers (not tuples) are allowed arguments.
 %   Only \enquote{normal} floating points (not $\pm 0$,
 %   $\pm\texttt{inf}$, \texttt{nan}) can be used as step; if positive,

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -1603,6 +1603,7 @@
     \tl_put_right:Nn \l_@@_tmp_tl { ^^@ \exp_not:N \or: }
     \char_set_catcode_letter:n { 0 }
     \tl_put_right:Nn \l_@@_tmp_tl { ^^@ \exp_not:N \or: }
+%    \end{macrocode}
 %   For making spaces, there needs to be an |o|-type expansion of a |\use:n|
 %   (or some other tokenization) to avoid dropping the space.
 %    \begin{macrocode}


### PR DESCRIPTION
All cases of unpaired `macrocode` envs are caught.

| | Before (2023-08-11) | After |
|--------|--------|--------|
| Page 656, l3file | ![image](https://github.com/latex3/latex3/assets/6376638/a5dc5167-d984-4d52-8978-28d6041e3882) | ![image](https://github.com/latex3/latex3/assets/6376638/e522d6a8-2902-4e88-b1ea-db4d63b3706b) |
| Page 865, l3token | ![image](https://github.com/latex3/latex3/assets/6376638/8fc36601-e23d-4a93-bc89-a8c7db5ebade) | ![image](https://github.com/latex3/latex3/assets/6376638/d7670112-022a-4271-b49a-caf278ce7dd2) |
| Page 1060--1061, l3fp | ![image](https://github.com/latex3/latex3/assets/6376638/1b593fc1-4b32-4f05-b157-6d02c5d95e83)  | ![image](https://github.com/latex3/latex3/assets/6376638/49d17390-7e79-41ba-a4b0-8f24de921988) | 
| | ![image](https://github.com/latex3/latex3/assets/6376638/00dfeba9-1aa3-4fc2-8d6b-e1efb28753e6) | |


Closes #1261 