### PR TITLE
Adapt doc and code comments to sync with x-to-e switch

### DIFF
--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -3259,7 +3259,7 @@
 %   wrapping code as otherwise we would wrongly see the definitions that
 %   are in place there.  To get correct escape characters, set the
 %   \tn{escapechar} in a group; this also localizes the assignment
-%   performed by \texttt{x}-expansion.  The \cs{cs_show:c} and \cs{cs_log:c} commands
+%   performed by \texttt{e}-expansion.  The \cs{cs_show:c} and \cs{cs_log:c} commands
 %   convert their argument to a control sequence within a group to avoid
 %   showing \tn{relax} for undefined control sequences.
 %    \begin{macrocode}

--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -138,7 +138,7 @@
 %   and skipping out of that would break horribly.
 %   The \cs{@@_wrap_item:n} function inserts the relevant
 %   \cs{@@_item:n} without expansion in the input stream,
-%   hence in the \texttt{x}-expanding assignment.
+%   hence in the \texttt{e}-expanding assignment.
 %    \begin{macrocode}
 \cs_new_protected:Npn \seq_set_filter:NNn
   { \@@_set_filter:NNNn \__kernel_tl_set:Ne }

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -1523,7 +1523,7 @@
 %     \clist_reverse:N, \clist_reverse:c,
 %     \clist_greverse:N, \clist_greverse:c
 %   }
-%   Use \cs{clist_reverse:n} in an \texttt{x}-expanding assignment.  The
+%   Use \cs{clist_reverse:n} in an \texttt{e}-expanding assignment.  The
 %   extra work that \cs{clist_reverse:n} does to preserve braces and
 %   spaces would not be needed for the well-controlled case of
 %   \texttt{N}-type comma lists, but the slow-down is not too bad.

--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -137,7 +137,7 @@
 %   In case we want a warning, the \meta{function} is defined to produce
 %   such a warning without grabbing any argument, then redefine itself
 %   to the standard definition that the \meta{function} should have,
-%   with arguments, and call that definition.  The \texttt{x}-type
+%   with arguments, and call that definition.  The \texttt{e}-type
 %   expansion and \cs{exp_not:n} avoid needing to double the~|#|, which
 %   we could not do anyways.  We then deal with the code for
 %   \cs{debug_off:n} |{deprecation}|: presumably someone doing that does

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1930,9 +1930,9 @@ and all files in that bundle must be distributed together.
     \raisebox{\baselineskip}[0pt][0pt]{\hypertarget{expstar}{}}%
     \write \@auxout { \def \string \Codedoc@expstar { } }
     \@@_typeset_exp:\ indicates~fully~expandable~functions,~which~
-    can~be~used~within~an~\texttt{x}-type~argument~(in~plain~
-    \TeX{}~terms,~inside~an~\cs{edef}),~as~well~as~within~an~
-    \texttt{f}-type~argument.
+    can~be~used~within~an~\texttt{e}-type~argument~(inside~an~\tn{expanded}),~
+    \texttt{x}-type~argument~(in~plain~\TeX{}~terms,~inside~an~\tn{edef}),~
+    as~well~as~within~an~\texttt{f}-type~argument.
   }
 \NewDocumentCommand { \CodedocExplainREXP } { }
   {
@@ -1940,8 +1940,8 @@ and all files in that bundle must be distributed together.
     \write \@auxout { \def \string \Codedoc@rexpstar { } }
     \@@_typeset_rexp:\ indicates~
     restricted~expandable~functions,~which~can~be~used~within~an~
-    \texttt{x}-type~argument~but~cannot~be~fully~expanded~within~an~
-    \texttt{f}-type~argument.
+    \texttt{x}-type~argument~or~an~\texttt{e}-type~argument,~
+    but~cannot~be~fully~expanded~within~an~\texttt{f}-type~argument.
   }
 \NewDocumentCommand { \CodedocExplainTF } { }
   {

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -486,7 +486,7 @@
 %   \end{syntax}
 %   This function writes \meta{tokens} to the specified
 %   \meta{stream} when the current page is finalised (\emph{i.e.}~at
-%   shipout). The \texttt{x}-type variants expand the \meta{tokens}
+%   shipout). The \texttt{e}-type variants expand the \meta{tokens}
 %   at the point where the function is used but \emph{not} when the
 %   resulting tokens are written to the \meta{stream}
 %   (\emph{cf.}~\cs{iow_shipout_e:Nn}).
@@ -597,7 +597,7 @@
 %   output does \emph{not} expand further when written to a file.
 %
 %   \begin{texnote}
-%     Internally, \cs{iow_wrap:nnnN} carries out an \texttt{x}-type expansion
+%     Internally, \cs{iow_wrap:nnnN} carries out an \texttt{e}-type expansion
 %     on the \meta{text} to expand it. This is done in such a way that
 %     \cs{exp_not:N} or \cs{exp_not:n} \emph{could} be used to prevent
 %     expansion of material. However, this is less conceptually clear than

--- a/l3kernel/l3fp-aux.dtx
+++ b/l3kernel/l3fp-aux.dtx
@@ -97,8 +97,8 @@
 % When used directly without an accessor function, floating points
 % should produce an error: this is the role of \cs{@@_chk:w}.  We could
 % make floating point variables be protected to prevent them from
-% expanding under \texttt{x}-expansion, but it seems more convenient to
-% treat them as a subcase of token list variables.
+% expanding under \texttt{e}/\texttt{x}-expansion, but it seems more
+% convenient to treat them as a subcase of token list variables.
 %
 % The (decimal part of the) IEEE-754-2008 standard requires the format
 % to be able to represent special floating point numbers besides the
@@ -235,7 +235,8 @@
 %   where \cs{s_@@} is equal to the \TeX{} primitive \tn{relax}, and
 %   \cs{@@_chk:w} is protected.  The rest of the floating point number
 %   is made of characters (or \tn{relax}).  This ensures that nothing
-%   expands under \texttt{f}-expansion, nor under \texttt{x}-expansion.
+%   expands under \texttt{f}-expansion, nor under
+%   \texttt{e}/\texttt{x}-expansion.
 %   However, when typeset, \cs{s_@@} does nothing, and \cs{@@_chk:w} is
 %   expanded.  We define \cs{@@_chk:w} to produce an error.
 %    \begin{macrocode}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1805,7 +1805,7 @@
 %   }
 %   Searching for a property means finding the last |.| in the input,
 %   and storing the text before and after it. Everything is turned into
-%   strings, so there is no problem using an \texttt{x}-type expansion. Since
+%   strings, so there is no problem using an \texttt{e}-type expansion. Since
 %   \cs{@@_trim_spaces:n} will turn its argument into a string anyway, this
 %   function uses \cs{cs_set_nopar:Npe} instead of \cs{tl_set:Ne} to gain some
 %   speed.

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -288,7 +288,7 @@
 % message, extra arguments are ignored, or empty arguments added (of
 % course the sense of the message may be impaired). The four arguments are
 % converted to strings before being added to the message text: the
-% \texttt{x}-type variants should be used to expand material.
+% \texttt{e}-type variants should be used to expand material.
 % Note that this expansion takes place with the standard definitions in
 % effect, which means that shorthands such as |\~| or |\\| are
 % \emph{not} available; instead one should use \cs{iow_char:N} |\~| and
@@ -961,7 +961,7 @@
 % \begin{macro}{\@@_interrupt_text:n, \@@_interrupt_more_text:n}
 %   First setup \TeX{}'s \tn{errhelp} register with the extra help |#1|,
 %   then build a nice-looking error message with |#2|.  Everything is
-%   done using \texttt{x}-type expansion as the new line markers are
+%   done using \texttt{e}-type expansion as the new line markers are
 %   different for the two type of text and need to be correctly set up.
 %   The auxiliary \cs{@@_interrupt_more_text:n} receives its argument
 %   as a line-wrapped string, which is thus unaffected by expansion.

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -1258,7 +1258,7 @@
 %   \meta{value} may contain arbitrary tokens, it is not safe to include
 %   them in the argument of \cs{@@_split:NnTF}.  We thus start by
 %   storing in \cs{l_@@_internal_tl} tokens which (after
-%   \texttt{x}-expansion) encode the key--value pair.  This variable can
+%   \texttt{e}-expansion) encode the key--value pair.  This variable can
 %   safely be used in \cs{@@_split:NnTF}.  If the \meta{key} was absent,
 %   append the new key--value to the list.
 %   Otherwise concatenate the extracts |##1|

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -6056,9 +6056,7 @@
 %   Unless the submatch appears inside a |\c{...}| or |\u{...}|
 %   construction, it must be taken into account in the brace balance.
 %   Later on, |##1| will be replaced by a pointer to the $0$-th submatch for a
-%   given match.  There is an \cs{exp_not:N} here as at the point-of-use
-%   of \cs{g_@@_balance_tl} there is an \texttt{x}-type expansion which is needed
-%   to get |##1| in correctly.
+%   given match.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_replacement_put_submatch:n #1
   {

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -1090,7 +1090,7 @@
 % When actually building the result,
 % \begin{itemize}
 %   \item \tn{toks}\meta{position} holds \meta{tokens} which \texttt{o}-
-%     and \texttt{x}-expand to the \meta{position}-th token in the query.
+%     and \texttt{e}-expand to the \meta{position}-th token in the query.
 %   \item \cs{g_@@_balance_intarray} holds the balance of begin-group and
 %     end-group character tokens which appear before that point in the
 %     token list.
@@ -1160,12 +1160,12 @@
 %
 % \begin{macro}{\@@_toks_put_left:Ne}
 % \begin{macro}{\@@_toks_put_right:Ne, \@@_toks_put_right:Nn}
-%   During the building phase we wish to add \texttt{x}-expanded
+%   During the building phase we wish to add \texttt{e}-expanded
 %   material to \tn{toks}, either to the left or to the right. The
 %   expansion is done \enquote{by hand} for optimization (these
 %   operations are used quite a lot). The \texttt{Nn} version of
 %   \cs{@@_toks_put_right:Ne} is provided because it is more
-%   efficient than \texttt{x}-expanding with \cs{exp_not:n}.
+%   efficient than \texttt{e}-expanding with \cs{exp_not:n}.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_toks_put_left:Ne #1#2
   {
@@ -1188,7 +1188,7 @@
 % \begin{macro}[rEXP]{\@@_curr_cs_to_str:}
 %   Expands to the string representation of the token (known to be a
 %   control sequence) at the current position \cs{l_@@_curr_pos_int}.
-%   It should only be used in \texttt{x}-expansion to avoid losing a
+%   It should only be used in \texttt{e}/\texttt{x}-expansion to avoid losing a
 %   leading space.
 %    \begin{macrocode}
 \cs_new:Npn \@@_curr_cs_to_str:
@@ -1705,14 +1705,14 @@
 % a string, then read from left to right, interpreting backslashes as
 % escaping the next character.  Unescaped characters are fed to the
 % function \meta{inline~1}, and escaped characters are fed to the function
-% \meta{inline~2} within an \texttt{x}-expansion context (typically those
+% \meta{inline~2} within an \texttt{e}-expansion context (typically those
 % functions perform some tests on their argument to decide how to output
 % them).  The escape sequences |\a|, |\e|, |\f|, |\n|, |\r|, |\t| and
 % |\x| are recognized, and those are replaced by the corresponding
 % character, then fed to \meta{inline~3}. The result is then left in the
 % input stream. Spaces are ignored unless escaped.
 %
-% The conversion is done within an \texttt{x}-expanding assignment.
+% The conversion is done within an \texttt{e}-expanding assignment.
 %
 % \begin{macro}{\@@_escape_use:nnnn}
 %   The result is built in \cs{l_@@_internal_a_tl}, which is then left
@@ -2393,7 +2393,7 @@
 % \begin{macro}{\@@_compile:w, \@@_compile_end:}
 %   Used when compiling a user regex or a regex for the |\c{...}| escape
 %   sequence within another regex. Start building a token list within a
-%   group (with \texttt{x}-expansion at the outset), and set a few
+%   group (with \texttt{e}-expansion at the outset), and set a few
 %   variables (group level, catcodes), then start the first branch. At
 %   the end, make sure there are no dangling classes nor groups, close
 %   the last branch: we are done building \cs{l_@@_internal_regex}.
@@ -3638,7 +3638,7 @@
 %
 % \begin{macro}[EXP]{\@@_compile_u_loop:NN}
 %   We collect the characters for the argument of |\u| within an
-%   \texttt{x}-expanding assignment. In principle we could just wait to
+%   \texttt{e}-expanding assignment. In principle we could just wait to
 %   encounter a right brace, but this is unsafe: if the right brace was
 %   missing, then we would reach the end-markers of the regex, and
 %   continue, leading to obscure fatal errors. Instead, we only allow

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -5748,7 +5748,7 @@
 %   \cs{exp_not:n} requires a braced argument. As far as I can tell, it
 %   is only needed if the user tries to include in the replacement text
 %   a control sequence set equal to a macro parameter character, such as
-%   \cs{c_parameter_token}. Indeed, within an \texttt{x}-expanding
+%   \cs{c_parameter_token}. Indeed, within an \texttt{e}/\texttt{x}-expanding
 %   assignment, \cs{exp_not:N}~|#| behaves as a single |#|, whereas
 %   \cs{exp_not:n}~|{#}| behaves as a doubled |##|.
 %    \begin{macrocode}
@@ -5774,7 +5774,7 @@
 %   exclusive. The function \cs{@@_query_range:nn} \Arg{min}
 %   \Arg{max} unpacks registers from the position \meta{min} to the
 %   position $\meta{max}-1$ included. Once this is expanded, a second
-%   \texttt{x}-expansion results in the actual tokens from the
+%   \texttt{e}-expansion results in the actual tokens from the
 %   query. That second expansion is only done by user functions at the
 %   very end of their operation, after checking (and correcting) the
 %   brace balance first.
@@ -6290,7 +6290,7 @@
 %
 % \begin{macro}{\@@_replacement_c_A:w}
 %   For an active character, expansion must be avoided, twice because we
-%   later do two \texttt{x}-expansions, to unpack \tn{toks} for the
+%   later do two \texttt{e}-expansions, to unpack \tn{toks} for the
 %   query, and to expand their contents to tokens of the query.
 %    \begin{macrocode}
   \char_set_catcode_active:N \^^@
@@ -6303,7 +6303,7 @@
 %   An explicit begin-group token increases the balance, unless within a
 %   |\c{...}| or |\u{...}| construction. Add the desired begin-group
 %   character, using the standard \cs{if_false:} trick. We eventually
-%   \texttt{x}-expand twice. The first time must yield a balanced token
+%   \texttt{e}-expand twice. The first time must yield a balanced token
 %   list, and the second one gives the bare begin-group token. The
 %   \cs{exp_after:wN} is not strictly needed, but is more consistent
 %   with \pkg{l3tl-analysis}.
@@ -6324,7 +6324,7 @@
 %   This is not quite catcode-related: when the user requests a
 %   character with category \enquote{control sequence}, the
 %   one-character control symbol is returned. As for the active
-%   character, we prepare for two \texttt{x}-expansions.
+%   character, we prepare for two \texttt{e}-expansions.
 %    \begin{macrocode}
   \cs_new_protected:Npn \@@_replacement_c_C:w #1#2
     {
@@ -6345,7 +6345,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_replacement_c_E:w}
-%   Similar to the begin-group case, the second \texttt{x}-expansion
+%   Similar to the begin-group case, the second \texttt{e}-expansion
 %   produces the bare end-group token.
 %    \begin{macrocode}
   \char_set_catcode_group_end:N \^^@
@@ -6389,7 +6389,7 @@
 %
 % \begin{macro}{\@@_replacement_c_P:w}
 %   For macro parameters, expansion is a tricky issue. We need to
-%   prepare for two \texttt{x}-expansions and passing through various
+%   prepare for two \texttt{e}-expansions and passing through various
 %   macro definitions. Note that we cannot replace one \cs{exp_not:n} by
 %   doubling the macro parameter characters because this would misbehave
 %   if a mischievous user asks for |\c{\cP\#}|, since that macro
@@ -7211,7 +7211,7 @@
 %   this match; we need to add the tokens from the end of the match to
 %   the end of the query. Finally, store the result in the user's
 %   variable after closing the group: this step involves an additional
-%   \texttt{x}-expansion, and checks that braces are balanced in the
+%   \texttt{e}-expansion, and checks that braces are balanced in the
 %   final result.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_replace_once:nnN #1#2
@@ -7497,7 +7497,7 @@
 %   match.  For \cs{peek_regex_remove_once:nTF} we reinsert the tokens
 %   seen only if the match failed; otherwise we just reinsert the
 %   tokens~|#1|, with one expansion.  To be more precise, |#1| consists
-%   of tokens that \texttt{o}-expand and \texttt{x}-expand to the last
+%   of tokens that \texttt{o}-expand and \texttt{e}-expand to the last
 %   token seen, for example it is \cs{exp_not:N} \meta{cs} for a control
 %   sequence.  This means that just doing \cs{exp_after:wN}
 %   \cs{l_@@_peek_true_tl} |#1| would be unsafe because the expansion of
@@ -7659,12 +7659,12 @@
 % \begin{macro}{\@@_peek_replacement_put:n}
 %   While building the replacement function
 %   \cs{@@_replacement_do_one_match:n}, we often want to put simple
-%   material, given as |#1|, whose \texttt{x}-expansion
+%   material, given as |#1|, whose \texttt{e}-expansion
 %   \texttt{o}-expands to a single token.  Normally we can just add the
 %   token to \cs{l_@@_build_tl}, but for
 %   \cs{peek_regex_replace_once:nnTF} we eventually want to do some
 %   strange expansion that is basically using \cs{exp_after:wN} to jump
-%   through numerous tokens (we cannot use \texttt{x}-expansion like for
+%   through numerous tokens (we cannot use \texttt{e}-expansion like for
 %   \cs{regex_replace_once:nnNTF} because it is ok for the result to be
 %   unbalanced since we insert it in the input stream rather than
 %   storing it.  When within a csname we don't do any such shenanigan

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1308,11 +1308,11 @@
 %   spaces the item is enclosed within braces. After
 %   \cs{tl_replace_all:Nnn}, the token list \cs{l_@@_internal_a_tl}
 %   is a repetition of the pattern
-%   \cs{@@_set_split_auxi:w} \cs{prg_do_nothing:}
+%   \cs{@@_set_split:Nw} \cs{prg_do_nothing:}
 %   \meta{item with spaces} \cs{@@_set_split_end:}.
-%   Then, \texttt{e}-expansion causes \cs{@@_set_split_auxi:w}
+%   Then, \texttt{e}-expansion causes \cs{@@_set_split:Nw}
 %   to trim spaces, and leaves its result as
-%   \cs{@@_set_split_auxii:w} \meta{trimmed item}
+%   \cs{@@_set_split:w} \meta{trimmed item}
 %   \cs{@@_set_split_end:}. This is then converted
 %   to the \pkg{l3seq} internal structure by another
 %   \texttt{e}-expansion. In the first step, we insert

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1542,15 +1542,15 @@
 %   items one at a time to an intermediate sequence.
 %   The approach taken is therefore similar to
 %   that in \cs{@@_pop_right:NNN}, using a \enquote{flexible}
-%   \texttt{x}-type expansion to do most of the work. As \cs{tl_if_eq:nnT}
+%   \texttt{e}-type expansion to do most of the work. As \cs{tl_if_eq:nnT}
 %   is not expandable, a two-part strategy is needed. First, the
-%   \texttt{x}-type expansion uses \cs{str_if_eq:nnT} to find potential
+%   \texttt{e}-type expansion uses \cs{str_if_eq:nnT} to find potential
 %   matches. If one is found, the expansion is halted and the necessary
-%   set up takes place to use the \cs{tl_if_eq:NNT} test. The \texttt{x}-type
+%   set up takes place to use the \cs{tl_if_eq:NNT} test. The \texttt{e}-type
 %   is started again, including all of the items copied already. This
 %   happens repeatedly until the entire sequence has been scanned. The code
-%   is set up to avoid needing and intermediate scratch list: the lead-off
-%   \texttt{x}-type expansion (|#1 #2 {#2}|) ensures that nothing is lost.
+%   is set up to avoid needing an intermediate scratch list: the lead-off
+%   \texttt{e}-type expansion (|#1 #2 {#2}|) ensures that nothing is lost.
 %    \begin{macrocode}
 \cs_new_protected:Npn \seq_remove_all:Nn
   { \@@_remove_all_aux:NNn \__kernel_tl_set:Ne }

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1310,12 +1310,12 @@
 %   is a repetition of the pattern
 %   \cs{@@_set_split_auxi:w} \cs{prg_do_nothing:}
 %   \meta{item with spaces} \cs{@@_set_split_end:}.
-%   Then, \texttt{x}-expansion causes \cs{@@_set_split_auxi:w}
+%   Then, \texttt{e}-expansion causes \cs{@@_set_split_auxi:w}
 %   to trim spaces, and leaves its result as
 %   \cs{@@_set_split_auxii:w} \meta{trimmed item}
 %   \cs{@@_set_split_end:}. This is then converted
 %   to the \pkg{l3seq} internal structure by another
-%   \texttt{x}-expansion. In the first step, we insert
+%   \texttt{e}-expansion. In the first step, we insert
 %   \cs{prg_do_nothing:} to avoid losing braces too early:
 %   that would cause space trimming to act within those
 %   lost braces. The second step is solely there to strip
@@ -1480,7 +1480,7 @@
 %
 % \begin{macro}{\@@_wrap_item:n}
 %   This function converts its argument to a proper sequence item
-%   in an \texttt{x}-expansion context.
+%   in an \texttt{e}-expansion context.
 %    \begin{macrocode}
 \cs_new:Npn \@@_wrap_item:n #1 { \exp_not:n { \@@_item:n {#1} } }
 %    \end{macrocode}
@@ -1993,7 +1993,7 @@
 %   use some of the same ideas as getting from the right. What is needed is a
 %   \enquote{flexible length} way to set a token list variable. This is
 %   supplied by the |{ \if_false: } \fi:| \ldots
-%   |\if_false: { \fi: }| construct. Using an \texttt{x}-type
+%   |\if_false: { \fi: }| construct. Using an \texttt{e}-type
 %   expansion and a \enquote{non-expanding} definition for \cs{@@_item:n},
 %   the left-most $n - 1$ entries in a sequence of $n$ items are stored
 %   back in the sequence. That needs a loop of unknown length, hence using the
@@ -2280,7 +2280,7 @@
 %   }
 % \UnitTested
 %   This is just a specialised version of the in-line mapping function,
-%   using an \texttt{x}-type expansion for the code set up so that the
+%   using an \texttt{e}-type expansion for the code set up so that the
 %   number of |#| tokens required is as expected.
 %    \begin{macrocode}
 \cs_new_protected:Npn \seq_map_variable:NNn #1#2#3

--- a/l3kernel/l3str-convert.dtx
+++ b/l3kernel/l3str-convert.dtx
@@ -979,7 +979,7 @@
 %   non-Unicode-aware engines we use a fall-back character |?| rather
 %   than nothing when given a character code outside $[0,255]$.  We
 %   detect the presence of bad characters using a flag and only produce
-%   a single error after the \texttt{x}-expanding assignment.
+%   a single error after the \texttt{e}-expanding assignment.
 %    \begin{macrocode}
 \bool_lazy_any:nTF
   {
@@ -2515,7 +2515,7 @@
 %   its second argument (expanded or not). It sets \cs{@@_tmp:w} to
 %   expand to the character code of either of its two arguments
 %   depending on endianness, then triggers the \texttt{_loop} auxiliary
-%   inside an \texttt{x}-expanding assignment to \cs{g_@@_result_tl}.
+%   inside an \texttt{e}-expanding assignment to \cs{g_@@_result_tl}.
 %
 %   The \texttt{_loop} auxiliary first checks for the end-of-string
 %   marker \cs{s_@@_stop}, calling the \texttt{_end} auxiliary if

--- a/l3kernel/l3str-convert.dtx
+++ b/l3kernel/l3str-convert.dtx
@@ -345,7 +345,7 @@
 %
 % \begin{variable}{str_byte, str_error}
 %   Conversions from one \meta{encoding}/\meta{escaping} pair to another
-%   are done within \texttt{x}-expanding assignments. Errors are
+%   are done within \texttt{e}-expanding assignments. Errors are
 %   signalled by raising the relevant flag.
 %    \begin{macrocode}
 \flag_new:n { str_byte }

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -61,7 +61,7 @@
 % \meta{token}:
 % \begin{itemize}
 %   \item \meta{tokens}, which both \texttt{o}-expand and
-%     \texttt{x}-expand to the \meta{token}. The detailed form of
+%     \texttt{e}/\texttt{x}-expand to the \meta{token}. The detailed form of
 %     \meta{tokens} may change in later releases.
 %   \item \meta{char code}, a decimal representation of the character
 %     code of the \meta{token}, $-1$ if it is a control sequence.
@@ -132,7 +132,7 @@
 % We thus need a way to encode any \meta{token} (even begin-group and
 % end-group character tokens) in a way amenable to manipulating tokens
 % individually. The best we can do is to find \meta{tokens} which both
-% \texttt{o}-expand and \texttt{x}-expand to the given
+% \texttt{o}-expand and \texttt{e}/\texttt{x}-expand to the given
 % \meta{token}. Collecting more information about the category code and
 % character code is also useful for regular expressions, since most
 % regexes are catcode-agnostic. The internal format thus takes the form
@@ -140,7 +140,7 @@
 % \begin{quote}
 %   \meta{tokens} \cs{s_@@} \meta{catcode} \meta{char code} \cs{s_@@}
 % \end{quote}
-% The \meta{tokens} \texttt{o}- \emph{and} \texttt{x}-expand to the
+% The \meta{tokens} \texttt{o}- \emph{and} \texttt{e}/\texttt{x}-expand to the
 % original token in the token list or to the cluster of tokens
 % corresponding to one Unicode character in the given encoding (for
 % \pkg{l3str-convert}). The \meta{catcode} is given as a single hexadecimal
@@ -155,7 +155,7 @@
 % converting from a general token list to the internal format.
 %
 % The current rule for converting a \meta{token} to a balanced set of
-% \meta{tokens} which both \texttt{o}-expands and \texttt{x}-expands to
+% \meta{tokens} which both \texttt{o}-expands and \texttt{e}/\texttt{x}-expands to
 % it is the following.
 % \begin{itemize}
 %   \item A control sequence |\cs| becomes |\exp_not:n { \cs }|
@@ -189,7 +189,7 @@
 %   then need to control expansion much more carefully: compare
 %   \cs{int_value:w} |`#1| \cs{s_@@} with \cs{int_value:w} |`#1|
 %   \cs{exp_stop_f:} \cs{exp_not:N} \cs{q_mark} to extract a character
-%   code followed by the delimiter in an \texttt{x}-expansion.
+%   code followed by the delimiter in an \texttt{e}-expansion.
 %    \begin{macrocode}
 \scan_new:N \s_@@
 %    \end{macrocode}
@@ -350,7 +350,7 @@
 % (\texttt{N}-type) argument by \TeX{}. The plan is to have a two pass
 % system. In the first pass, locate special tokens, and store them in
 % various \tn{toks} registers. In the second pass, which is done within
-% an \texttt{x}-expanding assignment, normal tokens are taken in as
+% an \texttt{e}-expanding assignment, normal tokens are taken in as
 % \texttt{N}-type arguments, and special tokens are retrieved from the
 % \tn{toks} registers, and removed from the input stream by some means.
 % The whole process takes linear time, because we avoid building the
@@ -830,7 +830,7 @@
 %   while a control sequence is always longer (we have set the escape
 %   character to a printable value). In both cases, we leave
 %   \cs{exp_not:n} \Arg{token} \cs{s_@@} in the input stream
-%   (after \texttt{x}-expansion). Here, \cs{exp_not:n} is used
+%   (after \texttt{e}-expansion). Here, \cs{exp_not:n} is used
 %   rather than \cs{exp_not:N} because |#3| could be
 %   a macro parameter character or could be \cs{s_@@}
 %   (which must be hidden behind braces in the result).
@@ -937,7 +937,7 @@
 %   Check now whether we reached the end (we shouldn't keep the trailing
 %   end-group character that marked the end of the token list in the
 %   first pass).
-%   Unpack the \tn{toks} register: when \texttt{x}-expanding again,
+%   Unpack the \tn{toks} register: when \texttt{e}/\texttt{x}-expanding again,
 %   we will get the special token.
 %   Then leave the category code in the input stream, followed by
 %   the character code, and call \cs{@@_analysis_b_loop:w} with the next index.
@@ -1069,7 +1069,7 @@
 % \end{macro}
 %
 % \begin{macro}[rEXP]{\@@_analysis_show:, \@@_analysis_show_loop:wNw}
-%   Here, |#1| \texttt{o}- and \texttt{x}-expands to the token;
+%   Here, |#1| \texttt{o}- and \texttt{e}/\texttt{x}-expands to the token;
 %   |#2| is the category code (one uppercase hexadecimal digit),
 %   $0$ for control sequences;
 %   |#3| is the character code, which we ignore.
@@ -1549,7 +1549,7 @@
 %   character code.  In the latter two cases we call
 %   \cs{char_generate:nn} with suitable arguments and put suitable
 %   \cs{if_false:} \cs{fi:} constructions to make the result balanced
-%   and such that \texttt{o}-expanding or \texttt{x}-expanding gives
+%   and such that \texttt{o}-expanding or \texttt{e}/\texttt{x}-expanding gives
 %   back a single (unbalanced) begin-group or end-group character.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_peek_analysis_explicit:n #1

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -2153,7 +2153,7 @@
 %   All of its work is done between
 %   \cs{group_align_safe_begin:} and \cs{group_align_safe_end:} to avoid
 %   issues in alignments.  It does the actual replacement within
-%   |#3|~|#4|~|{...}|, an \texttt{x}-expanding \meta{assignment}~|#3| to
+%   |#3|~|#4|~|{...}|, an \texttt{e}-expanding \meta{assignment}~|#3| to
 %   the \meta{tl~var}~|#4|.  The auxiliary \cs{@@_replace_next:w} is
 %   called, followed by the \meta{token list}, some tokens including the
 %   \meta{delimiter}~|#1|, followed by the \meta{pattern}~|#5|.
@@ -2166,7 +2166,7 @@
 %   |##1| cannot contain the \meta{delimiter}~|#1| that we worked so
 %   hard to obtain, thus \cs{@@_replace_wrap:w} gets~|##1| as its own
 %   argument~|##1|, and protects it against
-%   the \texttt{x}-expanding assignment.  It also finds \cs{exp_not:n}
+%   the \texttt{e}-expanding assignment.  It also finds \cs{exp_not:n}
 %   as~|##2| and does nothing to it, thus letting through \cs{exp_not:n}
 %   \Arg{replacement} into the assignment.  Note that
 %   \cs{@@_replace_next:w} and \cs{@@_replace_wrap:w} are always called
@@ -2858,7 +2858,7 @@
 %   \cs{@@_trim_mark:} expands to nothing in a single expansion.  In the case
 %   at hand, we take \cs{__kernel_exp_not:w} \cs{exp_after:wN} as our
 %   continuation, so that space trimming behaves correctly within an
-%   \texttt{x}-type expansion.
+%   \texttt{e}-type or \texttt{x}-type expansion.
 %    \begin{macrocode}
 \cs_new:Npn \tl_trim_spaces:n #1
   {

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -968,7 +968,7 @@
 %   receives three arguments for each \meta{token} in the input stream:
 %   \begin{itemize}
 %   \item \meta{tokens}, which both \texttt{o}-expand and
-%     \texttt{x}-expand to the \meta{token}. The detailed form of
+%     \texttt{e}/\texttt{x}-expand to the \meta{token}. The detailed form of
 %     \meta{tokens} may change in later releases.
 %   \item \meta{char code}, a decimal representation of the character
 %     code of the \meta{token}, $-1$ if it is a control sequence.
@@ -2328,7 +2328,7 @@
 %
 %   Characters used as delimiters must have catcode~$12$
 %   and are obtained through \cs{tl_to_str:n}.  This requires doing all
-%   definitions within \texttt{x}-expansion.  The temporary function
+%   definitions within \texttt{e}-expansion.  The temporary function
 %   \cs{@@_tmp:w} used to define each conditional receives three
 %   arguments: the name of the conditional, the auxiliary's delimiter
 %   (also used to name the auxiliary), and the string to which one


### PR DESCRIPTION
I put changes that I'm not quite sure in the last commit ca91f4abd9151574758bc0ff87c35b8256080873, but after checking that there're almost no use of `x`-type expansion in `expl3-code.tex` unpacked from latest `main` branch, the x-to-e substitution seems to be right.