### PR TITLE
fix deprecated command entries

### DIFF
--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -455,13 +455,13 @@
 %
 % \begin{macro}[EXP, noTF]{\bool_case_true:n}
 %    \begin{macrocode}
-\__kernel_patch_deprecation:nnNNpn { 2023-05-03 } { \bool_case_true:n }
+\__kernel_patch_deprecation:nnNNpn { 2023-05-03 } { \bool_case:n }
 \cs_gset:Npn \bool_case_true:n { \bool_case:n }
-\__kernel_patch_deprecation:nnNNpn { 2023-05-03 } { \bool_case_true:nT }
+\__kernel_patch_deprecation:nnNNpn { 2023-05-03 } { \bool_case:nT }
 \cs_gset:Npn \bool_case_true:nT { \bool_case:nT }
-\__kernel_patch_deprecation:nnNNpn { 2023-05-03 } { \bool_case_true:nF }
+\__kernel_patch_deprecation:nnNNpn { 2023-05-03 } { \bool_case:nF }
 \cs_gset:Npn \bool_case_true:nF { \bool_case:nF }
-\__kernel_patch_deprecation:nnNNpn { 2023-05-03 } { \bool_case_true:nTF }
+\__kernel_patch_deprecation:nnNNpn { 2023-05-03 } { \bool_case:nTF }
 \cs_gset:Npn \bool_case_true:nTF { \bool_case:nTF }
 %    \end{macrocode}
 % \end{macro}
@@ -531,7 +531,7 @@
 %
 % \begin{macro}{\seq_mapthread_function:NNN}
 %    \begin{macrocode}
-\__kernel_patch_deprecation:nnNNpn { 2023-05-10 } { \seq_mapthread_function:NNN }
+\__kernel_patch_deprecation:nnNNpn { 2023-05-10 } { \seq_map_pairwise_function:NNN }
 \cs_gset:Npn \seq_mapthread_function:NNN { \seq_map_pairwise_function:NNN }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
The entries for a few commands in l3deprecations.dtx have the wrong second argument to `\__kernel_patch_deprecation:nnNNpn`, repeating the deprecated command. This causes them to produce the wrong error when debugging, e.g.
```tex
! LaTeX Error: Use \bool_case_true:nT not \bool_case_true:nT
```
Full example:
```tex
\documentclass{article}

\ExplSyntaxOn
\debug_on:n { all }
\ExplSyntaxOff

\begin{document}

\ExplSyntaxOn
\bool_case_true:nT {}{}
\ExplSyntaxOff

\end{document}
```