### PR TITLE
Standarise titles of modules and packages

### DIFF
--- a/l3backend/l3backend-basics.dtx
+++ b/l3backend/l3backend-basics.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3backend-basics} package\\ Backend basics^^A
+%   The \pkg{l3backend-basics} package\\ Backend basics^^A
 % }
 %
 % \author{^^A

--- a/l3backend/l3backend-box.dtx
+++ b/l3backend/l3backend-box.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3backend-box} package\\ Backend box support^^A
+%   The \pkg{l3backend-box} package\\ Backend box support^^A
 % }
 %
 % \author{^^A

--- a/l3backend/l3backend-color.dtx
+++ b/l3backend/l3backend-color.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3backend-color} package\\ Backend color support^^A
+%   The \pkg{l3backend-color} package\\ Backend color support^^A
 % }
 %
 % \author{^^A

--- a/l3backend/l3backend-draw.dtx
+++ b/l3backend/l3backend-draw.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3backend-draw} package\\ Backend drawing support^^A
+%   The \pkg{l3backend-draw} package\\ Backend drawing support^^A
 % }
 %
 % \author{^^A

--- a/l3backend/l3backend-graphics.dtx
+++ b/l3backend/l3backend-graphics.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3backend-graphics} package\\ Backend graphics support^^A
+%   The \pkg{l3backend-graphics} package\\ Backend graphics support^^A
 % }
 %
 % \author{^^A

--- a/l3backend/l3backend-header.dtx
+++ b/l3backend/l3backend-header.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3backend-header} package\\ Backend graphics support^^A
+%   The \pkg{l3backend-header} package\\ Backend graphics support^^A
 % }
 %
 % \author{^^A

--- a/l3backend/l3backend-opacity.dtx
+++ b/l3backend/l3backend-opacity.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3backend-opacity} package\\ Backend opacity support^^A
+%   The \pkg{l3backend-opacity} package\\ Backend opacity support^^A
 % }
 %
 % \author{^^A

--- a/l3backend/l3backend-pdf.dtx
+++ b/l3backend/l3backend-pdf.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3backend-pdf} package\\ Backend PDF features^^A
+%   The \pkg{l3backend-pdf} package\\ Backend PDF features^^A
 % }
 %
 % \author{^^A

--- a/l3experimental/l3opacity/l3opacity.dtx
+++ b/l3experimental/l3opacity/l3opacity.dtx
@@ -34,7 +34,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3opacity} package\\ Experimental opacity (transparency) support^^A
+%   The \pkg{l3opacity} package\\ Experimental opacity (transparency) support^^A
 % }
 %
 % \author{^^A

--- a/l3experimental/l3str/l3str-format.dtx
+++ b/l3experimental/l3str/l3str-format.dtx
@@ -36,7 +36,7 @@
 %
 %
 % \title{^^A
-%   The \textsf{l3str-format} package: formatting strings of characters^^A
+%   The \pkg{l3str-format} package\\ Formatting strings of characters^^A
 % }
 %
 % \author{^^A

--- a/l3experimental/xcoffins/xcoffins.dtx
+++ b/l3experimental/xcoffins/xcoffins.dtx
@@ -41,7 +41,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{xcoffins} package\\ Design-level coffins^^A
+%   The \pkg{xcoffins} package\\ Design-level coffins^^A
 % }
 %
 % \author{^^A

--- a/l3experimental/xgalley/l3galley.dtx
+++ b/l3experimental/xgalley/l3galley.dtx
@@ -49,7 +49,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3galley} package\\ Galley code^^A
+%   The \pkg{l3galley} package\\ Galley code^^A
 % }
 %
 % \author{^^A

--- a/l3experimental/xgalley/xgalley.dtx
+++ b/l3experimental/xgalley/xgalley.dtx
@@ -32,7 +32,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{xgalley} package\\ Galley^^A
+%   The \pkg{xgalley} package\\ Galley^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1437,12 +1437,12 @@
 %   an older version of the kernel, so we \emph{must} patch.
 %
 %   In \texttt{package} mode, if these commands exist, then we are using
-%   a version of \LaTeXe{} with \textsf{expl3} preloaded (any version)
+%   a version of \LaTeXe{} with \pkg{expl3} preloaded (any version)
 %   and in any case patching is already done or the macros are in the
 %   format itself, so nothing to do.
 %   But if in \texttt{package} mode these macros don't exist, we have an
 %   even older version of \LaTeXe{} which doesn't even have
-%   \textsf{expl3} preloaded, so patching is necessary.
+%   \pkg{expl3} preloaded, so patching is necessary.
 %
 %   All this means that in both \texttt{2ekernel} and \texttt{package}
 %   mode we have to check whether \cs{@expl@sys@load@backend@@@@}

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -39,7 +39,7 @@
 %   \begin{itemize}\def\makelabel##1{\hss\llap{\bfseries##1}}}{\end{itemize}}
 %
 % \title{^^A
-%   The \textsf{expl3} package and \LaTeX3 programming^^A
+%   The \pkg{expl3} package and \LaTeX3 programming^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1513,7 +1513,7 @@
 %
 % \begin{variable}{\c_zero_int}
 %   We need the constant \cs{c_zero_int}
-%   which is used by some functions in the \pkg{l3alloc} module. The
+%   which is used by some functions in current module. The
 %   rest are defined in the \pkg{l3int} module -- at least for the
 %   ones that can be defined with \cs{tex_chardef:D} or
 %   \cs{tex_mathchardef:D}. For other constants the \pkg{l3int} module is
@@ -1525,8 +1525,8 @@
 % \end{variable}
 %
 % \begin{variable}{\c_max_register_int}
-%   This is here as this particular integer is needed both in package
-%   mode and to bootstrap \pkg{l3alloc}, and is documented in \pkg{l3int}.
+%   This is here as this particular integer is needed in modules
+%   loaded before \pkg{l3int}, and is documented in \pkg{l3int}.
 %   \LuaTeX{} and those which contain parts of the Omega extensions have
 %   more registers available than \eTeX{}.
 %    \begin{macrocode}

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1417,7 +1417,7 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]{\exp_after:wN, \exp_not:N, \exp_not:n}
-%    The five |\exp_| functions are used in the \textsf{l3expan} module
+%    The five |\exp_| functions are used in the \pkg{l3expan} module
 %    where they are described.
 %    \begin{macrocode}
 \tex_let:D \exp_after:wN       \tex_expandafter:D
@@ -1448,7 +1448,7 @@
 % \begin{macro}{\scan_stop:, \group_begin:, \group_end:}
 %    The next three are basic functions for which there also exist
 %    versions that are safe inside alignments. These safe versions are
-%    defined in the \textsf{l3prg} module.
+%    defined in the \pkg{l3prg} module.
 %    \begin{macrocode}
 \tex_let:D \scan_stop:         \tex_relax:D
 \tex_let:D \group_begin:       \tex_begingroup:D
@@ -1513,10 +1513,10 @@
 %
 % \begin{variable}{\c_zero_int}
 %   We need the constant \cs{c_zero_int}
-%   which is used by some functions in the \textsf{l3alloc} module. The
-%   rest are defined in the \textsf{l3int} module -- at least for the
+%   which is used by some functions in the \pkg{l3alloc} module. The
+%   rest are defined in the \pkg{l3int} module -- at least for the
 %   ones that can be defined with \cs{tex_chardef:D} or
-%   \cs{tex_mathchardef:D}. For other constants the \textsf{l3int} module is
+%   \cs{tex_mathchardef:D}. For other constants the \pkg{l3int} module is
 %   required but it can't be used until the allocation has been set
 %   up properly!
 %    \begin{macrocode}

--- a/l3kernel/l3bitset.dtx
+++ b/l3kernel/l3bitset.dtx
@@ -30,7 +30,7 @@
 %</driver>
 % \fi
 % \title{^^A
-%   The \pkg{l3bitset} package  \\ Bitsets ^^A
+%   The \pkg{l3bitset} package\\ Bitsets^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3candidates.dtx
+++ b/l3kernel/l3candidates.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3candidates} package\\ Experimental additions to
+%   The \pkg{l3candidates} package\\ Experimental additions to
 %   \pkg{l3kernel}^^A
 % }
 %

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3coffins} package\\ Coffin code layer^^A
+%   The \pkg{l3coffins} package\\ Coffin code layer^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3color} package\\ Color support^^A
+%   The \pkg{l3color} package\\ Color support^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3debug} package\\ Debugging support^^A
+%   The \pkg{l3debug} package\\ Debugging support^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3flag.dtx
+++ b/l3kernel/l3flag.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3flag} package: Expandable flags^^A
+%   The \pkg{l3flag} package\\ Expandable flags^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3fp-assign.dtx
+++ b/l3kernel/l3fp-assign.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-assign} package\\
-%   Floating point expressions}
+% \title{^^A
+%   The \pkg{l3fp-assign} package\\
+%   Floating point expressions^^A
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp-aux.dtx
+++ b/l3kernel/l3fp-aux.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3fp-aux} package\\ Support for floating points^^A
+%   The \pkg{l3fp-aux} package\\ Support for floating points^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3fp-basics.dtx
+++ b/l3kernel/l3fp-basics.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-basics} package\\
-%   Floating point arithmetic}
+% \title{^^A
+%   The \pkg{l3fp-basics} package\\
+%   Floating point arithmetic^^A
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp-convert.dtx
+++ b/l3kernel/l3fp-convert.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3fp-convert} package\\ Floating point conversion^^A
+%   The \pkg{l3fp-convert} package\\ Floating point conversion^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3fp-expo.dtx
+++ b/l3kernel/l3fp-expo.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-expo} package\\
-%   Floating point exponential-related functions}
+% \title{^^A
+%   The \pkg{l3fp-expo} package\\
+%   Floating point exponential-related functions^^A
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp-extended.dtx
+++ b/l3kernel/l3fp-extended.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-extended} package\\
-%   Manipulating numbers with extended precision, for internal use}
+% \title{^^A
+%   The \pkg{l3fp-extended} package\\
+%   Manipulating numbers with extended precision, for internal use^^A
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp-logic.dtx
+++ b/l3kernel/l3fp-logic.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-logic} package\\
-%   Floating point conditionals}
+% \title{^^A
+%   The \pkg{l3fp-logic} package\\
+%   Floating point conditionals^^A
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp-parse.dtx
+++ b/l3kernel/l3fp-parse.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-parse} package\\
-%   Floating point expression parsing}
+% \title{^^A
+%   The \pkg{l3fp-parse} package\\
+%   Floating point expression parsing^^A
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp-random.dtx
+++ b/l3kernel/l3fp-random.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-random} package\\
-%   Floating point random numbers}
+% \title{^^A
+%   The \pkg{l3fp-random} package\\
+%   Floating point random numbers
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp-round.dtx
+++ b/l3kernel/l3fp-round.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3fp-round} package\\ Rounding floating points^^A
+%   The \pkg{l3fp-round} package\\ Rounding floating points^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3fp-traps.dtx
+++ b/l3kernel/l3fp-traps.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-traps} package\\
-%   Trapping floating-point exceptions}
+% \title{^^A
+%   The \pkg{l3fp-traps} package\\
+%   Trapping floating-point exceptions^^A
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp-trig.dtx
+++ b/l3kernel/l3fp-trig.dtx
@@ -30,8 +30,10 @@
 %</driver>
 % \fi
 %
-% \title{The \textsf{l3fp-trig} package\\
-%   Floating point trigonometric functions}
+% \title{^^A
+%   The \pkg{l3fp-trig} package\\
+%   Floating point trigonometric functions^^A
+% }
 % \author{^^A
 %  The \LaTeX{} Project\thanks
 %    {^^A

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -37,7 +37,7 @@
 %
 %
 % \title{^^A
-%   The \textsf{l3fp} package: Floating points^^A
+%   The \pkg{l3fp} package\\ Floating points^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3fparray.dtx
+++ b/l3kernel/l3fparray.dtx
@@ -32,7 +32,7 @@
 %
 %
 % \title{^^A
-%   The \textsf{l3fparray} package: Fast global floating point arrays^^A
+%   The \pkg{l3fparray} package\\ Fast global floating point arrays^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3intarray.dtx
+++ b/l3kernel/l3intarray.dtx
@@ -32,7 +32,7 @@
 %
 %
 % \title{^^A
-%   The \textsf{l3intarray} package: Fast global integer arrays^^A
+%   The \pkg{l3intarray} package\\ Fast global integer arrays^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3kernel-functions.dtx
+++ b/l3kernel/l3kernel-functions.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \pkg{l3kernel-functions} package: Kernel-reserved functions^^A
+%   The \pkg{l3kernel-functions} package\\ Kernel-reserved functions^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3legacy.dtx
+++ b/l3kernel/l3legacy.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3legacy} package\\ Interfaces to legacy concepts^^A
+%   The \pkg{l3legacy} package\\ Interfaces to legacy concepts^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \pkg{l3luatex} package: \LuaTeX-specific functions^^A
+%   The \pkg{l3luatex} package\\ \LuaTeX-specific functions^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3regex} package: Regular expressions in \TeX{}^^A
+%   The \pkg{l3regex} package\\ Regular expressions in \TeX{}^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3str-convert.dtx
+++ b/l3kernel/l3str-convert.dtx
@@ -32,7 +32,7 @@
 %
 %
 % \title{^^A
-%   The \textsf{l3str-convert} package: String encoding conversions^^A
+%   The \pkg{l3str-convert} package\\ String encoding conversions^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \pkg{l3str} package: Strings^^A
+%   The \pkg{l3str} package\\ Strings^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \pkg{l3sys} package: System/runtime functions^^A
+%   The \pkg{l3sys} package\\ System/runtime functions^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3text-case.dtx
+++ b/l3kernel/l3text-case.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3text-case} package: text processing (case changing)^^A
+%   The \pkg{l3text-case} package\\ Text processing (case changing)^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3text-map.dtx
+++ b/l3kernel/l3text-map.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3text-map} package: text processing (mapping)^^A
+%   The \pkg{l3text-map} package\\ Text processing (mapping)^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3text-purify.dtx
+++ b/l3kernel/l3text-purify.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3text-purify} package: text processing (purification)^^A
+%   The \pkg{l3text-purify} package\\ Text processing (purification)^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3text.dtx
+++ b/l3kernel/l3text.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3text} package: Text processing^^A
+%   The \pkg{l3text} package\\ Text processing^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -32,7 +32,7 @@
 %
 %
 % \title{^^A
-%   The \textsf{l3tl-analysis} package: Analysing token lists^^A
+%   The \pkg{l3tl-analysis} package\\ Analysing token lists^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3tl-build.dtx
+++ b/l3kernel/l3tl-build.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3tl-build} package\\ Piecewise \texttt{tl} constructions^^A
+%   The \pkg{l3tl-build} package\\ Piecewise \texttt{tl} constructions^^A
 % }
 %
 % \author{^^A

--- a/l3kernel/l3unicode.dtx
+++ b/l3kernel/l3unicode.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \pkg{l3unicode} package: Unicode support functions^^A
+%   The \pkg{l3unicode} package\\ Unicode support functions^^A
 % }
 %
 % \author{^^A

--- a/l3packages/l3keys2e/l3keys2e.dtx
+++ b/l3packages/l3keys2e/l3keys2e.dtx
@@ -49,7 +49,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3keys2e} package\\
+%   The \pkg{l3keys2e} package\\
 %     \LaTeXe{} option processing using \LaTeX3 keys^^A
 % }
 %

--- a/l3packages/xfp/xfp.dtx
+++ b/l3packages/xfp/xfp.dtx
@@ -51,7 +51,7 @@
 % \providecommand\nan{\texttt{NaN}}
 %
 % \title{^^A
-%   The \textsf{xfp} package\\Floating Point Unit^^A
+%   The \pkg{xfp} package\\ Floating Point Unit^^A
 % }
 %
 % \author{^^A

--- a/l3packages/xfrac/xfrac.dtx
+++ b/l3packages/xfrac/xfrac.dtx
@@ -53,7 +53,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{xfrac} package\\ Split-level fractions^^A
+%   The \pkg{xfrac} package\\ Split-level fractions^^A
 % }
 %
 % \author{^^A

--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -55,7 +55,7 @@
 %   \begin{itemize}\def\makelabel##1{\hss\llap{\bfseries##1}}}{\end{itemize}}
 %
 % \title{^^A
-%   The \textsf{xparse} package\\ Document command parser^^A
+%   The \pkg{xparse} package\\ Document command parser^^A
 % }
 %
 % \author{^^A

--- a/l3packages/xtemplate/xtemplate.dtx
+++ b/l3packages/xtemplate/xtemplate.dtx
@@ -51,7 +51,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{xtemplate} package\\ Prototype document functions^^A
+%   The \pkg{xtemplate} package\\ Prototype document functions^^A
 % }
 %
 % \author{^^A
@@ -98,7 +98,7 @@
 %   \item Loading one of the many packages to customise certain elements of
 %     the standard classes.
 %   \item Loading a completely different document class, such as
-%     \textsf{KOMA-Script} or \textsf{memoir}, that allows easy customisation.
+%     \cls{KOMA-Script} or \cls{memoir}, that allows easy customisation.
 % \end{itemize}
 % All three of these approaches have their drawbacks and learning curves.
 %

--- a/l3trial/l3ldb/l3ldbparse.dtx
+++ b/l3trial/l3ldb/l3ldbparse.dtx
@@ -49,7 +49,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3ldbparse} package: parsing LDB entries^^A
+%   The \pkg{l3ldbparse} package\\ Parsing LDB entries^^A
 % }
 %
 % \author{^^A

--- a/l3trial/l3ldb/l3precom.dtx
+++ b/l3trial/l3ldb/l3precom.dtx
@@ -46,7 +46,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{l3precom} package: precompiling functions^^A
+%   The \pkg{l3precom} package\\ Precompiling functions^^A
 % }
 %
 % \author{^^A

--- a/l3trial/l3ldb/l3precom.dtx
+++ b/l3trial/l3ldb/l3precom.dtx
@@ -125,7 +125,7 @@
 %
 % \begin{macro}{\cs_record_name:N, \cs_record_name:c}
 %   These functions mark a control sequence for dumping into a
-%   precompiled class.  When the \textsf{trace} `module' is included in
+%   precompiled class.  When the \pkg{trace} `module' is included in
 %   the code we also write information about the control sequence into a
 %   |.dmp| file.
 %    \begin{macrocode}

--- a/l3trial/xbox/xbox.dtx
+++ b/l3trial/xbox/xbox.dtx
@@ -31,7 +31,7 @@
 % \fi
 %
 % \title{^^A
-%   The \textsf{xbox} package\\Document level boxes^^A
+%   The \pkg{xbox} package\\ Document level boxes^^A
 % }
 %
 % \author{^^A


### PR DESCRIPTION
Started as spotting stray space in title of `l3bitset` in toc, 
![image](https://github.com/latex3/latex3/assets/6376638/e1744705-3700-4f3a-b8d3-0b043ebf3edc)

I ended with standarising all titles of `l3backend` and `l3kernel` modules and `l3experimental`, `l3trial`, and `l3packages` packages.

Files in `l3leftovers` (after all they're leftovers) and `xpackages` (some files loaded non-`l3doc` class) are intact.