### PR TITLE
Fix doc typos mainly for fp var and funcs

### DIFF
--- a/l3experimental/l3str/l3str-format.dtx
+++ b/l3experimental/l3str/l3str-format.dtx
@@ -123,7 +123,7 @@
 %
 % \begin{function}[EXP]{\fp_format:nn}
 %   \begin{syntax}
-%     \cs{fp_format:nn} \Arg{fpexpr} \Arg{format specification}
+%     \cs{fp_format:nn} \Arg{fp expr} \Arg{format specification}
 %   \end{syntax}
 %   Evaluates the \meta{floating point expression} and converts the
 %   result to a string according to the \meta{format specification}.

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -661,7 +661,7 @@
 % \subsection{Symbolic expressions}
 %
 % Floating point expressions support variables: these can only be set locally,
-% so act like standard \cs{l_\dots} variables.
+% so act like standard \cs[no-index]{l_\dots} variables.
 % \begin{quote}
 %   \cs{fp_new_variable:n} |{ A }|
 %   \cs{fp_set:Nn} \cs{l_tmpb_fp} |{ 1 * sin(A) + 3**2 }|

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -1549,7 +1549,7 @@
 % \begin{function}[EXP, added = 2012-09-26, tested = m3fp-convert003]
 %   {\fp_max:nn, \fp_min:nn}
 %   \begin{syntax}
-%     \cs{fp_max:nn} \Arg{fp expression 1} \Arg{fp expression 2}
+%     \cs{fp_max:nn} \Arg{fp expr_1} \Arg{fp expr_2}
 %   \end{syntax}
 %   Evaluates the \meta{fp exprs} as described for
 %   \cs{fp_eval:n} and leaves the resulting larger (\texttt{max}) or

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -703,7 +703,7 @@
 %
 % \begin{function}[added = 2023-10-19]{\fp_set_variable:nn}
 %   \begin{syntax}
-%     \cs{fp_set_variable:nn} \Arg{identifier} \Arg{fpexpr}
+%     \cs{fp_set_variable:nn} \Arg{identifier} \Arg{fp expr}
 %   \end{syntax}
 %   Defines the \meta{identifier} to stand in any further expression for
 %   the result of evaluating the \meta{floating point expression} as
@@ -764,7 +764,7 @@
 %
 % \begin{function}[added = 2023-10-19]{\fp_set_function:nnn}
 %   \begin{syntax}
-%     \cs{fp_set_function:nnn} \Arg{identifier} \Arg{vars} \Arg{fpexpr}
+%     \cs{fp_set_function:nnn} \Arg{identifier} \Arg{vars} \Arg{fp expr}
 %   \end{syntax}
 %   Defines the \meta{identifier} to stand in any further expression for
 %   the result of evaluating the \meta{floating point expression}, with

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -658,7 +658,7 @@
 %   the \meta{code} should make use of the \meta{tl~var}.
 % \end{function}
 %
-% \subsection{Symbolic expressions}
+% \section{Symbolic expressions}
 %
 % Floating point expressions support variables: these can only be set locally,
 % so act like standard \cs[no-index]{l_\dots} variables.
@@ -740,7 +740,7 @@
 %   shows~|9|, then~|(A^2)|.
 % \end{function}
 %
-% \subsection{User-defined functions}
+% \section{User-defined functions}
 %
 % It is possible to define new user functions which can be used inside
 % the argument to \cs{fp_eval:n}, etc. These functions may take one or

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -662,7 +662,7 @@
 %
 % Floating point expressions support variables: these can only be set locally,
 % so act like standard \cs[no-index]{l_\dots} variables.
-% \begin{quote}
+% \begin{quote}\let\obeyedline=\newline\obeylines^^A
 %   \cs{fp_new_variable:n} |{ A }|
 %   \cs{fp_set:Nn} \cs{l_tmpb_fp} |{ 1 * sin(A) + 3**2 }|
 %   \cs{fp_show:n} |{| \cs{l_tmpb_fp} |}|
@@ -709,7 +709,7 @@
 %   the result of evaluating the \meta{floating point expression} as
 %   much as possible.  The result may contain other variables, which are
 %   then replaced by their values if they have any.  For instance,
-%   \begin{quote}
+%   \begin{quote}\let\obeyedline=\newline\obeylines^^A
 %     \cs{fp_new_variable:n} |{ A }|
 %     \cs{fp_new_variable:n} |{ B }|
 %     \cs{fp_new_variable:n} |{ C }|
@@ -730,7 +730,7 @@
 %   \end{syntax}
 %   Removes any value given by \cs{fp_set_variable:nn} to the variable
 %   with this \meta{identifier}.  For instance,
-%   \begin{quote}
+%   \begin{quote}\let\obeyedline=\newline\obeylines^^A
 %     \cs{fp_new_variable:n} |{ A }|
 %     \cs{fp_set_variable:nn} |{ A } { 3 }|
 %     \cs{fp_show:n} |{ A ^ 2 }|

--- a/l3trial/l3str-format-new/l3str-format-new.dtx
+++ b/l3trial/l3str-format-new/l3str-format-new.dtx
@@ -229,7 +229,7 @@
 %
 % \begin{function}[EXP]{\fp_format:nn}
 %   \begin{syntax}
-%     \cs{fp_format:nn} \Arg{fpexpr} \Arg{format specification}
+%     \cs{fp_format:nn} \Arg{fp expr} \Arg{format specification}
 %   \end{syntax}
 %   Evaluates the \meta{floating point expression} and converts the
 %   result to a string according to the \meta{format specification}.


### PR DESCRIPTION
About `\begin{quote}\let\obeyedline=\newline\obeylines^^A`
  - Compared to inserting `\\` per line, would this way be too tricky?
  - `verbatim` env is another option, but auto indexing is disabled.
  - By default `\obeyedline` uses `\par`, which will make larger visual "line spacing". Hence I redefined it (locally) to use `\newline`.

About `\subsection` -> `\section`, I'm also considering changing their titles or even restructuring them. Maybe in a later PR.
  - It's a bit hard to infer from only the title "Symbolic expressions" to know that expl3 functions about fp expr variables are documented under it.
  - And since "function" is also used to represent an expl3 function, the second title "User-defined functions" is more or less ambiguous.