### PR TITLE
Fix `\bool_to_str:n` and `\bool_to_str:N` returning letters

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Return truly string in `\bool_to_str:N` and `\bool_to_str:n` (issue \#1331)
+
 ## [2023-11-09]
 
 ### Added

--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -330,12 +330,13 @@
 %   based on this result.
 % \end{function}
 %
-% \begin{function}[EXP, added = 2021-11-01]{\bool_to_str:N, \bool_to_str:c, \bool_to_str:n}
+% \begin{function}[EXP, added = 2021-11-01, updated = 2023-11-14]
+%   {\bool_to_str:N, \bool_to_str:c, \bool_to_str:n}
 %   \begin{syntax}
 %     \cs{bool_to_str:N} \meta{boolean}
 %     \cs{bool_to_str:n} \meta{boolean expression}
 %   \end{syntax}
-%   Expands to the letters \texttt{true} or \texttt{false} depending on
+%   Expands to the string \texttt{true} or \texttt{false} depending on
 %   the logical truth of the \meta{boolean} or \meta{boolean
 %   expression}.
 % \end{function}
@@ -1048,11 +1049,19 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]{\bool_to_str:N, \bool_to_str:c, \bool_to_str:n}
-%   Expands to \texttt{true} or \texttt{false} with category code letter.
+%   Expands to string literal \texttt{true} or \texttt{false}.
 %    \begin{macrocode}
-\cs_new:Npn \bool_to_str:N #1 { \bool_if:NTF #1 { true } { false } }
+\cs_new:Npe \bool_to_str:N #1
+  {
+    \exp_not:N \bool_if:NTF #1
+      { \tl_to_str:n { true } } { \tl_to_str:n { false } }
+  }
 \cs_generate_variant:Nn \bool_to_str:N { c }
-\cs_new:Npn \bool_to_str:n #1 { \bool_if:nTF {#1} { true } { false } }
+\cs_new:Npe \bool_to_str:n #1
+  {
+    \exp_not:N \bool_if:nTF {#1}
+      { \tl_to_str:n { true } } { \tl_to_str:n { false } }
+  }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/testfiles/m3prg005.lvt
+++ b/l3kernel/testfiles/m3prg005.lvt
@@ -92,11 +92,22 @@
     \NEWLINE
   }
 
-\TESTEXP { bool_to_str }
+\TEST { bool_to_str }
   {
-    \bool_to_str:c { c_true_bool } ,
-    \bool_to_str:N ? ,
-    \bool_to_str:n { ! ! \c_false_bool && \c_false_bool }
+    \TYPE
+      {
+        \bool_to_str:c { c_true_bool } ,
+        \bool_to_str:N ? ,
+        \bool_to_str:n { ! ! \c_false_bool && \c_false_bool }
+      }
+    \tl_if_eq:eeTF
+      { \bool_to_str:N \c_false_bool }
+      { \tl_to_str:n {false} }
+      { \TRUE } { \ERROR },
+    \tl_if_eq:eeTF
+      { \bool_to_str:n { \l_tmpa_bool || \c_true_bool } }
+      { \tl_to_str:n {true} }
+      { \TRUE } { \ERROR }
   }
 
 \END

--- a/l3kernel/testfiles/m3prg005.tlg
+++ b/l3kernel/testfiles/m3prg005.tlg
@@ -66,4 +66,6 @@ A number should have been here; I inserted `0'.
 (If you can't figure out why I needed to see a number,
 look up `weird error' in the index to The TeXbook.)
 true,false,false
+TRUE
+TRUE
 ============================================================


### PR DESCRIPTION
Fixes #1331