### PR TITLE
Standarise "file name" in docs

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -725,10 +725,10 @@
 % \begin{function}[noTF, added = 2019-01-16, updated = 2019-02-16]
 %   {\file_get:nnN, \file_get:VnN}
 %   \begin{syntax}
-%     \cs{file_get:nnN} \Arg{filename} \Arg{setup} \meta{tl}
-%     \cs{file_get:nnNTF} \Arg{filename} \Arg{setup} \meta{tl} \Arg{true code} \Arg{false code}
+%     \cs{file_get:nnN} \Arg{file name} \Arg{setup} \meta{tl}
+%     \cs{file_get:nnNTF} \Arg{file name} \Arg{setup} \meta{tl} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Defines \meta{tl} to the contents of \meta{filename}.
+%   Defines \meta{tl} to the contents of \meta{file name}.
 %   Category codes may need to be set appropriately via the \meta{setup}
 %   argument.
 %   The non-branching version sets the \meta{tl} to \cs{q_no_value} if the file is


### PR DESCRIPTION
> In `l3kernel` repository,
> ```
> $ grep -rn '\\\(Arg\|meta\){filename}' **/*.dtx | wc -l
>        3
> $ grep -rn '\\\(Arg\|meta\){file name}' **/*.dtx | wc -l
>       47
> ```
> 
> _Originally posted by @muzimuzhi in https://github.com/latex3/l3build/issues/323#issuecomment-1846036749_
            