### PR TITLE
Drop docs for removed internal functions

### DIFF
--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -2327,27 +2327,6 @@
 %   the marker value $-1$.
 % \end{function}
 %
-% \begin{function}[EXP]{\@@_get_function_name:N}
-%   \begin{syntax}
-%     \cs{@@_get_function_name:N} \meta{function}
-%   \end{syntax}
-%   Splits the \meta{function} into the \meta{name} (\emph{i.e.}~the part
-%   before the colon) and the \meta{signature} (\emph{i.e.}~after the colon).
-%   The \meta{name} is then left in the input stream without the escape
-%   character present made up of tokens with category code $12$
-%   (other).
-% \end{function}
-%
-% \begin{function}[EXP]{\@@_get_function_signature:N}
-%   \begin{syntax}
-%     \cs{@@_get_function_signature:N} \meta{function}
-%   \end{syntax}
-%   Splits the \meta{function} into the \meta{name} (\emph{i.e.}~the part
-%   before the colon) and the \meta{signature} (\emph{i.e.}~after the colon).
-%   The \meta{signature} is then left in the input stream made up of
-%   tokens with category code $12$ (other).
-% \end{function}
-%
 % \begin{function}{\@@_tmp:w}
 %   Function used for various short-term usages, for instance defining
 %   functions whose definition involves tokens which are hard to insert

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -2316,7 +2316,7 @@
 %<@@=cs>
 %    \end{macrocode}
 %
-% \begin{function}{\@@_count_signature:N}
+% \begin{function}[EXP]{\@@_count_signature:N}
 %   \begin{syntax}
 %     \cs{@@_count_signature:N} \meta{function}
 %   \end{syntax}

--- a/l3kernel/l3bitset.dtx
+++ b/l3kernel/l3bitset.dtx
@@ -418,6 +418,8 @@
 %   {
 %     \bitset_set_true:Nn, \bitset_set_true:cn,
 %     \bitset_gset_true:Nn, \bitset_gset_true:cn,
+%     \bitset_set_false:Nn, \bitset_set_false:cn,
+%     \bitset_gset_false:Nn, \bitset_gset_false:cn
 %   }
 % \begin{macro}{\@@_set_aux:NNn}
 % The user commands must first translate the argument to an index number.

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1120,7 +1120,7 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{macro}{\@@_item:n}
+% \begin{macro}[EXP]{\@@_item:n}
 %   The delimiter is always defined, but when used incorrectly simply
 %   removes its argument and hits an undefined control sequence to
 %   raise an error.

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -129,9 +129,9 @@
 %
 % \begin{function}[added = 2015-09-18]
 %   {
-%      \str_clear_new:N, \str_clear_new:c,
-%      \str_gclear_new:N, \str_gclear_new:c
-%    }
+%     \str_clear_new:N, \str_clear_new:c,
+%     \str_gclear_new:N, \str_gclear_new:c
+%   }
 %   \begin{syntax}
 %     \cs{str_clear_new:N} \meta{str~var}
 %   \end{syntax}


### PR DESCRIPTION
Found when checking `l3build cmdcheck` output (run in `l3kernel` directory).