### PR TITLE
Update fallback definitions for `\tl_case:Nnn` and `\tl_case:cnn`

### DIFF
--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -396,9 +396,9 @@
 \@@_old_protected:Nnn \tl_show_analysis:n
   { \tl_analysis_show:n } { 2020-01-01 }
 \@@_old:Nnn \tl_case:cnn
-  { \tl_case:cnF } { 2015-07-14 }
+  { \exp_args:Nc \token_case_meaning:NnF } { 2015-07-14 }
 \@@_old:Nnn \tl_case:Nnn
-  { \tl_case:NnF } { 2015-07-14 }
+  { \token_case_meaning:NnF } { 2015-07-14 }
 \@@_old_protected:Nnn \tl_gset_from_file:Nnn
   { \file_get:nnN } { 2021-07-01 }
 \@@_old_protected:Nnn \tl_gset_from_file_x:Nnn


### PR DESCRIPTION
`\tl_case:NnF` and `\tl_case:cnF` are deprecated too, hence should be avoided in fallback definitions.