### PR TITLE
Add variant `\str_case_e:en(TF)`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 - Documentation for `\c_nan_fp`
+- `\str_case_e:en(TF)`
 
 ### Fixed
 - Normalisation of `.inherit:n` key data (issue \#1314)

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -1761,7 +1761,7 @@
 % \begin{macro}{\@@_case:nw, \@@_case_end:nw}
 %   For integer cases, the first task to fully expand the check
 %   condition. The over all idea is then much the same as for
-%   \cs{tl_case:nnTF} as described in \pkg{l3tl}.
+%   \cs{str_case:nnTF} as described in \pkg{l3str}.
 %    \begin{macrocode}
 \cs_new:Npn \int_case:nnTF #1
   {

--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -1546,7 +1546,7 @@
 % \begin{macro}{\@@_case:NnTF}
 % \begin{macro}{\@@_case:w,a\@@_case_end:nw}
 %   For boolean cases the overall idea is the same as for
-%   \cs{tl_case:nnTF} as described in \pkg{l3tl}.
+%   \cs{str_case:nnTF} as described in \pkg{l3str}.
 %    \begin{macrocode}
 \cs_new:Npn \bool_case:nTF
   { \exp:w \@@_case:nTF }

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -1240,8 +1240,13 @@
 % \begin{macro}[EXP]{\@@_case:nnTF, \@@_case_e:nnTF}
 % \begin{macro}[EXP]
 %   {\@@_case:nw, \@@_case_e:nw, \@@_case_end:nw}
-%   Much the same as \cs{tl_case:nnTF} here:
-%   just a change in the internal comparison.
+%   The aim here is to allow the case statement to be evaluated
+%   using a known number of expansion steps (two), and without
+%   needing to use an explicit \enquote{end of recursion} marker.
+%   That is achieved by using the test input as the final case,
+%   as this is always true. The trick is then to tidy up
+%   the output such that the appropriate case code plus either
+%   the \texttt{true} or \texttt{false} branch code is inserted.
 %    \begin{macrocode}
 \cs_new:Npn \str_case:nn #1#2
   {
@@ -1308,6 +1313,18 @@
       { \@@_case_end:nw {#3} }
       { \@@_case_e:nw {#1} }
   }
+%    \end{macrocode}
+%   To tidy up the recursion, there are two outcomes. If there was a hit to
+%   one of the cases searched for, then |#1| is the code to insert,
+%   |#2| is the \emph{next} case to check on and |#3| is all of
+%   the rest of the cases code. That means that |#4| is the \texttt{true}
+%   branch code, and |#5| tidies up the spare \cs{s_@@_mark} and the
+%   \texttt{false} branch. On the other hand, if none of the cases matched
+%   then we arrive here using the \enquote{termination} case of comparing
+%   the search with itself. That means that |#1| is empty, |#2| is
+%   the first \cs{s_@@_mark} and so |#4| is the \texttt{false} code (the
+%   \texttt{true} code is mopped up by |#3|).
+%    \begin{macrocode}
 \cs_new:Npn \@@_case_end:nw #1#2#3 \s_@@_mark #4#5 \s_@@_stop
   { \exp_end: #1 #4 }
 %    \end{macrocode}

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -299,7 +299,7 @@
 %     ~~\Arg{false code}
 %   \end{syntax}
 %   Compares the \meta{test string} in turn with each
-%   of the \meta{string cases} (all token lists are converted to strings).
+%   of the \meta{string case}s (all token lists are converted to strings).
 %   If the two are equal (as described for
 %   \cs{str_if_eq:nnTF}) then the associated \meta{code} is left in the
 %   input stream and other cases are discarded. If any of the
@@ -312,7 +312,7 @@
 %   This set of functions performs no expansion on each
 %   \meta{string~case} argument, so any variable in there will be
 %   compared as a string.  If expansion is needed in the
-%   \meta{string~cases}, then \cs[no-index]{str_case_e:nn(TF)} should
+%   \meta{string~case}s, then \cs[no-index]{str_case_e:nn(TF)} should
 %   be used instead.
 % \end{function}
 %
@@ -330,9 +330,9 @@
 %     ~~\Arg{false code}
 %   \end{syntax}
 %   Compares the full expansion of the \meta{test string}
-%   in turn with the full expansion of the \meta{string cases}
+%   in turn with the full expansion of the \meta{string case}s
 %   (all token lists are converted to strings).  If the two
-%   full expansions are equal (as described for \cs{str_if_eq:nnTF}) then the
+%   full expansions are equal (as described for \cs{str_if_eq:eeTF}) then the
 %   associated \meta{code} is left in the input stream
 %   and other cases are discarded.  If any of the
 %   cases are matched, the \meta{true code} is also inserted into the

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -316,7 +316,8 @@
 %   be used instead.
 % \end{function}
 %
-% \begin{function}[added = 2018-06-19, EXP, noTF]{\str_case_e:nn}
+% \begin{function}[added = 2018-06-19, EXP, noTF]
+%   {\str_case_e:nn, \str_case_e:en}
 %   \begin{syntax}
 %     \cs{str_case_e:nnTF} \Arg{test string} \\
 %     ~~|{| \\
@@ -339,9 +340,9 @@
 %   match then the \meta{false code} is inserted. The function
 %   \cs{str_case_e:nn}, which does nothing if there is no match, is also
 %   available.
-%   The \meta{test string} is expanded in each comparison, and must
-%   always yield the same result: for example, random numbers must
-%   not be used within this string.
+%   In \cs[index=str_case_e:nnTF]{str_case_e:nn(TF)}, the \meta{test string}
+%   is expanded in each comparison, and must always yield the same result:
+%   for example, random numbers must not be used within this string.
 % \end{function}
 %
 % \begin{function}[EXP, pTF, added = 2021-05-17]{\str_compare:nNn, \str_compare:eNe}
@@ -1234,7 +1235,7 @@
 % \begin{macro}[EXP, noTF]
 %   {
 %     \str_case:nn, \str_case:Vn, \str_case:Nn, \str_case:on, \str_case:en, \str_case:nV, \str_case:nv,
-%     \str_case_e:nn
+%     \str_case_e:nn, \str_case_e:en
 %   }
 % \begin{macro}[EXP]{\@@_case:nnTF, \@@_case_e:nnTF}
 % \begin{macro}[EXP]
@@ -1299,6 +1300,8 @@
   }
 \cs_new:Npn \@@_case_e:nnTF #1#2#3#4
   { \@@_case_e:nw {#1} #2 {#1} { } \s_@@_mark {#3} \s_@@_mark {#4} \s_@@_stop }
+\cs_generate_variant:Nn \str_case_e:nn { e }
+\prg_generate_conditional_variant:Nnn \str_case_e:nn { e } { T , F , TF }
 \cs_new:Npn \@@_case_e:nw #1#2#3
   {
     \str_if_eq:eeTF {#1} {#2}

--- a/l3trial/l3bigint/l3bigint.dtx
+++ b/l3trial/l3bigint/l3bigint.dtx
@@ -2501,7 +2501,7 @@
 %   comparison is not done with \cs{bigint_compare:nNnTF} because it
 %   would repeatedly parse the number to compare.  Instead, we rely on
 %   uniqueness of the decimal representation.
-%   This code is inspired from the code of \cs{tl_case:Nn}(TF).
+%   This code is inspired from the code of \cs{str_case:nnTF}.
 %    \begin{macrocode}
 \cs_new:Npn \bigint_case:nnTF #1
   {


### PR DESCRIPTION
I noticed `\str_case_e:nnTF` while preparing PR #1309, then the need for its `e`-variant `\str_case_e:enTF` arose quickly, as in base function `#1` is expanded in each comparison, which would be slow if expanding `#1` is expansive. #1309 happened to only need to compare `#1` to single unexpandalble tokens, hence `\str_case:en(TF)` was enough. (`\str_case_e:en(TF)` would still be a little quicker, due to no `\exp_not:n`.)

The only copy of comment explaining case implementation is also added to `\str_case:nn(TF)` functions, picked from corresponding deprecated `\tl_case:Nn(TF)` functions. See commit https://github.com/latex3/latex3/commit/abae082902e6cd9f4694932e605b7660e3e88495 (Deprecate \tl_case:Nn(TF), 2023-05-23).