### PR TITLE
Allow all branches to trigger CI

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,6 +1,6 @@
 name: Create release
 
-# We create releases for all new tags
+# We create releases for all new tags not having "/" in their names
 on:
   push:
     tags:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,7 +5,7 @@ on:
   # Whenever someone pushes to a branch in our repo
   push:
     branches:
-      - "*"
+      - "**"
   # Whenever a pull request is opened, reopened or gets new commits.
   pull_request:
 # This implies that for every push to a local branch in our repo for which a


### PR DESCRIPTION
Currently CI (workflow defined in `main.yaml`) was not triggered by pushing commits to a branch having `/` in its name. This PR fixes it by relaxing the glob pattern.

> - `*`: Matches zero or more characters, but does not match the `/` character. For example, `Octo*` matches `Octocat`.
> - `**`: Matches zero or more of any character.

See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet.