### PR TITLE
Support for `\fp_show:N` showing symbolic expressions

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -26,6 +26,7 @@ this project uses date-based 'snapshot' version identifiers.
 - `\fp_clear_variable:n` should act locally (issue \#1298)
 - `\fp_clear_function:n` should act locally and correctly
 - Support for `\fp_show:N` showing symbolic expressions (issue \#1301)
+- Undefined `\str_case:en(TF)` (excluding `\str_case:en`)
 
 ## [2023-10-23]
 

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -25,6 +25,7 @@ this project uses date-based 'snapshot' version identifiers.
 ### Fixed
 - `\fp_clear_variable:n` should act locally (issue \#1298)
 - `\fp_clear_function:n` should act locally and correctly
+- Support for `\fp_show:N` showing symbolic expressions (issue \#1301)
 
 ## [2023-10-23]
 

--- a/l3kernel/l3fp-assign.dtx
+++ b/l3kernel/l3fp-assign.dtx
@@ -165,7 +165,6 @@
 % \subsection{Showing values}
 %
 % \begin{macro}{\fp_show:N, \fp_show:c, \fp_log:N, \fp_log:c, \@@_show:NN}
-% \begin{macro}[EXP]{\@@_show_validate:w}
 %   This shows the result of computing its argument by
 %   passing the right data to \cs{tl_show:n} or \cs{tl_log:n}.
 %    \begin{macrocode}
@@ -176,24 +175,73 @@
 \cs_new_protected:Npn \@@_show:NN #1#2
   {
     \__kernel_chk_tl_type:NnnT #2 { fp }
+      { \exp_args:No \@@_show_validate:n #2 }
+      { \exp_args:Ne #1 { \token_to_str:N #2 = \fp_to_tl:N #2 } }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]
+%   {
+%     \@@_show_validate:n,
+%     \@@_show_validate:w,
+%     \@@_tuple_show_validate:w,
+%     \@@_symbolic_show_validate:w
+%   }
+%   To support symbolic expression, validation has to be done recursively.
+%    \begin{macrocode}
+\cs_new:Npn \@@_show_validate:n #1
+  {
+    \tl_if_empty:nF { #1 }
       {
-        \str_if_eq:eeTF { \tl_head:N #2 } { \s_@@_tuple } { \exp_not:o #2 }
+        \str_case:enF { \tl_head:n { #1 } }
           {
-            \exp_after:wN \@@_show_validate:w #2
-            \s_@@ \@@_chk:w ??? ; \s_@@_stop
+            { \s_@@ }
+              {
+                \@@_show_validate:w #1 \s_@@
+                \@@_chk:w ??? ; \s_@@_stop
+              }
+            { \s_@@_tuple }
+              {
+                \@@_tuple_show_validate:w #1
+                \s_@@_tuple \_@@_tuple_chk:w ?? ; \s_@@_stop
+              }
+            { \s_@@_symbolic }
+              {
+                \@@_symbolic_show_validate:w #1
+                \s_@@_symbolic \@@_symbolic_chk:w ? , ?? ; \s_@@_stop
+              }
           }
       }
-      { \exp_args:Ne #1 { \token_to_str:N #2 = \fp_to_tl:N #2 } }
   }
 \cs_new:Npn \@@_show_validate:w
     #1 \s_@@ \@@_chk:w #2#3#4#5 ; #6 \s_@@_stop
   {
-    \token_if_eq_meaning:NNTF #2 1
-      { \s_@@ \@@_chk:w #2 #3 {#4} #5 ; }
-      { \s_@@ \@@_chk:w #2 #3 #4 #5 ; }
+    \str_if_eq:nnF { #2 } {?}
+      {
+        \token_if_eq_meaning:NNTF #2 1
+          { \s_@@ \@@_chk:w #2 #3 { #4 } #5 ; }
+          { \s_@@ \@@_chk:w #2 #3 #4 #5 ; }
+        \@@_show_validate:n { #6 }
+      }
+  }
+\cs_new:Npn \@@_tuple_show_validate:w
+    #1 \s_@@_tuple \_@@_tuple_chk:w #2#3 ; #4 \s_@@_stop
+  {
+    \str_if_eq:nnF { #2 } {?}
+      { \s_@@_tuple \@@_tuple_chk:w { \@@_show_validate:n { #2 } } ; }
+  }
+\cs_new:Npn \@@_symbolic_show_validate:w
+    #1 \s_@@_symbolic \@@_symbolic_chk:w #2 , #3#4 ; #5 \s_@@_stop
+  {
+    \str_if_eq:nnF { #2 } {?}
+      {
+        \s_@@_symbolic \@@_symbolic_chk:w \exp_not:n { #2 } ,
+        { \@@_show_validate:n { #3 } };
+        \@@_show_validate:n { #5 }
+      }
   }
 %    \end{macrocode}
-% \end{macro}
 % \end{macro}
 %
 % \begin{macro}{\fp_show:n, \fp_log:n}

--- a/l3kernel/l3fp-assign.dtx
+++ b/l3kernel/l3fp-assign.dtx
@@ -183,14 +183,33 @@
 %
 % \begin{macro}[EXP]
 %   {
-%     \@@_show_validate:n,
+%     \@@_show_validate:n, \@@_show_validate_aux:n, \@@_show_validate:nn,
+%   }
+% \begin{macro}[EXP]
+%   {
 %     \@@_show_validate:w,
 %     \@@_tuple_show_validate:w,
 %     \@@_symbolic_show_validate:w
 %   }
 %   To support symbolic expression, validation has to be done recursively.
+%   Two |\@@_show_validate:nn| wrappers are used to distinguish between
+%   initial and recursive calls, in which the former provides a demo of
+%   possible forms a |fp| variable would have.
 %    \begin{macrocode}
 \cs_new:Npn \@@_show_validate:n #1
+  {
+    \@@_show_validate:nn { #1 }
+      {
+        \s_@@ \@@_chk:w ??? ;~ or \iow_newline:
+        \s_@@_tuple \_@@_tuple_chk:w ? ;~ or \iow_newline:
+        \s_@@_symbolic \@@_symbolic_chk:w ? , ? ;
+      }
+  }
+\cs_new:Npn \@@_show_validate_aux:n #1
+  {
+    \@@_show_validate:nn { #1 } { }
+  }
+\cs_new:Npn \@@_show_validate:nn #1#2
   {
     \tl_if_empty:nF { #1 }
       {
@@ -212,6 +231,7 @@
                 \s_@@_symbolic \@@_symbolic_chk:w ? , ?? ; \s_@@_stop
               }
           }
+          { #2 }
       }
   }
 \cs_new:Npn \@@_show_validate:w
@@ -222,14 +242,14 @@
         \token_if_eq_meaning:NNTF #2 1
           { \s_@@ \@@_chk:w #2 #3 { #4 } #5 ; }
           { \s_@@ \@@_chk:w #2 #3 #4 #5 ; }
-        \@@_show_validate:n { #6 }
+        \@@_show_validate_aux:n { #6 }
       }
   }
 \cs_new:Npn \@@_tuple_show_validate:w
     #1 \s_@@_tuple \_@@_tuple_chk:w #2#3 ; #4 \s_@@_stop
   {
     \str_if_eq:nnF { #2 } {?}
-      { \s_@@_tuple \@@_tuple_chk:w { \@@_show_validate:n { #2 } } ; }
+      { \s_@@_tuple \@@_tuple_chk:w { \@@_show_validate_aux:n { #2 } } ; }
   }
 \cs_new:Npn \@@_symbolic_show_validate:w
     #1 \s_@@_symbolic \@@_symbolic_chk:w #2 , #3#4 ; #5 \s_@@_stop
@@ -237,11 +257,12 @@
     \str_if_eq:nnF { #2 } {?}
       {
         \s_@@_symbolic \@@_symbolic_chk:w \exp_not:n { #2 } ,
-        { \@@_show_validate:n { #3 } };
-        \@@_show_validate:n { #5 }
+        { \@@_show_validate_aux:n { #3 } };
+        \@@_show_validate_aux:n { #5 }
       }
   }
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 % \begin{macro}{\fp_show:n, \fp_log:n}

--- a/l3kernel/l3fp-functions.dtx
+++ b/l3kernel/l3fp-functions.dtx
@@ -91,12 +91,12 @@
 % \begin{macro}
 %   {\@@_function_set_parsing:Nn, \@@_function_set_parsing_aux:NNn}
 %    \begin{macrocode}
-\cs_new:Npn \@@_function_set_parsing:Nn #1#2
+\cs_new_protected:Npn \@@_function_set_parsing:Nn #1#2
   {
     \exp_args:NNc \@@_function_set_parsing_aux:NNn #1
       { @@_parse_word_#2:N } {#2}
   }
-\cs_new:Npn \@@_function_set_parsing_aux:NNn #1#2#3
+\cs_new_protected:Npn \@@_function_set_parsing_aux:NNn #1#2#3
   {
     \cs_set:Npe \@@_tmp:w
       {

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -157,8 +157,8 @@
 % \begin{macro}[EXP]
 %   {\@@_if_has_symbolic:nTF, \@@_if_has_symbolic_aux:w}
 %   Tests if |#1| contains \cs{s_@@_symbolic} at top-level.  This test
-%   should be precise enough to determine if a given an array contains a
-%   symbolic expression or only consists in floating points.  Used in
+%   should be precise enough to determine if a given array contains a
+%   symbolic expression or only consists of floating points.  Used in
 %   \cs{@@_exp_after_symbolic_f:nw}.
 %    \begin{macrocode}
 \cs_new:Npn \@@_if_has_symbolic:nTF #1
@@ -277,7 +277,7 @@
 %
 % \subsection{Applying prefix functions to expressions}
 %
-% \begin{macro}[aux, EXP]{\@@_symbolic_unary_o:NNw}
+% \begin{macro}[EXP]{\@@_symbolic_unary_o:NNw}
 %   Used when applying infix operators to expressions.
 %    \begin{macrocode}
 \cs_new:Npn \@@_symbolic_unary_o:NNw #1#2#3; @
@@ -384,7 +384,8 @@
 % \begin{macro}[rEXP]
 %   {
 %     \@@_symbolic_unary_to_tl:NNw,
-%     \@@_symbolic_binary_to_tl:Nww
+%     \@@_symbolic_binary_to_tl:Nww,
+%     \@@_symbolic_function_to_tl:Nw
 %   }
 %   Converting a symbolic expression to a token list is possible.
 %    \begin{macrocode}
@@ -544,8 +545,8 @@
 %
 % \begin{macro}
 %   {
-%     \fp_clear_variable:n, \@@_clear_variable:n, 
-%     \@@_clear_variable_aux:n
+%     \fp_clear_variable:n,
+%     \@@_clear_variable:n, \@@_clear_variable_aux:n
 %   }
 %   We need local undefining, so have to do it low-level.
 %   \cs{@@_clear_variable_aux:n} is needed by \cs{@@_set_function:Nnnn}

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -255,7 +255,7 @@
 %     \@@_&_symbolic_o:ww,
 %   }
 %    \begin{macrocode}
-\cs_set:Npn \@@_tmp:w #1#2
+\cs_set_protected:Npn \@@_tmp:w #1#2
   {
     \cs_new:cpn
       { @@_symbolic_#2_symbolic_o:ww }
@@ -512,7 +512,7 @@
 % \begin{macro}
 %   {\@@_variable_set_parsing:Nn, \@@_variable_set_parsing_aux:NNn}
 %    \begin{macrocode}
-\cs_new:Npn \@@_variable_set_parsing:Nn #1#2
+\cs_new_protected:Npn \@@_variable_set_parsing:Nn #1#2
   {
     \cs_set:Npn \@@_tmp:w
       {
@@ -523,7 +523,7 @@
     \exp_args:NNc \@@_variable_set_parsing_aux:NNn #1
       { @@_parse_word_#2:N } {#2}
   }
-\cs_new:Npn \@@_variable_set_parsing_aux:NNn #1#2#3
+\cs_new_protected:Npn \@@_variable_set_parsing_aux:NNn #1#2#3
   {
     \cs_if_eq:NNF #2 \@@_tmp:w
       {

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -1266,7 +1266,7 @@
   { \@@_case:nw {#1} #2 {#1} { } \s_@@_mark {#3} \s_@@_mark {#4} \s_@@_stop }
 \cs_generate_variant:Nn \str_case:nn   { V , o , e , nV , nv }
 \prg_generate_conditional_variant:Nnn \str_case:nn
-  { V , o , nV , nv } { T , F , TF }
+  { V , o , e , nV , nv } { T , F , TF }
 \cs_new_eq:NN \str_case:Nn   \str_case:Vn
 \cs_new_eq:NN \str_case:NnT  \str_case:VnT
 \cs_new_eq:NN \str_case:NnF  \str_case:VnF

--- a/l3kernel/testfiles/m3fp-symbolic001.luatex.tlg
+++ b/l3kernel/testfiles/m3fp-symbolic001.luatex.tlg
@@ -7,8 +7,12 @@ TEST 1: Assign a symbolic expression
 Defining \__fp_parse_word_A:N on line ...
 Defining \__fp_parse_word_B:N on line ...
 Defining \__fp_parse_word_C:N on line ...
-((A)+(csc(B)))+((C)*(sin(B)))
-((A)+(csc(B)))+((C)*(sin(B)))
+> \l_tmpa_fp=((A)+(csc(B)))+((C)*(sin(B))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=((A)+(csc(B)))+((C)*(sin(B))).
+<recently read> }
+l. ...  }
 ((A)+(2))+((C)*(0.4999999999999999))
 ((A)+(2))+(0.5999999999999999)
 3.6

--- a/l3kernel/testfiles/m3fp-symbolic001.lvt
+++ b/l3kernel/testfiles/m3fp-symbolic001.lvt
@@ -22,9 +22,9 @@
     \fp_new_variable:n { B }
     \fp_new_variable:n { C }
     \fp_set:Nn \l_tmpa_fp { A + csc(B) + C * sin(B) }
-    \TYPE { \fp_to_tl:N \l_tmpa_fp }
+    \fp_show:N \l_tmpa_fp
     \fp_set_variable:nn { B } { pi/6 }
-    \TYPE { \fp_to_tl:N \l_tmpa_fp }
+    \fp_show:N \l_tmpa_fp
     \TYPE { \fp_to_tl:n { \l_tmpa_fp } }
     \fp_set_variable:nn { C } { 1.2 }
     \TYPE { \fp_to_tl:n { \l_tmpa_fp } }
@@ -33,6 +33,7 @@
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \TESTEXP { Conversions }
   {
     \fp_to_decimal:n { A + B**2 } \NEWLINE
@@ -87,7 +88,7 @@
 \TEST { Set~and~clear~both~acts~locally }
   {
     \OMIT
-    \cs_set:Npn \test_temp:
+    \cs_set_protected:Npn \test_temp:
       { \TYPE { \fp_to_tl:n { P*P + 1 } } }
     \TIMO
     \fp_new_variable:n { P }

--- a/l3kernel/testfiles/m3fp-symbolic001.lvt
+++ b/l3kernel/testfiles/m3fp-symbolic001.lvt
@@ -65,7 +65,7 @@
     \fp_new_variable:n { tmpa }
     \fp_new_variable:n { pi }
     \fp_new_variable:n { inf }
-    \iow_term:x { \fp_to_tl:n { 1 / inf + pi + tmpa + aux + chk } }
+    \TYPE { \fp_to_tl:n { 1 / inf + pi + tmpa + aux + chk } }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3fp-symbolic001.tlg
+++ b/l3kernel/testfiles/m3fp-symbolic001.tlg
@@ -7,8 +7,12 @@ TEST 1: Assign a symbolic expression
 Defining \__fp_parse_word_A:N on line ...
 Defining \__fp_parse_word_B:N on line ...
 Defining \__fp_parse_word_C:N on line ...
-((A)+(csc(B)))+((C)*(sin(B)))
-((A)+(csc(B)))+((C)*(sin(B)))
+> \l_tmpa_fp=((A)+(csc(B)))+((C)*(sin(B))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=((A)+(csc(B)))+((C)*(sin(B))).
+<recently read> }
+l. ...  }
 ((A)+(2))+((C)*(0.4999999999999999))
 ((A)+(2))+(0.5999999999999999)
 3.6

--- a/l3kernel/testfiles/m3fp-symbolic002.luatex.tlg
+++ b/l3kernel/testfiles/m3fp-symbolic002.luatex.tlg
@@ -7,12 +7,18 @@ TEST 1: Functions in symbolic expression
 Defining \__fp_parse_word_A:N on line ...
 Defining \__fp_parse_word_B:N on line ...
 Defining \__fp_parse_word_C:N on line ...
-((A(3))+(B(3.141592653589793, 3)))+((C(0, 0, 0.2))*(B(3.141592653589793, 6)))
+> \l_tmpa_fp=((A(3))+(B(3.141592653589793, 3)))+((C(0, 0,
+0.2))*(B(3.141592653589793, 6))).
+<recently read> }
+l. ...  }
 Defining \__fp_parse_word__i:N on line ...
 Defining \__fp_parse_word_i:N on line ...
 Defining \__fp_parse_word__ii:N on line ...
 Defining \__fp_parse_word_j:N on line ...
-((A(3))+(B(3.141592653589793, 3)))+((C(0, 0, 0.2))*(B(3.141592653589793, 6)))
+> \l_tmpa_fp=((A(3))+(B(3.141592653589793, 3)))+((C(0, 0,
+0.2))*(B(3.141592653589793, 6))).
+<recently read> }
+l. ...  }
 ((A(3))+(1.047197551196598))+((C(0, 0, 0.2))*(0.5235987755982988))
 Defining \__fp_parse_word__i:N on line ...
 Defining \__fp_parse_word_i:N on line ...
@@ -125,7 +131,61 @@ Defining \__fp_parse_word_inf:N on line ...
 (((1)/(inf(pi(tmpa(1)))))+(aux(-1)))+(chk(1))
 ============================================================
 ============================================================
-TEST 5: Function parameters are created locally
+TEST 5: Show a variable holding symbolic expression
+============================================================
+Defining \__fp_parse_word_x:N on line ...
+Defining \__fp_parse_word_F:N on line ...
+> \l_tmpa_fp=x.
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =x.
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=F(1).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =F(1).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=F(x, F(x)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =F(x, F(x)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=F(1, (x)+(1), (tan(F(-1)))/(5)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =F(1, (x)+(1), (tan(F(-1)))/(5)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=(3)+((sin(x))*(F((x)^(x)))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =(3)+((sin(x))*(F((x)^(x)))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=(1, F(x)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =(1, F(x)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=(0, (x)+(-(x)), ((F(x))+(1))+((-1)+(!(F(x))))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =(0, (x)+(-(x)), ((F(x))+(1))+((-1)+(!(F(x))))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=((2)*(x), ((7)/(F(0.0174532925199433)))-(x), 4).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =((2)*(x), ((7)/(F(0.0174532925199433)))-(x), 4).
+<recently read> }
+l. ...  }
+============================================================
+============================================================
+TEST 6: Function parameters are created locally
 ============================================================
 Defining \__fp_parse_word_FUNCA:N on line ...
 Defining \__fp_parse_word__i:N on line ...
@@ -144,7 +204,7 @@ Defining \__fp_parse_word_a:N on line ...
 42
 ============================================================
 ============================================================
-TEST 6: Function parameters are cleared locally
+TEST 7: Function parameters are cleared locally
 ============================================================
 Defining \__fp_parse_word_E:N on line ...
 Defining \__fp_parse_word_PS:N on line ...
@@ -154,7 +214,7 @@ Defining \__fp_parse_word__i:N on line ...
 l. ...  }
 ============================================================
 ============================================================
-TEST 7: Set and clear both act locally
+TEST 8: Set and clear both act locally
 ============================================================
 Defining \__fp_parse_word_FUNCP:N on line ...
 ((FUNCP(3, 4))*(10))-(7)

--- a/l3kernel/testfiles/m3fp-symbolic002.lvt
+++ b/l3kernel/testfiles/m3fp-symbolic002.lvt
@@ -67,7 +67,7 @@
     \fp_new_function:n { tmpa } % works
     \fp_new_function:n { pi }
     \fp_new_function:n { inf }
-    \iow_term:x { \fp_to_tl:n { 1 / inf + pi + tmpa(1) + aux(-1) + chk(+1) } }
+    \TYPE { \fp_to_tl:n { 1 / inf + pi + tmpa(1) + aux(-1) + chk(+1) } }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3fp-symbolic002.lvt
+++ b/l3kernel/testfiles/m3fp-symbolic002.lvt
@@ -23,9 +23,9 @@
     \fp_new_function:n { C }
     % wired fp-expr :)
     \fp_set:Nn \l_tmpa_fp { A(3) + B(pi, 3) + C(0,0,.2) * B(pi, 6) }
-    \TYPE { \fp_to_tl:N \l_tmpa_fp } % symbolic
+    \fp_show:N \l_tmpa_fp % symbolic
     \fp_set_function:nnn { B } { i, j } { i/j }
-    \TYPE { \fp_to_tl:N \l_tmpa_fp } % symbolic
+    \fp_show:N \l_tmpa_fp % symbolic
     \TYPE { \fp_to_tl:n { \l_tmpa_fp } } % symbolic, B(pi, 3) evaluated
     \fp_set_function:nnn { C } { i, j, k } { k * -10 }
     \TYPE { \fp_to_tl:n { \l_tmpa_fp } } % symbolic, B & C evaluated
@@ -34,6 +34,7 @@
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \TESTEXP { Conversions }
   {
     \fp_to_decimal:n { A(1) + B(1,2)**2 } \NEWLINE
@@ -87,10 +88,37 @@
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+\TEST { Show~a~variable~holding~symbolic~expression }
+  {
+    \OMIT
+    \cs_set_protected:Npn \test_temp:n #1
+      {
+        \fp_set:Nn \l_tmpa_fp {#1}
+        \fp_show:N \l_tmpa_fp
+        \fp_show:n \l_tmpa_fp
+      }
+    \TIMO
+    \fp_new_variable:n { x }
+    \fp_new_function:n { F }
+    \test_temp:n { x }
+    \test_temp:n { F(1) }
+    \test_temp:n { F(x, F(x)) }
+    \test_temp:n { F(1, x + 1, tan(F(-1)) / 5) }
+    \test_temp:n { 3 + sin(x) * F(x**x) }
+    % tuples
+    \test_temp:n { 1 , F(x) }
+    \test_temp:n { (1 , x , F(x) + 1) + (-1 , -x , -1 + !F(x)) }
+    % after using \fp_new_function:n { pi } in a previous test,
+    % pi is not a constant anymore
+    \test_temp:n { 2 * x , 7 / F(deg) - x , 4 }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
 \TEST { Function~parameters~are~created~locally }
   {
     \OMIT
-    \cs_set:Npn \test_temp:
+    \cs_set_protected:Npn \test_temp:
       { \TYPE { \fp_to_tl:n { a + FUNCA(1) } } }
     \TIMO
     \fp_new_function:n { FUNCA }
@@ -118,7 +146,7 @@
 \TEST { Set~and~clear~both~act~locally }
   {
     \OMIT
-    \cs_set:Npn \test_temp:
+    \cs_set_protected:Npn \test_temp:
       { \TYPE { \fp_to_tl:n { FUNCP(3, 4) * 10 - 7 } } }
     \TIMO
     \fp_new_function:n { FUNCP }

--- a/l3kernel/testfiles/m3fp-symbolic002.tlg
+++ b/l3kernel/testfiles/m3fp-symbolic002.tlg
@@ -7,12 +7,18 @@ TEST 1: Functions in symbolic expression
 Defining \__fp_parse_word_A:N on line ...
 Defining \__fp_parse_word_B:N on line ...
 Defining \__fp_parse_word_C:N on line ...
-((A(3))+(B(3.141592653589793, 3)))+((C(0, 0, 0.2))*(B(3.141592653589793, 6)))
+> \l_tmpa_fp=((A(3))+(B(3.141592653589793, 3)))+((C(0, 0,
+0.2))*(B(3.141592653589793, 6))).
+<recently read> }
+l. ...  }
 Defining \__fp_parse_word__i:N on line ...
 Defining \__fp_parse_word_i:N on line ...
 Defining \__fp_parse_word__ii:N on line ...
 Defining \__fp_parse_word_j:N on line ...
-((A(3))+(B(3.141592653589793, 3)))+((C(0, 0, 0.2))*(B(3.141592653589793, 6)))
+> \l_tmpa_fp=((A(3))+(B(3.141592653589793, 3)))+((C(0, 0,
+0.2))*(B(3.141592653589793, 6))).
+<recently read> }
+l. ...  }
 ((A(3))+(1.047197551196598))+((C(0, 0, 0.2))*(0.5235987755982988))
 Defining \__fp_parse_word__i:N on line ...
 Defining \__fp_parse_word_i:N on line ...
@@ -125,7 +131,61 @@ Defining \__fp_parse_word_inf:N on line ...
 (((1)/(inf(pi(tmpa(1)))))+(aux(-1)))+(chk(1))
 ============================================================
 ============================================================
-TEST 5: Function parameters are created locally
+TEST 5: Show a variable holding symbolic expression
+============================================================
+Defining \__fp_parse_word_x:N on line ...
+Defining \__fp_parse_word_F:N on line ...
+> \l_tmpa_fp=x.
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =x.
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=F(1).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =F(1).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=F(x, F(x)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =F(x, F(x)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=F(1, (x)+(1), (tan(F(-1)))/(5)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =F(1, (x)+(1), (tan(F(-1)))/(5)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=(3)+((sin(x))*(F((x)^(x)))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =(3)+((sin(x))*(F((x)^(x)))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=(1, F(x)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =(1, F(x)).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=(0, (x)+(-(x)), ((F(x))+(1))+((-1)+(!(F(x))))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =(0, (x)+(-(x)), ((F(x))+(1))+((-1)+(!(F(x))))).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp=((2)*(x), ((7)/(F(0.0174532925199433)))-(x), 4).
+<recently read> }
+l. ...  }
+> \l_tmpa_fp =((2)*(x), ((7)/(F(0.0174532925199433)))-(x), 4).
+<recently read> }
+l. ...  }
+============================================================
+============================================================
+TEST 6: Function parameters are created locally
 ============================================================
 Defining \__fp_parse_word_FUNCA:N on line ...
 Defining \__fp_parse_word__i:N on line ...
@@ -144,7 +204,7 @@ Defining \__fp_parse_word_a:N on line ...
 42
 ============================================================
 ============================================================
-TEST 6: Function parameters are cleared locally
+TEST 7: Function parameters are cleared locally
 ============================================================
 Defining \__fp_parse_word_E:N on line ...
 Defining \__fp_parse_word_PS:N on line ...
@@ -154,7 +214,7 @@ Defining \__fp_parse_word__i:N on line ...
 l. ...  }
 ============================================================
 ============================================================
-TEST 7: Set and clear both act locally
+TEST 8: Set and clear both act locally
 ============================================================
 Defining \__fp_parse_word_FUNCP:N on line ...
 ((FUNCP(3, 4))*(10))-(7)

--- a/l3kernel/testfiles/m3show003.tlg
+++ b/l3kernel/testfiles/m3show003.tlg
@@ -299,7 +299,9 @@ This is a coding error.
 The variable '\l_tmpa_tl' with value
     a,
 should be a fp variable, but it does not have the correct internal structure:
-    \s__fp \__fp_chk:w ???;
+    \s__fp \__fp_chk:w ???; or
+    \s__fp_tuple \__fp_tuple_chk:w ?; or
+    \s__fp_symbolic \__fp_symbolic_chk:w ?,?;
 ! LaTeX Error: Variable '\l_tmpa_tl' is not a valid fp.
 For immediate help type H <return>.
  ...                                              


### PR DESCRIPTION
Fix #1301