### PR TITLE
Speed up string assignment functions like `\str_set:Nn`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -16,6 +16,10 @@ this project uses date-based 'snapshot' version identifiers.
 - Documentation for `\c_nan_fp`
 - `\str_case_e:en(TF)`
 
+### Changes
+- Speed up `\str_(g)set:Nn`, `\str_const:Nn`, `\str_(g)put_left:Nn`,
+  and `\str_(g)put_right:Nn`
+
 ### Fixed
 - Normalisation of `.inherit:n` key data (issue \#1314)
 

--- a/l3kernel/build.lua
+++ b/l3kernel/build.lua
@@ -71,6 +71,10 @@ function update_tag(file,content,tagname,tagdate)
     content = string.gsub(content,
       "\n\\def\\ExplFileDate{" .. iso .. "}%%\n",
       "\n\\def\\ExplFileDate{" .. tagname .. "}%%\n")
+  elseif string.match(file,"l3debug%.dtx$") then
+    content = string.gsub(content,
+      "\n\\ProvidesExplFile{l3debug%.def}{" .. iso .. "}",
+      "\n\\ProvidesExplFile{l3debug.def}{" .. tagname .. "}")
   end
   if string.match(file,"%.dtx$") or string.match(file,"%.tex$") then
     return string.gsub(content,

--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -838,6 +838,10 @@
       \skip_set_eq:NN
       \skip_add:Nn
       \skip_sub:Nn
+      \str_clear:N
+      \str_set_eq:NN
+      \str_put_left:Nn
+      \str_put_right:Nn
       \__kernel_tl_set:Ne
       \tl_clear:N
       \tl_set_eq:NN
@@ -903,6 +907,10 @@
       \skip_gset_eq:NN
       \skip_gadd:Nn
       \skip_gsub:Nn
+      \str_gclear:N
+      \str_gset_eq:NN
+      \str_gput_left:Nn
+      \str_gput_right:Nn
       \__kernel_tl_gset:Ne
       \tl_gclear:N
       \tl_gset_eq:NN
@@ -941,6 +949,7 @@
       \intarray_const_from_clist:Nn
       \muskip_const:Nn
       \skip_const:Nn
+      \str_const:Nn
       \tl_const:Nn
     }
 %    \end{macrocode}

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -106,7 +106,7 @@
 %   initially empty.
 % \end{function}
 %
-% \begin{function}[added = 2015-09-18, updated = 2023-11-25]
+% \begin{function}[added = 2015-09-18, updated = 2018-07-28]
 %   {
 %     \str_const:Nn, \str_const:NV, \str_const:Ne,
 %     \str_const:cn, \str_const:cV, \str_const:ce
@@ -176,7 +176,7 @@
 %
 % \section{Adding data to string variables}
 %
-% \begin{function}[added = 2015-09-18, updated = 2023-11-25]
+% \begin{function}[added = 2015-09-18, updated = 2018-07-28]
 %   {
 %     \str_set:Nn,  \str_set:NV, \str_set:Ne,
 %     \str_set:cn,  \str_set:cV, \str_set:ce,
@@ -190,7 +190,7 @@
 %   result in \meta{str var}.
 % \end{function}
 %
-% \begin{function}[added = 2015-09-18, updated = 2023-11-25]
+% \begin{function}[added = 2015-09-18, updated = 2018-07-28]
 %   {
 %     \str_put_left:Nn, \str_put_left:NV, \str_put_left:Ne,
 %     \str_put_left:cn, \str_put_left:cV, \str_put_left:ce,
@@ -205,7 +205,7 @@
 %     var} are not automatically converted to a string.
 % \end{function}
 %
-% \begin{function}[added = 2015-09-18, updated = 2023-11-25]
+% \begin{function}[added = 2015-09-18, updated = 2018-07-28]
 %   {
 %     \str_put_right:Nn, \str_put_right:NV, \str_put_right:Ne,
 %     \str_put_right:cn, \str_put_right:cV, \str_put_right:Ne,

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -981,6 +981,14 @@
 %   }
 %   Similar to corresponding \pkg{l3tl} base functions, except that
 %   \cs{__kernel_exp_not:w} is replaced with \cs{__kernel_tl_to_str:w}.
+%   Just like token list, string constants use \cs{cs_gset_nopar:Npe}
+%   instead of \cs{__kernel_tl_gset:Ne} so that the scope checking for
+%   |c| is applied when \pkg{l3debug} is used.
+%   To maintain backward compatibility, in
+%     \cs[index=str_put_left:Nn]{str_(g)put_left:Nn} and
+%     \cs[index=str_put_right:Nn]{str_(g)put_right:Nn},
+%   contents of string variables are wrapped in \cs{__kernel_exp_not:w}
+%   to prevent further expansion.
 %    \begin{macrocode}
 \cs_new_protected:Npn \str_set:Nn #1#2
   { \__kernel_tl_set:Ne #1 { \__kernel_tl_to_str:w {#2} } }

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -106,7 +106,7 @@
 %   initially empty.
 % \end{function}
 %
-% \begin{function}[added = 2015-09-18, updated = 2018-07-28]
+% \begin{function}[added = 2015-09-18, updated = 2023-11-25]
 %   {
 %     \str_const:Nn, \str_const:NV, \str_const:Ne,
 %     \str_const:cn, \str_const:cV, \str_const:ce
@@ -176,7 +176,7 @@
 %
 % \section{Adding data to string variables}
 %
-% \begin{function}[added = 2015-09-18, updated = 2018-07-28]
+% \begin{function}[added = 2015-09-18, updated = 2023-11-25]
 %   {
 %     \str_set:Nn,  \str_set:NV, \str_set:Ne,
 %     \str_set:cn,  \str_set:cV, \str_set:ce,
@@ -190,7 +190,7 @@
 %   result in \meta{str var}.
 % \end{function}
 %
-% \begin{function}[added = 2015-09-18, updated = 2018-07-28]
+% \begin{function}[added = 2015-09-18, updated = 2023-11-25]
 %   {
 %     \str_put_left:Nn, \str_put_left:NV, \str_put_left:Ne,
 %     \str_put_left:cn, \str_put_left:cV, \str_put_left:ce,
@@ -205,7 +205,7 @@
 %     var} are not automatically converted to a string.
 % \end{function}
 %
-% \begin{function}[added = 2015-09-18, updated = 2018-07-28]
+% \begin{function}[added = 2015-09-18, updated = 2023-11-25]
 %   {
 %     \str_put_right:Nn, \str_put_right:NV, \str_put_right:Ne,
 %     \str_put_right:cn, \str_put_right:cV, \str_put_right:Ne,
@@ -979,33 +979,45 @@
 %     \str_gput_right:Nn, \str_gput_right:NV, \str_gput_right:Ne, \str_gput_right:Nx,
 %     \str_gput_right:cn, \str_gput_right:cV, \str_gput_right:ce, \str_gput_right:cx
 %   }
-%   Simply convert the token list inputs to \meta{strings}.
+%   Similar to corresponding \pkg{l3tl} base functions, except that
+%   \cs{__kernel_exp_not:w} is replaced with \cs{__kernel_tl_to_str:w}.
 %    \begin{macrocode}
-\group_begin:
-  \cs_set_protected:Npn \@@_tmp:n #1
-    {
-      \tl_if_blank:nF {#1}
-        {
-          \cs_new_protected:cpe { str_ #1 :Nn } ##1##2
-            {
-              \exp_not:c { tl_ #1 :Ne } ##1
-                { \exp_not:N \tl_to_str:n {##2} }
-            }
-          \cs_generate_variant:cn { str_ #1 :Nn }
-            { NV , Ne , Nx , cn , cV , ce , cx }
-          \@@_tmp:n
-        }
-    }
-  \@@_tmp:n
-    { set }
-    { gset }
-    { const }
-    { put_left }
-    { gput_left }
-    { put_right }
-    { gput_right }
-    { }
-\group_end:
+\cs_new_protected:Npn \str_set:Nn #1#2
+  { \__kernel_tl_set:Ne #1 { \__kernel_tl_to_str:w {#2} } }
+\cs_gset_protected:Npn \str_gset:Nn #1#2
+  { \__kernel_tl_gset:Ne #1 { \__kernel_tl_to_str:w {#2} } }
+\cs_new_protected:Npn \str_const:Nn #1#2
+  {
+    \__kernel_chk_if_free_cs:N #1
+    \cs_gset_nopar:Npe #1 { \__kernel_tl_to_str:w {#2} }
+  }
+\cs_new_protected:Npn \str_put_left:Nn #1#2
+  {
+    \__kernel_tl_set:Ne #1
+      { \__kernel_tl_to_str:w {#2} \__kernel_exp_not:w \exp_after:wN {#1} }
+  }
+\cs_new_protected:Npn \str_gput_left:Nn #1#2
+  {
+    \__kernel_tl_gset:Ne #1
+      { \__kernel_tl_to_str:w {#2} \__kernel_exp_not:w \exp_after:wN {#1} }
+  }
+\cs_new_protected:Npn \str_put_right:Nn #1#2
+  {
+    \__kernel_tl_set:Ne #1
+      { \__kernel_exp_not:w \exp_after:wN {#1} \__kernel_tl_to_str:w {#2} }
+  }
+\cs_new_protected:Npn \str_gput_right:Nn #1#2
+  {
+    \__kernel_tl_gset:Ne #1
+      { \__kernel_exp_not:w \exp_after:wN {#1} \__kernel_tl_to_str:w {#2} }
+  }
+\cs_generate_variant:Nn \str_set:Nn        { NV , Ne , Nx , c , cV , ce , cx }
+\cs_generate_variant:Nn \str_gset:Nn       { NV , Ne , Nx , c , cV , ce , cx }
+\cs_generate_variant:Nn \str_const:Nn      { NV , Ne , Nx , c , cV , ce , cx }
+\cs_generate_variant:Nn \str_put_left:Nn   { NV , Ne , Nx , c , cV , ce , cx }
+\cs_generate_variant:Nn \str_gput_left:Nn  { NV , Ne , Nx , c , cV , ce , cx }
+\cs_generate_variant:Nn \str_put_right:Nn  { NV , Ne , Nx , c , cV , ce , cx }
+\cs_generate_variant:Nn \str_gput_right:Nn { NV , Ne , Nx , c , cV , ce , cx }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -1352,8 +1352,11 @@
 %     \tl_const:cn, \tl_const:ce, \tl_const:cx
 %   }
 %   Constants are also easy to generate. They use \cs{cs_gset_nopar:Npe} instead
-%   of \cs{__kernel_tl_gset:Ne} so that the correct scope checking is applied if
-%   \pkg{l3debug} is used.
+%   of \cs{__kernel_tl_gset:Ne} so that the correct scope checking for |c|,
+%   instead of for |g|, is applied when
+%   \cs{debug_on:n} |{ check-declarations }| is used.
+%   Constant assignment functions are patched specially in \pkg{l3debug} to
+%   apply such checks.
 %    \begin{macrocode}
 \cs_new_protected:Npn \tl_const:Nn #1#2
   {


### PR DESCRIPTION
Full list is `\str_(g)set:Nn`, `\str_const:Nn`, `\str_(g)put_left:Nn`, and `\str_(g)put_right:Nn`.

Their current implementations use a structure `\tl_<func>:Ne <str var> { \tl_to_str:n {<token list>}}`, which is slow. Since (the current implementation of) `\tl_to_str:n` needs only one expansion step, the `e`-type variants `\tl_<func>:Ne` can be replaced with `o`-type  variants. In addition since string won't expand further, the `\__kernel_exp_not:w` used in corresponding base functions `\tl_<func>:Nn` is superfluous.

This PR hand-tune these base functions by using structures similar to their `\tl_<func>:Nn` siblings.

If needed, their variants can be hand-tuned as well, just like corresponding `tl` variants. `\str_set:Ne` is one of commonly used variants I think.

I'll add tests on local/global string assignments in a follow-up PR, including extending coverage for local/global token list assignments.

**Benchmark results** on setting `abc \c_empty_tl` (first lines for `\str_set:Nn` and second lines for `\str_set:Ne`)
```
[0] use \tl_set:Ne 
1.15e-6 seconds (4.88 ops)
1.2e-6 seconds (5.09 ops)
[1] use \tl_set:No 
7.76e-7 seconds (3.34 ops)
8.95e-7 seconds (3.81 ops)
[2] base hand-tuned
4.32e-7 seconds (1.83 ops)
6.55e-7 seconds (2.78 ops)
[3] e variant hand-tuned
4.43e-7 seconds (1.8 ops)
5.78e-7 seconds (2.37 ops)
```

<details><summary>Benchmark example</summary>
<p>


```tex
\documentclass{article}
\usepackage{l3benchmark}

\ExplSyntaxOn
\cs_new_protected:Npn \my_str_benchmarks:n #1
  {
    \iow_term:n { #1 }
    \benchmark:n { \str_set:Nn \l_tmpa_str { abc \c_empty_tl } }
    \benchmark:n { \str_set:Ne \l_tmpa_str { abc \c_empty_tl } }
  }

% trigger log line "\g__benchmark_1_int=\count<num>"
\benchmark_once:n { }
\iow_term:n { }

% copy the old implementation
\cs_gset_protected:Npn \str_set:Nn #1#2
  { \tl_set:Ne #1 { \tl_to_str:n { #2 } } }
\my_str_benchmarks:n { [0]~ use~\tl_set:Ne }

% use \tl_set:No
\cs_gset_protected:Npn \str_set:Nn #1#2
  { \tl_set:No #1 { \tl_to_str:n { #2 } } }
\my_str_benchmarks:n { [1]~ use~\tl_set:No }

% hand-tune base form
\cs_gset_protected:Npn \str_set:Nn #1#2
  { \__kernel_tl_set:Ne #1 { \tl_to_str:n { #2 } } }
\my_str_benchmarks:n { [2]~ base~hand-tuned }

% hand-tune e-type variant in addition
\cs_gset_protected:Npn \str_set:Ne #1#2
  { \__kernel_tl_set:Ne #1 { \exp_args:Ne \tl_to_str:n { #2 } } }
\my_str_benchmarks:n { [3]~ e~variant~hand-tuned  } 
\ExplSyntaxOff

\begin{document}
\end{document}
```

</p>
</details>