### PR TITLE
Adapt doc for `\seq_set_map_e:NNn` and `\seq_gset_map_e:NNn`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -8,7 +8,7 @@ this project uses date-based 'snapshot' version identifiers.
 ## [Unreleased]
 
 ### Added
-- `\seq_set_map_e:NNn`
+- `\seq_(g)set_map_e:NNn`
 - Documentation for `\ExplLoaderFileDate` in `expl3.pdf`
 
 ### Changed

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -740,15 +740,15 @@
 %   \end{texnote}
 % \end{function}
 %
-% \begin{function}[added = 2020-07-16]
-%   {\seq_set_map_x:NNn, \seq_gset_map_x:NNn}
+% \begin{function}[added = 2020-07-16, updated = 2023-10-26]
+%   {\seq_set_map_e:NNn, \seq_gset_map_e:NNn}
 %   \begin{syntax}
-%     \cs{seq_set_map_x:NNn} \meta{seq~var_1} \meta{seq~var_2} \Arg{inline function}
+%     \cs{seq_set_map_e:NNn} \meta{seq~var_1} \meta{seq~var_2} \Arg{inline function}
 %   \end{syntax}
 %   Applies \meta{inline function} to every \meta{item} stored
 %   within the \meta{seq~var_2}. The \meta{inline function} should
 %   consist of code which will receive the \meta{item} as |#1|.
-%   The sequence resulting from \texttt{x}-expanding
+%   The sequence resulting from \texttt{e}-expanding
 %   \meta{inline function} applied to each \meta{item}
 %   is assigned to \meta{seq~var_1}. As such, the code
 %   in \meta{inline function} should be expandable.
@@ -2411,7 +2411,7 @@
 %
 % \begin{macro}{\seq_set_map:NNn, \seq_gset_map:NNn}
 % \begin{macro}{\@@_set_map:NNNn}
-%   Similar to \cs{seq_set_map_x:NNn}, but prevents expansion of the
+%   Similar to \cs{seq_set_map_e:NNn}, but prevents expansion of the
 %   <inline function>.
 %    \begin{macrocode}
 \cs_new_protected:Npn \seq_set_map:NNn


### PR DESCRIPTION
This is the missing doc part of commit 69b7c6fd0 (Deprecate \seq_(g)set_map_x:NNn, 2023-10-26).