### PR TITLE
Fix `\fp_clear_function:n` acting globally, add tests, and a bit more

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -17,6 +17,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Fixed
 - `\fp_clear_variable:n` should act locally (issue \#1298)
+- `\fp_clear_function:n` should act locally and correctly
 
 ## [2023-10-23]
 

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -16,7 +16,7 @@ this project uses date-based 'snapshot' version identifiers.
   first (relevant) codepoint in the input
 
 ### Fixed
-- Support fp vars setting intermixed with fp function creation (issue \#1298) 
+- `\fp_clear_variable:n` should act locally (issue \#1298)
 
 ## [2023-10-23]
 

--- a/l3kernel/l3fp-functions.dtx
+++ b/l3kernel/l3fp-functions.dtx
@@ -264,7 +264,7 @@
   { \exp_args:No \@@_clear_function:n { \tl_to_str:n {#1} } }
 \cs_new_protected:Npn \@@_clear_function:n #1
   {
-    \cs_undefine:c { @@_parse_word_ #1 :N }
+    \cs_set_eq:cN { @@_#1_o:w } \tex_undefine:D
     \@@_function_set_parsing:Nn \cs_set_eq:NN {#1}
   }
 %    \end{macrocode}

--- a/l3kernel/l3fp-functions.dtx
+++ b/l3kernel/l3fp-functions.dtx
@@ -72,7 +72,7 @@
 \cs_new_protected:Npn \@@_new_function:n #1
   {
     \@@_id_if_invalid:nTF {#1}
-      { \msg_error:nnn { fp } { invalid-identifier } {#1} }
+      { \msg_error:nnn { fp } { id-invalid } {#1} }
       {
         \cs_if_exist:cT { @@_parse_word_#1:N }
           {
@@ -171,7 +171,7 @@
 \cs_new_protected:Npn \@@_set_function:Nnnn #1#2#3#4
   {
     \@@_id_if_invalid:nTF {#2}
-      { \msg_error:nnn { fp } { invalid-identifier } {#2} }
+      { \msg_error:nnn { fp } { id-invalid } {#2} }
       {
         \cs_if_exist:cF { @@_parse_word_#2:N }
           { \@@_function_set_parsing:Nn \cs_set_eq:NN {#2} }
@@ -265,7 +265,7 @@
 \cs_new_protected:Npn \@@_clear_function:n #1
   {
     \@@_id_if_invalid:nTF {#1}
-      { \msg_error:nnn { fp } { invalid-identifier } {#1} }
+      { \msg_error:nnn { fp } { id-invalid } {#1} }
       {
         \cs_set_eq:cN { @@_#1_o:w } \tex_undefine:D
         \@@_function_set_parsing:Nn \cs_set_eq:NN {#1} 

--- a/l3kernel/l3fp-functions.dtx
+++ b/l3kernel/l3fp-functions.dtx
@@ -264,8 +264,12 @@
   { \exp_args:No \@@_clear_function:n { \tl_to_str:n {#1} } }
 \cs_new_protected:Npn \@@_clear_function:n #1
   {
-    \cs_set_eq:cN { @@_#1_o:w } \tex_undefine:D
-    \@@_function_set_parsing:Nn \cs_set_eq:NN {#1}
+    \@@_id_if_invalid:nTF {#1}
+      { \msg_error:nnn { fp } { invalid-identifier } {#1} }
+      {
+        \cs_set_eq:cN { @@_#1_o:w } \tex_undefine:D
+        \@@_function_set_parsing:Nn \cs_set_eq:NN {#1} 
+      }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/l3fp-functions.dtx
+++ b/l3kernel/l3fp-functions.dtx
@@ -180,8 +180,10 @@
           \exp_args:No \clist_map_inline:nn { \tl_to_str:n {#3} }
             {
               \int_incr:N \l_@@_function_arg_int
-              \exp_args:Ne \@@_clear_variable:n
-                { _ \tex_romannumeral:D \l_@@_function_arg_int }
+              \exp_args:Ne \@@_clear_variable_aux:n
+                {
+                  \c_underscore_str \tex_romannumeral:D \l_@@_function_arg_int
+                }
               \fp_clear_variable:n {##1}
               \cs_set_nopar:cpe { l_@@_variable_##1_fp }
                 {

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -440,6 +440,7 @@
 %   loop through letters in |#1|: if it is not a letter, break the loop
 %   and return \texttt{true}.  If the end of the loop is reached
 %   without finding any non-letter, return \texttt{false}.
+%   Note |#1| must be a str (i.e., resulted from \cs{tl_to_str:n}).
 %    \begin{macrocode}
 \prg_new_protected_conditional:Npnn
     \@@_id_if_invalid:n #1 { T , F , TF }
@@ -447,10 +448,10 @@
     \tl_if_empty:nTF {#1}
       { \prg_return_true: }
       {
-        \tl_if_in:onTF { \tl_to_str:n {#1} } { ~ }
+        \tl_if_in:nnTF { #1 } { ~ }
           { \prg_return_true: }
           {
-            \exp_after:wN \@@_id_if_invalid_aux:N \tl_to_str:n {#1}
+            \@@_id_if_invalid_aux:N #1
               { ? \prg_break:n \prg_return_false: }
             \prg_break_point:
           }
@@ -547,14 +548,16 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \fp_clear_variable:n #1
   {
-    \@@_id_if_invalid:nTF {#1}
-      { \msg_error:nnn { fp } { id-invalid } {#1} }
-      { \exp_args:No \@@_clear_variable:n { \tl_to_str:n {#1} } }
+    \exp_args:No \@@_clear_variable:n { \tl_to_str:n {#1} }
   }
 \cs_new_protected:Npn \@@_clear_variable:n #1
   {
-    \cs_set_eq:cN { l_@@_variable_#1_fp } \tex_undefined:D
-    \@@_variable_set_parsing:Nn \cs_set_eq:NN {#1}
+    \@@_id_if_invalid:nTF {#1}
+      { \msg_error:nnn { fp } { id-invalid } {#1} }
+      {
+        \cs_set_eq:cN { l_@@_variable_#1_fp } \tex_undefined:D
+        \@@_variable_set_parsing:Nn \cs_set_eq:NN {#1}
+      }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -568,20 +571,22 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \fp_new_variable:n #1
   {
-    \@@_id_if_invalid:nTF {#1}
-      { \msg_error:nnn { fp } { id-invalid } {#1} }
-      { \exp_args:No \@@_new_variable:n { \tl_to_str:n {#1} } }
+    \exp_args:No \@@_new_variable:n { \tl_to_str:n {#1} }
   }
 \cs_new_protected:Npn \@@_new_variable:n #1
   {
-    \cs_if_exist:cT { @@_parse_word_#1:N }
+    \@@_id_if_invalid:nTF {#1}
+      { \msg_error:nnn { fp } { id-invalid } {#1} }
       {
-        \msg_error:nnn
-          { fp } { id-already-defined } {#1}
-        \cs_undefine:c { @@_parse_word_#1:N }
-        \cs_set_eq:cN { l_@@_variable_#1_fp } \tex_undefined:D
+        \cs_if_exist:cT { @@_parse_word_#1:N }
+        {
+          \msg_error:nnn
+            { fp } { id-already-defined } {#1}
+          \cs_undefine:c { @@_parse_word_#1:N }
+          \cs_set_eq:cN { l_@@_variable_#1_fp } \tex_undefined:D
+        }
+      \@@_variable_set_parsing:Nn \cs_gset_eq:NN {#1}
       }
-    \@@_variable_set_parsing:Nn \cs_gset_eq:NN {#1}
   }
 %    \end{macrocode}
 % \end{macro}
@@ -606,24 +611,26 @@
 \flag_new:n { @@_symbolic }
 \cs_new_protected:Npn \fp_set_variable:nn #1
   {
-    \@@_id_if_invalid:nTF {#1}
-      { \msg_error:nnn { fp } { id-invalid } {#1} }
-      { \exp_args:No \@@_set_variable:nn { \tl_to_str:n {#1} } }
+    \exp_args:No \@@_set_variable:nn { \tl_to_str:n {#1} }
   }
 \cs_new_protected:Npn \@@_set_variable:nn #1#2
   {
-    \@@_variable_set_parsing:Nn \cs_set_eq:NN {#1}
-    \fp_set:Nn \l_@@_symbolic_fp {#2}
-    \cs_set_nopar:cpn { l_@@_variable_#1_fp }
-      { \flag_ensure_raised:n { @@_symbolic } \c_nan_fp }
-    \flag_clear:n { @@_symbolic }
-    \fp_set:cn { l_@@_variable_#1_fp } { \l_@@_symbolic_fp }
-    \flag_if_raised:nT { @@_symbolic }
+    \@@_id_if_invalid:nTF {#1}
+      { \msg_error:nnn { fp } { id-invalid } {#1} }
       {
-        \msg_error:nneee { fp } { id-loop }
-          { \tl_to_str:n {#1} }
-          { \tl_to_str:n {#2} }
-          { \fp_to_tl:N \l_@@_symbolic_fp }
+        \@@_variable_set_parsing:Nn \cs_set_eq:NN {#1}
+        \fp_set:Nn \l_@@_symbolic_fp {#2}
+        \cs_set_nopar:cpn { l_@@_variable_#1_fp }
+          { \flag_ensure_raised:n { @@_symbolic } \c_nan_fp }
+        \flag_clear:n { @@_symbolic }
+        \fp_set:cn { l_@@_variable_#1_fp } { \l_@@_symbolic_fp }
+        \flag_if_raised:nT { @@_symbolic }
+          {
+            \msg_error:nneee { fp } { id-loop }
+              { #1 }
+              { \tl_to_str:n {#2} }
+              { \fp_to_tl:N \l_@@_symbolic_fp }
+          }
       }
   }
 %    \end{macrocode}

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -257,7 +257,7 @@
 %    \begin{macrocode}
 \cs_set:Npn \@@_tmp:w #1#2
   {
-    \cs_new_nopar:cpn
+    \cs_new:cpn
       { @@_symbolic_#2_symbolic_o:ww }
       { \@@_symbolic_binary_o:Nww #1 }
     \cs_new_eq:cc
@@ -313,7 +313,7 @@
     {not} {sec} {set_sign} {sin} {sqrt} {tan}
   }
   {
-    \cs_new_nopar:cpe { @@_symbolic_#1_o:w }
+    \cs_new:cpe { @@_symbolic_#1_o:w }
       {
         \exp_not:N \@@_symbolic_unary_o:NNw
         \exp_not:c { @@_#1_o:w }
@@ -336,7 +336,7 @@
 %    \begin{macrocode}
 \cs_set_protected:Npn \@@_tmp:w #1#2#3
   {
-    \cs_new_nopar:cpn { @@_symbolic_to_#1:w }
+    \cs_new:cpn { @@_symbolic_to_#1:w }
       {
         \exp_after:wN \@@_symbolic_convert:wnnN
         \exp:w \exp_end_continue_f:w
@@ -513,7 +513,7 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_variable_set_parsing:Nn #1#2
   {
-    \cs_set_nopar:Npn \@@_tmp:w
+    \cs_set:Npn \@@_tmp:w
       {
         \@@_exp_after_symbolic_f:nw { \@@_parse_infix:NN }
         \s_@@_symbolic \@@_symbolic_chk:w

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -579,7 +579,7 @@
         \msg_error:nnn
           { fp } { id-already-defined } {#1}
         \cs_undefine:c { @@_parse_word_#1:N }
-        \cs_undefine:c { l_@@_variable_#1_fp }
+        \cs_set_eq:cN { l_@@_variable_#1_fp } \tex_undefined:D
       }
     \@@_variable_set_parsing:Nn \cs_gset_eq:NN {#1}
   }

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -542,9 +542,14 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\fp_clear_variable:n}
-% \begin{macro}{\@@_clear_variable:n}
+% \begin{macro}
+%   {
+%     \fp_clear_variable:n, \@@_clear_variable:n, 
+%     \@@_clear_variable_aux:n
+%   }
 %   We need local undefining, so have to do it low-level.
+%   \cs{@@_clear_variable_aux:n} is needed by \cs{@@_set_function:Nnnn}
+%   to skip \cs{@@_id_if_invalid:nTF}.
 %    \begin{macrocode}
 \cs_new_protected:Npn \fp_clear_variable:n #1
   {
@@ -554,13 +559,14 @@
   {
     \@@_id_if_invalid:nTF {#1}
       { \msg_error:nnn { fp } { id-invalid } {#1} }
-      {
-        \cs_set_eq:cN { l_@@_variable_#1_fp } \tex_undefined:D
-        \@@_variable_set_parsing:Nn \cs_set_eq:NN {#1}
-      }
+      { \@@_clear_variable_aux:n {#1} }
+  }
+\cs_new_protected:Npn \@@_clear_variable_aux:n #1
+  {
+    \cs_set_eq:cN { l_@@_variable_#1_fp } \tex_undefined:D
+    \@@_variable_set_parsing:Nn \cs_set_eq:NN {#1}
   }
 %    \end{macrocode}
-% \end{macro}
 % \end{macro}
 %
 % \begin{macro}{\fp_new_variable:n}

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -768,7 +768,8 @@
 %   \end{syntax}
 %   Defines the \meta{identifier} to stand in any further expression for
 %   the result of evaluating the \meta{floating point expression}, with
-%   the \meta{identifier} accepting the \meta{vars} (a comma list).
+%   the \meta{identifier} accepting the \meta{vars} (a non-empty
+%   comma-separated list).
 %   The result may contain other functions, which are
 %   then replaced by their results if they have any.  For instance,
 %   \begin{quote}

--- a/l3kernel/testfiles/m3fp-symbolic001.luatex.tlg
+++ b/l3kernel/testfiles/m3fp-symbolic001.luatex.tlg
@@ -142,12 +142,14 @@ contains 'Y' itself.
 l. ...  }
 ============================================================
 ============================================================
-TEST 6: Intermixing variables and functions
+TEST 6: Set and clear both acts locally
 ============================================================
-Defining \__fp_parse_word_E:N on line ...
-Defining \__fp_parse_word_PS:N on line ...
-Defining \__fp_parse_word__i:N on line ...
-> E**2+PS(3)=31.
-<recently read> }
-l. ...  }
+Defining \__fp_parse_word_P:N on line ...
+((P)*(P))+(1)
+401
+((P)*(P))+(1)
+401
+((P)*(P))+(1)
+401
+((P)*(P))+(1)
 ============================================================

--- a/l3kernel/testfiles/m3fp-symbolic001.lvt
+++ b/l3kernel/testfiles/m3fp-symbolic001.lvt
@@ -84,13 +84,30 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST { Intermixing~variables~and~functions }
+\TEST { Set~and~clear~both~acts~locally }
   {
-    \fp_new_variable:n { E }
-    \fp_new_function:n { PS }
-    \fp_set_variable:nn { E } { 2 }
-    \fp_set_function:nnn { PS } { E } { E**E }
-    \fp_show:n { E**2 + PS(3) }
+    \OMIT
+    \cs_set:Npn \test_temp:
+      { \TYPE { \fp_to_tl:n { P*P + 1 } } }
+    \TIMO
+    \fp_new_variable:n { P }
+    \test_temp: % symbolic
+
+    \group_begin:
+      \fp_set_variable:nn { P } { 20 }
+      \test_temp: % numeric
+    \group_end:
+    \test_temp: % symbolic
+    \fp_set_variable:nn { P } { 20 }
+    \test_temp: % numeric
+
+    \group_begin:
+      \fp_clear_variable:n { P }
+      \test_temp: % symbolic
+    \group_end:
+    \test_temp: % numeric
+    \fp_clear_variable:n { P }
+    \test_temp: % symbolic
   }
 
 \END

--- a/l3kernel/testfiles/m3fp-symbolic002.luatex.tlg
+++ b/l3kernel/testfiles/m3fp-symbolic002.luatex.tlg
@@ -1,24 +1,36 @@
 This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
-Author: Bruno Le Floch
+Author: Yukai Chou
 ============================================================
-TEST 1: Assign a symbolic expression
+TEST 1: Functions in symbolic expression
 ============================================================
 Defining \__fp_parse_word_A:N on line ...
 Defining \__fp_parse_word_B:N on line ...
 Defining \__fp_parse_word_C:N on line ...
-((A)+(csc(B)))+((C)*(sin(B)))
-((A)+(csc(B)))+((C)*(sin(B)))
-((A)+(2))+((C)*(0.4999999999999999))
-((A)+(2))+(0.5999999999999999)
-3.6
+((A(3))+(B(3.141592653589793, 3)))+((C(0, 0, 0.2))*(B(3.141592653589793, 6)))
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_j:N on line ...
+((A(3))+(B(3.141592653589793, 3)))+((C(0, 0, 0.2))*(B(3.141592653589793, 6)))
+((A(3))+(1.047197551196598))+((C(0, 0, 0.2))*(0.5235987755982988))
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_j:N on line ...
+Defining \__fp_parse_word__iii:N on line ...
+Defining \__fp_parse_word_k:N on line ...
+((A(3))+(1.047197551196598))+(-1.047197551196598)
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+3
 ============================================================
 ============================================================
 TEST 2: Conversions
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Invalid operation fp_to_decimal((A)+((B)^(2)))
+      ! LaTeX Error: Invalid operation fp_to_decimal((A(1))+((B(1, 2))^(2)))
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -26,7 +38,7 @@ made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Invalid operation fp_to_dim((A)+((B)^(2)))
+      ! LaTeX Error: Invalid operation fp_to_dim((A(1))+((B(1, 2))^(2)))
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -34,7 +46,7 @@ made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Invalid operation fp_to_int((A)+((B)^(2)))
+      ! LaTeX Error: Invalid operation fp_to_int((A(1))+((B(1, 2))^(2)))
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -42,7 +54,7 @@ made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Invalid operation fp_to_scientific((A)+((B)^...
+      ! LaTeX Error: Invalid operation fp_to_scientific((A(1))+((B(1, 2))^(2)))
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -52,16 +64,16 @@ followed by the required stuff, so I'm ignoring it.
 0pt
 0
 nan
-(A)+((B)^(2))
+(A(1))+((B(1, 2))^(2))
 ============================================================
 ============================================================
 TEST 3: Unary minus and not
 ============================================================
--((A)+((B)^(2)))
-!((A)+((B)^(2)))
+-((A(1))+((B(1, 2))^(2)))
+!((A(1))+((B(1, 2))^(2)))
 ============================================================
 ============================================================
-TEST 4: Various variable names
+TEST 4: Various function names
 ============================================================
 ! LaTeX Error: Floating point identifier '' invalid.
 For immediate help type H <return>.
@@ -110,46 +122,54 @@ l. ...  }
 LaTeX has been asked to create a new floating point identifier 'inf' but this
 name has already been used elsewhere.
 Defining \__fp_parse_word_inf:N on line ...
-(((((1)/(inf))+(pi))+(tmpa))+(aux))+(chk)
+(((1)/(inf(pi(tmpa(1)))))+(aux(-1)))+(chk(1))
 ============================================================
 ============================================================
-TEST 5: Loops
+TEST 5: Function parameters are created locally
 ============================================================
-Defining \__fp_parse_word_X:N on line ...
-Defining \__fp_parse_word_Y:N on line ...
-! LaTeX Error: Variable 'X' used in the definition of 'X'.
-For immediate help type H <return>.
- ...                                              
+Defining \__fp_parse_word_FUNCA:N on line ...
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_a:N on line ...
+! Use of \??? doesn't match its definition.
+<argument> \???  
+      ! LaTeX Error: Unknown fp word a.
 l. ...  }
-LaTeX has been asked to set the floating point identifier 'X' to the
-expression 'sin(X)'. Evaluating this expression yields 'sin(X)', which
-contains 'X' itself.
-> X=nan.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
+nan
+Defining \__fp_parse_word_a:N on line ...
+(a)+(10)
+42
+============================================================
+============================================================
+TEST 6: Function parameters are cleared locally
+============================================================
+Defining \__fp_parse_word_E:N on line ...
+Defining \__fp_parse_word_PS:N on line ...
+Defining \__fp_parse_word__i:N on line ...
+> E**2+PS(3)=31.
 <recently read> }
 l. ...  }
-> X=(Y)^(1).
-<recently read> }
-l. ...  }
-! LaTeX Error: Variable 'Y' used in the definition of 'Y'.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-LaTeX has been asked to set the floating point identifier 'Y' to the
-expression 'X+1'. Evaluating this expression yields '((Y)^(1))+(1)', which
-contains 'Y' itself.
-> Y=nan.
-<recently read> }
-l. ...  }
 ============================================================
 ============================================================
-TEST 6: Set and clear both acts locally
+TEST 7: Set and clear both act locally
 ============================================================
-Defining \__fp_parse_word_P:N on line ...
-((P)*(P))+(1)
-401
-((P)*(P))+(1)
-401
-((P)*(P))+(1)
-401
-((P)*(P))+(1)
+Defining \__fp_parse_word_FUNCP:N on line ...
+((FUNCP(3, 4))*(10))-(7)
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_j:N on line ...
+243
+((FUNCP(3, 4))*(10))-(7)
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_j:N on line ...
+243
+((FUNCP(3, 4))*(10))-(7)
+243
+((FUNCP(3, 4))*(10))-(7)
 ============================================================

--- a/l3kernel/testfiles/m3fp-symbolic002.lvt
+++ b/l3kernel/testfiles/m3fp-symbolic002.lvt
@@ -1,0 +1,144 @@
+%
+% Copyright (C) The LaTeX Project
+%
+
+\documentclass{minimal}
+\input{regression-test}
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation , log-functions }
+\ExplSyntaxOff
+
+\begin{document}
+\START
+\AUTHOR{Yukai Chou}
+\ExplSyntaxOn
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { Functions~in~symbolic~expression }
+  {
+    \fp_new_function:n { A }
+    \fp_new_function:n { B }
+    \fp_new_function:n { C }
+    % wired fp-expr :)
+    \fp_set:Nn \l_tmpa_fp { A(3) + B(pi, 3) + C(0,0,.2) * B(pi, 6) }
+    \TYPE { \fp_to_tl:N \l_tmpa_fp } % symbolic
+    \fp_set_function:nnn { B } { i, j } { i/j }
+    \TYPE { \fp_to_tl:N \l_tmpa_fp } % symbolic
+    \TYPE { \fp_to_tl:n { \l_tmpa_fp } } % symbolic, B(pi, 3) evaluated
+    \fp_set_function:nnn { C } { i, j, k } { k * -10 }
+    \TYPE { \fp_to_tl:n { \l_tmpa_fp } } % symbolic, B & C evaluated
+    \fp_set_function:nnn { A } { i } { sqrt(i * i) }
+    \TYPE { \fp_to_tl:n { \l_tmpa_fp } } % numeric
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\TESTEXP { Conversions }
+  {
+    \fp_to_decimal:n { A(1) + B(1,2)**2 } \NEWLINE
+    \fp_to_dim:n { A(1) + B(1,2)**2 } \NEWLINE
+    \fp_to_int:n { A(1) + B(1,2)**2 } \NEWLINE
+    \fp_to_scientific:n { A(1) + B(1,2)**2 } \NEWLINE
+    % the only one that works with a symbolic result
+    \fp_to_tl:n { A(1) + B(1,2)**2 } \NEWLINE
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TESTEXP { Unary~minus~and~not }
+  {
+    \fp_to_tl:n { - (A(1) + B(1,2)**2) } \NEWLINE
+    \fp_to_tl:n { ! (A(1) + B(1,2)**2) } \NEWLINE
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { Various~function~names }
+  {
+    \fp_new_function:n { }
+    \fp_new_function:n { a ~ b }
+    \fp_new_function:n { a12 }
+    \fp_new_function:n { \\ }
+    \fp_new_function:n { a_b }
+    \fp_new_function:n { chk } % works
+    \fp_new_function:n { aux } % works
+    \fp_new_function:n { tmpa } % works
+    \fp_new_function:n { pi }
+    \fp_new_function:n { inf }
+    \iow_term:x { \fp_to_tl:n { 1 / inf + pi + tmpa(1) + aux(-1) + chk(+1) } }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+% !TODO not supported yet
+% \TEST { Loops }
+%   {
+%     \fp_new_function:n { X }
+%     \fp_new_function:n { Y }
+%     \fp_set_function:nnn { X } { x } { sin(X(x)) }
+%     \fp_show:n { X(1.1) }
+%     \fp_set_function:nnn { X } { x } { 1 }
+%     \fp_set_function:nnn { X } { x } { Y(x)**X(x) }
+%     \fp_show:n { X }
+%     \fp_set_function:nnn { Y } { y } { X(y) + 1 }
+%     \fp_show:n { Y }
+%   }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { Function~parameters~are~created~locally }
+  {
+    \OMIT
+    \cs_set:Npn \test_temp:
+      { \TYPE { \fp_to_tl:n { a + FUNCA(1) } } }
+    \TIMO
+    \fp_new_function:n { FUNCA }
+    \fp_set_function:nnn { FUNCA } { a } { a * 10 }
+    \test_temp: % error, unknown fp word "a"
+    \fp_new_variable:n { a }
+    \test_temp: % symbolic, FUNCA(1) evaluated to 10
+    \fp_set_variable:nn { a } { 32 }
+    \test_temp: % numeric, 42
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { Function~parameters~are~cleared~locally }
+  {
+    \fp_new_variable:n { E }
+    \fp_new_function:n { PS }
+    \fp_set_variable:nn { E } { 2 }
+    \fp_set_function:nnn { PS } { E } { E**E }
+    \fp_show:n { E**2 + PS(3) } % numeric
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { Set~and~clear~both~act~locally }
+  {
+    \OMIT
+    \cs_set:Npn \test_temp:
+      { \TYPE { \fp_to_tl:n { FUNCP(3, 4) * 10 - 7 } } }
+    \TIMO
+    \fp_new_function:n { FUNCP }
+    \test_temp: % symbolic
+
+    \group_begin:
+      \fp_set_function:nnn { FUNCP } { i, j } { i*i + j*j }
+      \test_temp: % numeric
+    \group_end:
+    \test_temp: % symbolic
+    \fp_set_function:nnn { FUNCP } { i, j } { i*i + j*j }
+    \test_temp: % numeric
+
+    \group_begin:
+      \fp_clear_function:n { FUNCP }
+      \test_temp: % symbolic
+    \group_end:
+    \test_temp: % numeric
+    \fp_clear_function:n { FUNCP }
+    \test_temp: % symbolic
+  }
+
+\END

--- a/l3kernel/testfiles/m3fp-symbolic002.tlg
+++ b/l3kernel/testfiles/m3fp-symbolic002.tlg
@@ -1,24 +1,36 @@
 This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
-Author: Bruno Le Floch
+Author: Yukai Chou
 ============================================================
-TEST 1: Assign a symbolic expression
+TEST 1: Functions in symbolic expression
 ============================================================
 Defining \__fp_parse_word_A:N on line ...
 Defining \__fp_parse_word_B:N on line ...
 Defining \__fp_parse_word_C:N on line ...
-((A)+(csc(B)))+((C)*(sin(B)))
-((A)+(csc(B)))+((C)*(sin(B)))
-((A)+(2))+((C)*(0.4999999999999999))
-((A)+(2))+(0.5999999999999999)
-3.6
+((A(3))+(B(3.141592653589793, 3)))+((C(0, 0, 0.2))*(B(3.141592653589793, 6)))
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_j:N on line ...
+((A(3))+(B(3.141592653589793, 3)))+((C(0, 0, 0.2))*(B(3.141592653589793, 6)))
+((A(3))+(1.047197551196598))+((C(0, 0, 0.2))*(0.5235987755982988))
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_j:N on line ...
+Defining \__fp_parse_word__iii:N on line ...
+Defining \__fp_parse_word_k:N on line ...
+((A(3))+(1.047197551196598))+(-1.047197551196598)
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+3
 ============================================================
 ============================================================
 TEST 2: Conversions
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Invalid operation fp_to_decimal((A)+((B)^(2)))
+                 ! LaTeX Error: Invalid operation fp_to_decimal((A(1))+((B(1...
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -26,7 +38,7 @@ made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Invalid operation fp_to_dim((A)+((B)^(2)))
+                 ! LaTeX Error: Invalid operation fp_to_dim((A(1))+((B(1, 2)...
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -34,7 +46,7 @@ made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Invalid operation fp_to_int((A)+((B)^(2)))
+                 ! LaTeX Error: Invalid operation fp_to_int((A(1))+((B(1, 2)...
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -42,7 +54,7 @@ made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Invalid operation fp_to_scientific((A)+((B)^...
+                 ! LaTeX Error: Invalid operation fp_to_scientific((A(1))+((...
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -52,16 +64,16 @@ followed by the required stuff, so I'm ignoring it.
 0pt
 0
 nan
-(A)+((B)^(2))
+(A(1))+((B(1, 2))^(2))
 ============================================================
 ============================================================
 TEST 3: Unary minus and not
 ============================================================
--((A)+((B)^(2)))
-!((A)+((B)^(2)))
+-((A(1))+((B(1, 2))^(2)))
+!((A(1))+((B(1, 2))^(2)))
 ============================================================
 ============================================================
-TEST 4: Various variable names
+TEST 4: Various function names
 ============================================================
 ! LaTeX Error: Floating point identifier '' invalid.
 For immediate help type H <return>.
@@ -110,46 +122,54 @@ l. ...  }
 LaTeX has been asked to create a new floating point identifier 'inf' but this
 name has already been used elsewhere.
 Defining \__fp_parse_word_inf:N on line ...
-(((((1)/(inf))+(pi))+(tmpa))+(aux))+(chk)
+(((1)/(inf(pi(tmpa(1)))))+(aux(-1)))+(chk(1))
 ============================================================
 ============================================================
-TEST 5: Loops
+TEST 5: Function parameters are created locally
 ============================================================
-Defining \__fp_parse_word_X:N on line ...
-Defining \__fp_parse_word_Y:N on line ...
-! LaTeX Error: Variable 'X' used in the definition of 'X'.
-For immediate help type H <return>.
- ...                                              
+Defining \__fp_parse_word_FUNCA:N on line ...
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_a:N on line ...
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Unknown fp word a.
 l. ...  }
-LaTeX has been asked to set the floating point identifier 'X' to the
-expression 'sin(X)'. Evaluating this expression yields 'sin(X)', which
-contains 'X' itself.
-> X=nan.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
+nan
+Defining \__fp_parse_word_a:N on line ...
+(a)+(10)
+42
+============================================================
+============================================================
+TEST 6: Function parameters are cleared locally
+============================================================
+Defining \__fp_parse_word_E:N on line ...
+Defining \__fp_parse_word_PS:N on line ...
+Defining \__fp_parse_word__i:N on line ...
+> E**2+PS(3)=31.
 <recently read> }
 l. ...  }
-> X=(Y)^(1).
-<recently read> }
-l. ...  }
-! LaTeX Error: Variable 'Y' used in the definition of 'Y'.
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-LaTeX has been asked to set the floating point identifier 'Y' to the
-expression 'X+1'. Evaluating this expression yields '((Y)^(1))+(1)', which
-contains 'Y' itself.
-> Y=nan.
-<recently read> }
-l. ...  }
 ============================================================
 ============================================================
-TEST 6: Set and clear both acts locally
+TEST 7: Set and clear both act locally
 ============================================================
-Defining \__fp_parse_word_P:N on line ...
-((P)*(P))+(1)
-401
-((P)*(P))+(1)
-401
-((P)*(P))+(1)
-401
-((P)*(P))+(1)
+Defining \__fp_parse_word_FUNCP:N on line ...
+((FUNCP(3, 4))*(10))-(7)
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_j:N on line ...
+243
+((FUNCP(3, 4))*(10))-(7)
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_i:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_j:N on line ...
+243
+((FUNCP(3, 4))*(10))-(7)
+243
+((FUNCP(3, 4))*(10))-(7)
 ============================================================


### PR DESCRIPTION
I'd like to recheck content of new `m3fp-symbolic002.tlg` file before merging.