### PR TITLE
Promote e-type expansion

### DIFF
--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -133,8 +133,9 @@
 % is therefore used as a shorthand for \enquote{replacement text}.
 %
 % Functions which are not \enquote{protected} are fully expanded
-% inside an \texttt{x} expansion. In contrast, \enquote{protected}
-% functions are not expanded within \texttt{x} expansions.
+% inside an \texttt{e}-type or \texttt{x}-type expansion.
+% In contrast, \enquote{protected} functions are not expanded within
+% \texttt{e} and \texttt{x} expansions.
 %
 % \subsection{Defining functions}
 %
@@ -178,7 +179,7 @@
 %      Create a new function with the \texttt{protected} restriction,
 %      such as \cs{cs_set_protected:Npn}. The parameter may contain
 %      \cs{par} tokens but the function will not expand within an
-%      \texttt{x}-type or \texttt{e}-type expansion.
+%      \texttt{e}-type or \texttt{x}-type expansion.
 % \end{description}
 %
 % Finally, the functions in
@@ -248,8 +249,8 @@
 %   Creates \meta{function} to expand to \meta{code} as replacement text.
 %   Within the \meta{code}, the \meta{parameters} (|#1|, |#2|,
 %   \emph{etc.}) will be replaced by those absorbed by the function.
-%   The \meta{function} will not expand within an \texttt{x}-type or
-%   or \texttt{e}-type
+%   The \meta{function} will not expand within an \texttt{e}-type or
+%   or \texttt{x}-type
 %   argument. The definition is global and an error results if the
 %   \meta{function} is already defined.
 % \end{function}
@@ -268,7 +269,7 @@
 %   \emph{etc.}) will be replaced by those absorbed by the function.
 %   When the \meta{function} is used the \meta{parameters} absorbed
 %   cannot contain \cs{par} tokens. The \meta{function} will not
-%   expand within an \texttt{x}-type or \texttt{e}-type argument. The definition is global
+%   expand within an \texttt{e}-type or \texttt{x}-type argument. The definition is global
 %   and an error results if the \meta{function} is already defined.
 % \end{function}
 %
@@ -320,7 +321,7 @@
 %   \emph{etc.}) will be replaced by those absorbed by the function.
 %   The assignment of a meaning to the \meta{function} is restricted to
 %   the current \TeX{} group level. The \meta{function} will
-%   not expand within an \texttt{x}-type or \texttt{e}-type argument.
+%   not expand within an \texttt{e}-type or \texttt{x}-type argument.
 % \end{function}
 %
 % \begin{function}
@@ -339,7 +340,7 @@
 %   cannot contain \cs{par} tokens. The assignment of a meaning
 %   to the \meta{function} is restricted to the current \TeX{} group
 %   level. The \meta{function} will not expand within an
-%   \texttt{x}-type or \texttt{e}-type argument.
+%   \texttt{e}-type or \texttt{x}-type argument.
 % \end{function}
 %
 % \begin{function}
@@ -392,7 +393,7 @@
 %   The assignment of a meaning to the \meta{function} is \emph{not}
 %   restricted to the current \TeX{} group level: the assignment is
 %   global. The \meta{function} will not expand within an
-%   \texttt{x}-type or \texttt{e}-type argument.
+%   \texttt{e}-type or \texttt{x}-type argument.
 % \end{function}
 %
 % \begin{function}
@@ -411,7 +412,7 @@
 %   cannot contain \cs{par} tokens. The assignment of a meaning to the
 %   \meta{function} is \emph{not} restricted to the current \TeX{}
 %   group level: the assignment is global. The \meta{function} will
-%   not expand within an \texttt{x}-type or \texttt{e}-type argument.
+%   not expand within an \texttt{e}-type or \texttt{x}-type argument.
 % \end{function}
 %
 % \subsection{Defining new functions using the signature}
@@ -462,8 +463,8 @@
 %   Within the \meta{code}, the number of \meta{parameters} is detected
 %   automatically from the function signature. These \meta{parameters}
 %   (|#1|, |#2|, \emph{etc.}) will be replaced by those absorbed by the
-%   function. The \meta{function} will not expand within an \texttt{x}-type
-%   or \texttt{e}-type argument. The definition is global and
+%   function. The \meta{function} will not expand within an \texttt{e}-type
+%   or \texttt{x}-type argument. The definition is global and
 %   an error results if the \meta{function} is already defined.
 % \end{function}
 %
@@ -481,7 +482,7 @@
 %   (|#1|, |#2|, \emph{etc.}) will be replaced by those absorbed by the
 %   function.  When the \meta{function} is used the \meta{parameters}
 %   absorbed cannot contain \cs{par} tokens. The \meta{function} will not
-%   expand within an \texttt{x}-type or \texttt{e}-type argument. The definition is global and
+%   expand within an \texttt{e}-type or \texttt{x}-type argument. The definition is global and
 %   an error results if the \meta{function} is already defined.
 % \end{function}
 %
@@ -532,8 +533,8 @@
 %   Within the \meta{code}, the number of \meta{parameters} is detected
 %   automatically from the function signature. These \meta{parameters}
 %   (|#1|, |#2|, \emph{etc.}) will be replaced by those absorbed by the
-%   function. The \meta{function} will not expand within an \texttt{x}-type
-%   or \texttt{e}-type argument.
+%   function. The \meta{function} will not expand within an \texttt{e}-type
+%   or \texttt{x}-type argument.
 %   The assignment of a meaning to the \meta{function} is restricted to
 %   the current \TeX{} group level.
 % \end{function}
@@ -552,7 +553,7 @@
 %   (|#1|, |#2|, \emph{etc.}) will be replaced by those absorbed by the
 %   function.  When the \meta{function} is used the \meta{parameters}
 %   absorbed cannot contain \cs{par} tokens. The \meta{function} will not
-%   expand within an \texttt{x}-type or \texttt{e}-type argument.
+%   expand within an \texttt{e}-type or \texttt{x}-type argument.
 %   The assignment of a meaning to the \meta{function} is restricted to
 %   the current \TeX{} group level.
 % \end{function}
@@ -602,8 +603,8 @@
 %   Within the \meta{code}, the number of \meta{parameters} is detected
 %   automatically from the function signature. These \meta{parameters}
 %   (|#1|, |#2|, \emph{etc.}) will be replaced by those absorbed by the
-%   function. The \meta{function} will not expand within an \texttt{x}-type
-%   or \texttt{e}-type argument.
+%   function. The \meta{function} will not expand within an \texttt{e}-type
+%   or \texttt{x}-type argument.
 %   The assignment of a meaning to the \meta{function} is  global.
 % \end{function}
 %
@@ -621,7 +622,7 @@
 %   (|#1|, |#2|, \emph{etc.}) will be replaced by those absorbed by the
 %   function.  When the \meta{function} is used the \meta{parameters}
 %   absorbed cannot contain \cs{par} tokens. The \meta{function} will not
-%   expand within an \texttt{x}-type or \texttt{e}-type argument.
+%   expand within an \texttt{e}-type or \texttt{x}-type argument.
 %   The assignment of a meaning to the \meta{function} is global.
 % \end{function}
 %
@@ -828,7 +829,7 @@
 %   of category code $10$. The result does \emph{not} include
 %   the current escape token, contrarily to \cs{token_to_str:N}.
 %   Full expansion of this function requires exactly $2$ expansion
-%   steps, and so an \texttt{x}-type or \texttt{e}-type expansion, or two
+%   steps, and so an \texttt{e}-type or \texttt{x}-type expansion, or two
 %   \texttt{o}-type expansions are required to
 %   convert the \meta{control sequence} to a sequence of characters
 %   in the input stream. In most cases, an \texttt{f}-expansion

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -361,7 +361,7 @@
 %   \begin{texnote}
 %     The result is returned within \tn{unexpanded}, which means that the
 %     comma list does not expand further when appearing in an
-%     \texttt{x}-type or \texttt{e}-type argument expansion.
+%     \texttt{e}-type or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -586,8 +586,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{items}
-%     do not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     do not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -611,8 +611,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{items}
-%     do not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     do not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -631,8 +631,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{items}
-%     do not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     do not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -737,8 +737,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}
-%     does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -753,8 +753,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}
-%     does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -758,7 +758,7 @@
 %   and all of \meta{tokens} are expandable \cs{exp_stop_f:}
 %   terminates the expansion of tokens even if \meta{more tokens}
 %   are also expandable. The function itself is an implicit space
-%   token. Inside an \texttt{x}-type or \texttt{e}-type expansion, it retains its
+%   token. Inside an \texttt{e}-type or \texttt{x}-type expansion, it retains its
 %   form, but when typeset it produces the underlying space (\verb*| |).
 % \end{function}
 %

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1023,12 +1023,12 @@
 %   all). Spaces are trimmed from the ends of the \meta{key} and \meta{value},
 %   then one \emph{outer} set of braces is removed from the \meta{key}
 %   and \meta{value} as part of the processing. If you need exactly the output
-%   shown above, you'll need to either \texttt{x}-type or \texttt{e}-type expand
+%   shown above, you'll need to either \texttt{e}-type or \texttt{x}-type expand
 %   the function.
 %   \begin{texnote}
 %     The result of each list element is returned within \cs{exp_not:n}, which
 %     means that the converted input stream does not expand further when
-%     appearing in an \texttt{x}-type or \texttt{e}-type argument expansion.
+%     appearing in an \texttt{e}-type or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -1068,7 +1068,7 @@
 %   \begin{texnote}
 %     The result is returned within \cs{exp_not:n}, which means that the
 %     converted input stream does not expand further when appearing in an
-%     \texttt{x}-type or \texttt{e}-type argument expansion.
+%     \texttt{e}-type or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -335,8 +335,8 @@
 %     \cs{prop_get:NnN}.
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{value}
-%     does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -358,7 +358,7 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded} primitive
 %     (\cs{exp_not:n}), which means that the key--value list does not expand
-%     further when appearing in an \texttt{x}-type or \texttt{e}-type argument expansion.
+%     further when appearing in an \texttt{e}-type or \texttt{x}-type argument expansion.
 %     It also needs exactly two steps of expansion.
 %   \end{texnote}
 % \end{function}

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -327,8 +327,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}
-%     does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -342,8 +342,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}
-%     does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -796,8 +796,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{items}
-%     do not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     do not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -821,8 +821,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{items}
-%     do not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     do not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -566,8 +566,8 @@
 %   See also \cs{tl_reverse:N}.
 %   \begin{texnote}
 %     The result is returned within \tn{unexpanded}, which means that the token
-%     list does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     list does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -603,8 +603,8 @@
 %   consider the slower function \cs{tl_reverse:n}.
 %   \begin{texnote}
 %     The result is returned within \tn{unexpanded}, which means that the token
-%     list does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     list does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -623,8 +623,8 @@
 %   stream.
 %   \begin{texnote}
 %     The result is returned within \tn{unexpanded}, which means that the token
-%     list does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     list does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -873,8 +873,8 @@
 %   \cs{tl_head:n} leaving nothing in the input stream.
 %   \begin{texnote}
 %     The result is returned within \cs{exp_not:n}, which means that the token
-%     list does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     list does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -918,8 +918,8 @@
 %   in \cs{tl_tail:n} leaving nothing in the input stream.
 %   \begin{texnote}
 %     The result is returned within \cs{exp_not:n}, which means that the
-%     token list does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     token list does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -959,8 +959,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}
-%     does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -976,8 +976,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}
-%     does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -1047,8 +1047,8 @@
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}
-%     does not expand further when appearing in an \texttt{x}-type
-%     or \texttt{e}-type argument expansion.
+%     does not expand further when appearing in an \texttt{e}-type
+%     or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %
@@ -1079,7 +1079,7 @@
 %   \begin{texnote}
 %     The result is returned within \cs{exp_not:n}, which means that the
 %     token list does not expand further when appearing in an
-%     \texttt{x}-type or \texttt{e}-type argument expansion.
+%     \texttt{e}-type or \texttt{x}-type argument expansion.
 %   \end{texnote}
 % \end{function}
 %


### PR DESCRIPTION
Change phrases "x-type and e-type expansion/argument" to "e-type and x-type ...".

Need a Changelog entry?