### PR TITLE
Document `\c_nan_fp`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Documentation for `\c_nan_fp`
+
 ### Fixed
 - Normalisation of `.inherit:n` key data (issue \#1314)
 

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -806,6 +806,11 @@
 %   floating point expression as \texttt{inf} and \texttt{-inf}.
 % \end{variable}
 %
+% \begin{variable}[added = 2012-05-08, module = fp]{\c_nan_fp}
+%   Not a number.  This can be input directly in a floating point expression
+%   as \texttt{nan}.
+% \end{variable}
+%
 % \begin{variable}[updated = 2012-05-08, module = fp]{\c_e_fp}
 %   The value of the base of the natural logarithm, $\mathrm{e} = \exp(1)$.
 % \end{variable}


### PR DESCRIPTION
It was added in commit fb3f38ff (First stage of installing new FPU: copy code and test files into l3kernel, 2012-05-09), along with other fp constants.

Reading l3fp implementation slowly, I found `\c_nan_fp` the only fp constant (in a group of five) that's not documented.

If user wants to process the expansion result of an `<fp expr>`, `\c_nan_fp` is needed in one case of `\str_case_e:nn(TF) {<fp expr>} {<string and code cases>}`.
![image](https://github.com/latex3/latex3/assets/6376638/27b7a239-6a6d-4b3e-ae10-41d5128400ad)
