### PR TITLE
Docu `\ExplLoaderFileDate` and `\c__kernel_expl_date_tl`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Documentation for `\ExplLoaderFileDate` in `expl3.pdf`
+
 ## [2023-10-23]
 
 ### Added

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -958,6 +958,16 @@
 % loadable: package loading is dependent on the \LaTeXe{} package-management
 % mechanism.
 %
+% \section{Getting the version of \pkg{expl3}}
+%
+% \begin{function}{\ExplLoaderFileDate}
+%   Once the programming layer is loaded by one of the loaders, you can access
+%   its version in the ISO date format \meta{year}-\meta{month}-\meta{day},
+%   through \cs{ExplLoaderFileDate}.
+%
+%   The current version of \pkg{expl3} is \ExplLoaderFileDate.
+% \end{function}
+%
 % \section{Engine/primitive requirements}
 %
 % To use \pkg{expl3} and the higher level packages provided by the


### PR DESCRIPTION
As `\ExplLoaderFileDate` is already used to define `\IfExplAtLeastTF` in LaTeX2e (see https://github.com/latex3/latex2e/pull/1146), latex3 may want it and its expl3 alias `\c__kernel_expl_date_tl` documented somewhere.

Since they're both defined in loader file (`expl3.ltx`, `expl3.sty`, and `expl3-generic.tex`), I think `expl3.pdf` is more appropriate a place than `interface3.pdf` for their documentations. `interface3.pdf` never even mentions "loader(s)".