### PR TITLE
Promote e-type expansion and sync docs with x-to-e switch, part 2

### DIFF
--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -2428,9 +2428,6 @@
 %   returned with \meta{true} for when there is a colon in the function
 %   and \meta{false} if there is not.
 %
-%   We cannot use |:| directly as it has the wrong category code so
-%   an |x|-type expansion is used to force the conversion.
-%
 %   First ensure that we actually get a properly evaluated string by
 %   expanding \cs{cs_to_str:N} twice.  If the function contained a
 %   colon, the auxiliary takes as |#1| the function name, delimited by

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1190,7 +1190,7 @@ and all files in that bundle must be distributed together.
 %   Get predicate from a function's base name.  The code is not broken
 %   by functions with no signature.  The |n|-type version can be used
 %   for keys and other non-control sequences.  The output after
-%   |x|-expansion is a string.
+%   |e|-expansion is a string.
 %    \begin{macrocode}
 \cs_new:Npn \@@_predicate_from_base:n #1
   {

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -1061,7 +1061,7 @@
 %   Since the expansion of \cs{exp:w} \cs{exp_end_continue_f:w} is
 %   empty, we wind up with a fully expanded list, only \TeX{} has not
 %   tried to execute any of the non-expandable tokens. This is what
-%   differentiates this function from the |x| argument type.
+%   differentiates this function from the |e| and |x| argument type.
 %    \begin{macrocode}
 \cs_new:Npn \::f #1 \::: #2#3
   {
@@ -1817,7 +1817,7 @@
 %       trigger an error, because we do not have a means to replace
 %       |o|-expansion by |x|-expansion.
 %       More generally, we can only convert |N| to |c|, or convert |n|
-%       to |V|, |v|, |o|, |f|, |x|.
+%       to |V|, |v|, |o|, |e|, |f|, or |x|.
 %     \end{itemize}
 %     All this boils down to a few rules.  Only |n| and |N|-type
 %     arguments can be replaced by \cs{cs_generate_variant:Nn}.  Other
@@ -1888,7 +1888,7 @@
 %
 %   The case where the two letters are different is only allowed if the
 %   base is |N| and the variant is |c|, or when the base is |n| and the
-%   variant is |o|, |V|, |v|, |f| or |x|.  Otherwise, call
+%   variant is |V|, |v|, |o|, |e|, |f|, or |x|.  Otherwise, call
 %   \cs{@@_generate_variant_loop_invalid:NNwNNnn} to remove the end of
 %   the loop, get arguments at the end of the loop, and place an
 %   appropriate error message as a second argument of

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -658,8 +658,8 @@
 %     \cs{exp_not:N} \meta{token}
 %   \end{syntax}
 %   Prevents expansion of the \meta{token} in a context where it would
-%   otherwise be expanded, for example an |x|-type argument or the first
-%   token in an |o| or |e| or |f| argument.
+%   otherwise be expanded, for example an |e|-type or |x|-type argument or
+%   the first token in an |o|-type or |f|-type argument.
 %   \begin{texnote}
 %     This is the \TeX{} primitive \tn{noexpand}.  It only prevents
 %     expansion.  At the beginning of an |f|-type argument, a space

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -229,7 +229,7 @@
 % contrast to |e|, all macro parameter characters |#| must be doubled,
 % and omitting this leads to low-level errors.  In addition this type of
 % expansion is not expandable, namely functions that have |x| in their
-% signature do not themselves expand when appearing inside |x| or |e|
+% signature do not themselves expand when appearing inside |e| or |x|
 % expansion.
 %
 % The |f| type is so special that it deserves an example.  It is
@@ -706,7 +706,7 @@
 %     \cs{exp_not:o} \Arg{tokens}
 %   \end{syntax}
 %   Expands the \meta{tokens} once, then prevents any further expansion
-%   in |x|-type or \texttt{e}-type arguments using \cs{exp_not:n}.
+%   in |e|-type or |x|-type arguments using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:V}
@@ -714,7 +714,7 @@
 %     \cs{exp_not:V} \meta{variable}
 %   \end{syntax}
 %   Recovers the content of the \meta{variable}, then prevents expansion
-%   of this material in |x|-type or \texttt{e}-type arguments using \cs{exp_not:n}.
+%   of this material in |e|-type or |x|-type arguments using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:v}
@@ -725,7 +725,7 @@
 %   converts this into a control sequence which should be a \meta{variable}
 %   name.
 %   The content of the \meta{variable} is recovered, and further
-%   expansion in |x|-type or \texttt{e}-type arguments is prevented using \cs{exp_not:n}.
+%   expansion in |e|-type or |x|-type arguments is prevented using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:e}
@@ -734,7 +734,7 @@
 %   \end{syntax}
 %   Expands \meta{tokens} exhaustively, then protects the result of the
 %   expansion (including any tokens which were not expanded) from
-%   further expansion in |e| or |x|-type arguments using \cs{exp_not:n}.
+%   further expansion in |e|-type or |x|-type arguments using \cs{exp_not:n}.
 %   This is very rarely useful but is provided for consistency.
 % \end{function}
 %
@@ -745,7 +745,7 @@
 %   Expands \meta{tokens} fully until the first unexpandable token is
 %   found (if it is a space it is removed). Expansion then stops, and
 %   the result of the expansion (including any tokens which were not
-%   expanded) is protected from further expansion in |x|-type or \texttt{e}-type arguments
+%   expanded) is protected from further expansion in |e|-type or |x|-type arguments
 %   using \cs{exp_not:n}.
 % \end{function}
 %

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -264,8 +264,7 @@
 % \begin{quote}
 %   |\example:n { 3 , 7 }|
 % \end{quote}
-% at the cost of being protected (for |x| type) or very much slower in
-% old engines (for |e| type).
+% at the cost of being protected for |x|-type.
 % If you use |f| type expansion in conditional processing then
 % you should stick to using |TF|  type functions only as the expansion
 % does not finish any |\if... \fi:| itself!

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -685,16 +685,16 @@
 %   \begin{syntax}
 %     \cs{exp_not:n} \Arg{tokens}
 %   \end{syntax}
-%   Prevents expansion of the \meta{tokens} in an |e| or |x|-type argument.  In
-%   all other cases the \meta{tokens} continue to be expanded, for
+%   Prevents expansion of the \meta{tokens} in an |e|-type or |x|-type argument.
+%   In all other cases the \meta{tokens} continue to be expanded, for
 %   example in the input stream or in other types of arguments such as
 %   \texttt{c}, \texttt{f}, \texttt{v}.  The argument of \cs{exp_not:n}
 %   \emph{must} be surrounded by braces.
 %   \begin{texnote}
 %     This is the \eTeX{} primitive \tn{unexpanded}.  In an
-%     |x|-expanding definition (\cs{cs_new:Npe}), \cs{exp_not:n}~|{#1}|
+%     |e|-expanding definition (\cs{cs_new:Npe}), \cs{exp_not:n}~|{#1}|
 %     is equivalent to |##1| rather than to~|#1|, namely it inserts the
-%     two characters |#| and~|1|.  In an |e|-type argument
+%     two characters |#| and~|1|, and
 %     \cs{exp_not:n}~|{#}| is equivalent to |#|, namely it inserts the
 %     character~|#|.
 %   \end{texnote}
@@ -947,7 +947,7 @@
 % In this section a general mechanism for defining functions that handle
 % arguments is defined.  These general expansion functions are
 % expandable unless |x| is used.  (Any version of |x| is going to have
-% to use one of the \LaTeX3 names for \cs{cs_set:Npe} at some
+% to use one of the \LaTeX3 names for \cs{cs_set:Npx} at some
 % point, and so is never going to be expandable.)
 %
 % The definition of expansion functions with this technique happens
@@ -1827,7 +1827,7 @@
 %     part is ignored.
 %
 %     We compare the base and variant signatures one character at a time
-%     within |x|-expansion.  The result is given to
+%     within |e|-expansion.  The result is given to
 %     \cs{@@_generate_variant:wwNN} (defined later) in the form
 %     \meta{processed variant signature} \cs{s_@@_mark} \meta{errors}
 %     \cs{s_@@_stop} \meta{base function} \meta{new function}.  If all went

--- a/l3kernel/l3kernel-functions.dtx
+++ b/l3kernel/l3kernel-functions.dtx
@@ -101,7 +101,7 @@
 %   given \meta{specific type} of token list.  Produces suitable error
 %   messages if the \meta{control sequence} does not exist, or if it is
 %   not a token list variable at all, or if the \meta{control sequence}
-%   differs from the result of |x|-expanding \meta{reconstruction}.  If
+%   differs from the result of |e|-expanding \meta{reconstruction}.  If
 %   all of these tests succeed then the \meta{true code} is run.
 % \end{function}
 %

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -7301,7 +7301,7 @@
 %     \@@_group_end_replace:N, \@@_group_end_replace_try:,
 %     \@@_group_end_replace_check:w, \@@_group_end_replace_check:n
 %   }
-%   At this stage \cs{l_@@_internal_a_tl} (|x|-expands to the desired
+%   At this stage \cs{l_@@_internal_a_tl} (|e|-expands to the desired
 %   result).  Guess from \cs{l_@@_balance_int} the number of braces to
 %   add before or after the result then try expanding.  The simplest
 %   case is when \cs{l_@@_internal_a_tl} together with the braces we

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -1036,7 +1036,7 @@
 %   simplified version of the token list code because neither the
 %   delimiter nor the replacement can contain macro parameters or
 %   braces.  The delimiter \cs{s_@@_mark} cannot appear in the string to
-%   edit so it is used in all cases.  Some |x|-expansion is unnecessary.
+%   edit so it is used in all cases.  Some |e|-expansion is unnecessary.
 %   There is no need to avoid losing braces nor to protect against
 %   expansion.  The ending code is much simplified and does not need to
 %   hide in braces.

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -1390,7 +1390,7 @@
 %   characters to anything else than character code~$32$), then we apply
 %   \cs{@@_analysis_b_char:Nn}, which detects active characters by
 %   comparing them to \cs{tex_undefined:D}, and we must have undefined
-%   the active space for this test to work ---we use an |x|-expanding
+%   the active space for this test to work ---we use an |e|-expanding
 %   assignment to get the active space in the right place.  Finally
 %   \cs{@@_peek_analysis_char:w} puts the arguments in the correct
 %   order, including \cs{exp_not:n} for macro parameter characters and

--- a/l3kernel/l3tl-build.dtx
+++ b/l3kernel/l3tl-build.dtx
@@ -242,7 +242,7 @@
 %   See \cs{tl_build_put_right:Nn} for all the machinery.  We could
 %   easily provide \cs[no-index]{tl_build_put_left_right:Nnn}, by just
 %   adding the \meta{right} material after the \Arg{left} in the
-%   |x|-expanding assignment.
+%   |e|-expanding assignment.
 %    \begin{macrocode}
 \cs_new_protected:Npn \tl_build_put_left:Nn #1
   { \@@_build_put_left:NNn \cs_set_nopar:Npe #1 }


### PR DESCRIPTION
#1312 and #1313 dealt with `\texttt{x}` markups, and this PR dealt with `|x|` markups used mainly in `l3expan.dtx`.

Fortunately, there're no `"x"` usages, as `"` is another short verb characters supported in `function`-like environments by `l3doc`.