### PR TITLE
Drop repetitive `\l__codedoc_macro_internal_set_bool` and fix variant generations

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -695,7 +695,6 @@ and all files in that bundle must be distributed together.
 %
 % \begin{variable}
 %   {
-%     \l_@@_macro_internal_set_bool,
 %     \l_@@_macro_internal_bool,
 %     \l_@@_macro_TF_bool,
 %     \l_@@_macro_pTF_bool,
@@ -710,7 +709,6 @@ and all files in that bundle must be distributed together.
 %   environments.  We initialize \cs{l_@@_override_module_tl} to avoid
 %   overriding module names by an empty name (meaning no module).
 %    \begin{macrocode}
-\bool_new:N \l_@@_macro_internal_set_bool
 \bool_new:N \l_@@_macro_internal_bool
 \bool_new:N \l_@@_macro_TF_bool
 \bool_new:N \l_@@_macro_pTF_bool
@@ -2350,11 +2348,8 @@ and all files in that bundle must be distributed together.
 %    \begin{macrocode}
 \prg_new_conditional:Npnn \@@_if_macro_internal:n #1 { p , T , F , TF }
   {
-    \bool_if:NTF \l_@@_macro_internal_set_bool
-      {
-        \bool_if:NTF \l_@@_macro_internal_bool
-          { \prg_return_true: } { \prg_return_false: }
-      }
+    \bool_if:NTF \l_@@_macro_internal_bool
+      { \prg_return_true: }
       {
         \tl_if_empty:fTF
           {
@@ -2886,16 +2881,10 @@ and all files in that bundle must be distributed together.
       } ,
     internal .value_forbidden:n = true ,
     internal .code:n =
-      {
-        \bool_set_true:N \l_@@_macro_internal_bool
-        \bool_set_true:N \l_@@_macro_internal_set_bool
-      } ,
+      { \bool_set_true:N \l_@@_macro_internal_bool } ,
     int .value_forbidden:n = true ,
     int .code:n =
-      {
-        \bool_set_true:N \l_@@_macro_internal_bool
-        \bool_set_true:N \l_@@_macro_internal_set_bool
-      } ,
+      { \bool_set_true:N \l_@@_macro_internal_bool } ,
     var .value_forbidden:n = true ,
     var .code:n =
       { \bool_set_true:N \l_@@_macro_var_bool } ,
@@ -2978,7 +2967,6 @@ and all files in that bundle must be distributed together.
   {
     \int_incr:N \l_@@_nested_macro_int
     \bool_set_false:N \l_@@_macro_internal_bool
-    \bool_set_false:N \l_@@_macro_internal_set_bool
     \bool_set_false:N \l_@@_macro_TF_bool
     \bool_set_false:N \l_@@_macro_pTF_bool
     \bool_set_false:N \l_@@_macro_noTF_bool

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -982,15 +982,11 @@ and all files in that bundle must be distributed together.
 \cs_generate_variant:Nn \str_case:nn { fn }
 \cs_generate_variant:Nn \tl_count:n { f }
 \cs_generate_variant:Nn \tl_greplace_all:Nnn { Nx , Nno }
-\cs_generate_variant:Nn \tl_if_empty:nTF { f }
-\cs_generate_variant:Nn \tl_if_head_eq_charcode:nNTF { o }
-\cs_generate_variant:Nn \tl_if_head_eq_charcode:nNT  { o }
-\cs_generate_variant:Nn \tl_if_head_eq_charcode:nNF  { o }
-\cs_generate_variant:Nn \tl_if_head_eq_meaning:nNF  { V }
-\cs_generate_variant:Nn \tl_if_in:nnTF { no , oo }
-\cs_generate_variant:Nn \tl_if_in:NnTF { No }
-\cs_generate_variant:Nn \tl_if_in:NnT  { No }
-\cs_generate_variant:Nn \tl_if_in:NnF  { No }
+\prg_generate_conditional_variant:Nnn \tl_if_empty:n { f } { TF }
+\prg_generate_conditional_variant:Nnn \tl_if_head_eq_charcode:nN { o } { T , F , TF }
+\prg_generate_conditional_variant:Nnn \tl_if_head_eq_meaning:nN  { V } { F }
+\prg_generate_conditional_variant:Nnn \tl_if_in:nn { no , oo } { TF }
+\prg_generate_conditional_variant:Nnn \tl_if_in:Nn { No } { T , F , TF }
 \cs_generate_variant:Nn \tl_remove_all:Nn   { Nx }
 \cs_generate_variant:Nn \tl_replace_all:Nnn { Nx , Nnx, No , Nno }
 \cs_generate_variant:Nn \tl_replace_once:Nnn { Noo }
@@ -1014,7 +1010,7 @@ and all files in that bundle must be distributed together.
       { \prg_return_false: }
       { \prg_return_true: }
   }
-\cs_generate_variant:Nn \@@_if_almost_str:nT { V }
+\prg_generate_conditional_variant:Nnn \@@_if_almost_str:n { V } { T }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -966,9 +966,6 @@ and all files in that bundle must be distributed together.
 %     \tl_if_in:NoTF,
 %     \tl_if_in:NoT,
 %     \tl_if_in:NoF,
-%     \tl_remove_all:Ne,
-%     \tl_replace_all:Nen,
-%     \tl_replace_all:Nne,
 %     \tl_replace_all:Non,
 %     \tl_replace_all:Nno,
 %     \tl_replace_once:Noo,
@@ -987,8 +984,7 @@ and all files in that bundle must be distributed together.
 \prg_generate_conditional_variant:Nnn \tl_if_head_eq_meaning:nN  { V } { F }
 \prg_generate_conditional_variant:Nnn \tl_if_in:nn { no , oo } { TF }
 \prg_generate_conditional_variant:Nnn \tl_if_in:Nn { No } { T , F , TF }
-\cs_generate_variant:Nn \tl_remove_all:Nn   { Nx }
-\cs_generate_variant:Nn \tl_replace_all:Nnn { Nx , Nnx, No , Nno }
+\cs_generate_variant:Nn \tl_replace_all:Nnn { No , Nno }
 \cs_generate_variant:Nn \tl_replace_once:Nnn { Noo }
 \cs_generate_variant:Nn \tl_set_rescan:Nnn { NnV }
 \cs_generate_variant:Nn \tl_to_str:n { f , o }
@@ -3087,7 +3083,6 @@ and all files in that bundle must be distributed together.
           { \@@_get_function_name:n {#1} } #2
       }
   }
-\cs_generate_variant:Nn \@@_macro_typeset_block:nN { x }
 \cs_new_protected:Npn \@@_macro_typeset_variant_list:nN #1#2
   {
     \seq_map_inline:Nn \g_@@_variants_seq


### PR DESCRIPTION
`\l__codedoc_macro_internal_set_bool` and `\l__codedoc_macro_internal_bool` always have the same value, hence one of them can be dropped. Since `\l__codedoc_macro_internal_set_bool` was added more recently, by commit bf322508 (Treat macros as internal/not-internal on a individual basis, 2017-11-30), I decided to drop it.

Found when digging for #1345.

Need a Changelog entry?