### PR TITLE
Add documentation for `\sys_if_timer_exsit_p:` and `\sys_if_timer_exsit:(TF)`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Documentation for `\sys_if_timer_exist_p:` and `\sys_if_timer_exist:(TF)`.
+  They were supported since l3kernel 2021-05-25, along with `\sys_timer:`.
+
 ### Changed
 - Standardise variants for `\prop_(g)pop:NnN(TF)`
 - Standardise variants for `\prop_(g)put:Nnn`

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -148,7 +148,7 @@
 %   where the |u| part is only present for \upTeX{}.
 % \end{variable}
 %
-% \begin{function}[added = 2020-09-24, EXP]{\sys_timer:}
+% \begin{function}[added = 2021-05-12, EXP]{\sys_timer:}
 %   \begin{syntax}
 %     \cs{sys_timer:}
 %   \end{syntax}
@@ -157,6 +157,14 @@
 %   timer support.  This command measures not just CPU time but
 %   real time (including time waiting for user input).  The unit are
 %   scaled seconds ($2^{-16}$ seconds).
+% \end{function}
+%
+% \begin{function}[added = 2021-05-12, EXP, pTF]{\sys_if_timer_exist:}
+%   \begin{syntax}
+%     \cs{sys_if_timer_exist_p:}
+%     \cs{sys_if_timer_exist:TF} \Arg{true code} \Arg{false code}
+%   \end{syntax}
+%   Tests whether current engine has timer support.
 % \end{function}
 %
 % \section{Output format}


### PR DESCRIPTION
They were added by commit 1867e95 (Move timer to sys, 2020-10-05), as part of PR #859 which was merged on 2021-05-12.

The added date is set to 2021-05-12, the merged date, because the commit date (2020-10-05) and current added date of `\sys_timer:` (2020-09-24) are both quite prior to merged date of such commit.