### PR TITLE
Improve l3color and (x)color coexistance in LuaLaTeX

### DIFF
--- a/l3backend/CHANGELOG.md
+++ b/l3backend/CHANGELOG.md
@@ -6,6 +6,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Changed `luaotfload` integration to allow coexistance with (x)color.
+
 ## [2023-11-04]
 
 ### Fixed

--- a/l3backend/l3backend-color.dtx
+++ b/l3backend/l3backend-color.dtx
@@ -1308,6 +1308,16 @@ if luaotfload and luaotfload.set_transparent_colorstack then
     local html = htmlcolor:match(value)
     if html then return html end
 
+% If no l3color named color with this name is known, check for defined xcolor colors
+    local l3color_prop = token.get_macro(string.format('l__color_named_%s_prop', value))
+    if l3color_prop == nil or l3color_prop == '' then
+      local legacy_color_macro = token.create(string.format('\\color@%s', value))
+      if legacy_color_macro.cmdname ~= 'undefined_cs' then
+        token.put_next(legacy_color_macro)
+        return token.scan_argument()
+      end
+    end
+
     tex.runtoks(function()
       token.get_next()
       color_export[6] = value


### PR DESCRIPTION
Currently the `l3color` code interacting with luaotfload assumes that all colors are defined with l3color.
While this is a reasonable long-term goal, it is more practical to assume that some user might also use (x)color to define color names.

Therefore this changes the luaotfload hook to use the (x)color color definition if no color with the same name is defined in l3color.