### PR TITLE
Fix typos of missing commas

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -788,10 +788,10 @@
 %   {
 %     \keys_set_known:nn, \keys_set_known:nV,
 %     \keys_set_known:nv, \keys_set_known:ne,
-%     \keys_set_known:no
+%     \keys_set_known:no,
 %     \keys_set_known:nnN, \keys_set_known:nVN,
 %     \keys_set_known:nvN, \keys_set_known:neN,
-%     \keys_set_known:noN
+%     \keys_set_known:noN,
 %     \keys_set_known:nnnN, \keys_set_known:nVnN,
 %     \keys_set_known:nvnN, \keys_set_known:nenN,
 %     \keys_set_known:nonN

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -187,7 +187,7 @@
 %     \tl_put_left:co,
 %     \tl_gput_left:Nn, \tl_gput_left:NV, \tl_gput_left:Nv, \tl_gput_left:Ne,
 %     \tl_gput_left:No,
-%     \tl_gput_left:cn, \tl_gput_left:cV, \tl_gput_left:cv, \tl_gput_left:ce
+%     \tl_gput_left:cn, \tl_gput_left:cV, \tl_gput_left:cv, \tl_gput_left:ce,
 %     \tl_gput_left:co
 %   }
 %   \begin{syntax}
@@ -205,7 +205,7 @@
 %     \tl_put_right:co,
 %     \tl_gput_right:Nn, \tl_gput_right:NV, \tl_gput_right:Nv, \tl_gput_right:Ne,
 %     \tl_gput_right:No,
-%     \tl_gput_right:cn, \tl_gput_right:cV, \tl_gput_right:cv, \tl_gput_right:ce
+%     \tl_gput_right:cn, \tl_gput_right:cV, \tl_gput_right:cv, \tl_gput_right:ce,
 %     \tl_gput_right:co
 %   }
 %   \begin{syntax}


### PR DESCRIPTION
This commit fixes several missing commas in the documentation.

Before:
<img width="833" alt="Screenshot 2023-10-18 at 15 28 54" src="https://github.com/latex3/latex3/assets/12290822/a3db9c25-33e7-4089-a890-48edbbb001eb">
<img width="796" alt="Screenshot 2023-10-18 at 15 29 31" src="https://github.com/latex3/latex3/assets/12290822/5d1db122-8f81-4f84-a311-f35ead49ff2e">
<img width="808" alt="Screenshot 2023-10-18 at 15 29 42" src="https://github.com/latex3/latex3/assets/12290822/08b64dbc-82ed-4ff4-b432-c0cd410c02a3">

After:
<img width="823" alt="Screenshot 2023-10-18 at 15 29 59" src="https://github.com/latex3/latex3/assets/12290822/7e740ff9-1bad-4a71-bd10-bde97f8612f5">
<img width="799" alt="Screenshot 2023-10-18 at 15 30 15" src="https://github.com/latex3/latex3/assets/12290822/cd675c4f-b7bc-4c1c-b2aa-41c3774c798e">
<img width="821" alt="Screenshot 2023-10-18 at 15 30 25" src="https://github.com/latex3/latex3/assets/12290822/eb536d77-a209-4556-bcda-eb4a905ff248">

