### PR TITLE
Keep indents in l3bitset multi-line syntaxes, and more

### DIFF
--- a/l3kernel/l3bitset.dtx
+++ b/l3kernel/l3bitset.dtx
@@ -210,7 +210,7 @@
 % \begin{function}[EXP,added = 2021-01-26]
 %   {\bitset_item:Nn, \bitset_item:cn}
 %   \begin{syntax}
-%     \cs{bitset_item:Nn}   \meta{bitset var}  \Arg{name}
+%     \cs{bitset_item:Nn} \meta{bitset var} \Arg{name}
 %   \end{syntax}
 % \cs{bitset_item:Nn} outputs \texttt{1} if the bit with
 % the index number represented by \Arg{name} is set and \texttt{0} otherwise.
@@ -227,6 +227,7 @@
 %   a binary (string) number in the input stream.
 %   If no bit has been set yet, the output is zero.
 % \end{function}
+%
 % \begin{function}[EXP,added = 2021-01-26]
 %   {\bitset_to_arabic:N, \bitset_to_arabic:c}
 %   \begin{syntax}
@@ -334,8 +335,7 @@
 \prg_new_eq_conditional:NNn
   \bitset_if_exist:N \str_if_exist:N { p , T , F , TF }
 \prg_new_eq_conditional:NNn
-  \bitset_if_exist:c \str_if_exist:c
-  { p , T , F , TF }
+  \bitset_if_exist:c \str_if_exist:c { p , T , F , TF }
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}{\@@_set_true:Nn, \@@_gset_true:Nn, \@@_set_false:Nn, \@@_gset_false:Nn}

--- a/l3kernel/l3bitset.dtx
+++ b/l3kernel/l3bitset.dtx
@@ -78,10 +78,10 @@
 %   \begin{syntax}
 %     \cs{bitset_new:N}  \meta{bitset var} \\
 %     \cs{bitset_new:Nn} \meta{bitset var}
-%      \{
-%         \meta{name1} |=| \meta{index1} |,|
-%         \meta{name2} |=| \meta{index2} |,| \ldots{}
-%      \}
+%     ~~\{
+%     ~~~~\meta{name1} |=| \meta{index1} |,|
+%     ~~~~\meta{name2} |=| \meta{index2} |,| \ldots{}
+%     ~~\}
 %   \end{syntax}
 % Creates a new \meta{bitset var} or raises an error if the name is already taken.
 % The declaration is global. The \meta{bitset var} is initially $0$.
@@ -116,10 +116,10 @@
 %   {\bitset_addto_named_index:Nn}
 %   \begin{syntax}
 %     \cs{bitset_addto_named_index:Nn} \meta{bitset var}
-%      \{
-%         \meta{name1} |=| \meta{index1} |,|
-%         \meta{name2} |=| \meta{index2} |,| \ldots{}
-%      \}
+%     ~~\{
+%     ~~~~\meta{name1} |=| \meta{index1} |,|
+%     ~~~~\meta{name2} |=| \meta{index2} |,| \ldots{}
+%     ~~\}
 %   \end{syntax}
 %   This extends or changes the name--index pairs for \meta{bitset var}
 %   globally as described for \cs{bitset_new:Nn}.

--- a/l3kernel/l3bitset.dtx
+++ b/l3kernel/l3bitset.dtx
@@ -169,8 +169,7 @@
 %     \bitset_gset_true:Nn, \bitset_gset_true:cn
 %   }
 %   \begin{syntax}
-%     \cs{bitset_set_true:Nn}   \meta{bitset var}  \Arg{name}\\
-%     \cs{bitset_gset_true:Nn}  \meta{bitset var}  \Arg{name}
+%     \cs{bitset_set_true:Nn} \meta{bitset var} \Arg{name}
 %   \end{syntax}
 %   This sets the bit of the index position represented by \Arg{name} to $1$.
 %   \Arg{name} should be either one of the predeclared names
@@ -185,8 +184,7 @@
 %     \bitset_gset_false:Nn, \bitset_set_false:cn
 %   }
 %   \begin{syntax}
-%     \cs{bitset_set_false:Nn}   \meta{bitset var}  \Arg{name}\\
-%     \cs{bitset_gset_false:Nn}  \meta{bitset var}  \Arg{name}
+%     \cs{bitset_set_false:Nn} \meta{bitset var} \Arg{name}
 %   \end{syntax}
 %   This unsets the bit of the index position represented by \Arg{name} (sets
 %   it to $0$).
@@ -202,8 +200,7 @@
 % \begin{function}[added = 2021-01-26]
 %   {\bitset_clear:N,\bitset_clear:c,\bitset_gclear:N,\bitset_gclear:c}
 %   \begin{syntax}
-%     \cs{bitset_clear:N}  \meta{bitset var} \\
-%     \cs{bitset_gclear:N}  \meta{bitset var}
+%     \cs{bitset_clear:N} \meta{bitset var}
 %   \end{syntax}
 %   This resets the bitset to the initial state. The declared names are not changed.
 % \end{function}


### PR DESCRIPTION
This PR mainly corrects lost indentations found in several `l3bitset` function syntaxes. 

> From `texdoc l3bitset`, indents are missing in this and several more `syntax` envs.
> 
> <sub>_Originally posted by @muzimuzhi in https://github.com/latex3/latex3/pull/1341#discussion_r1394967095_</sub>

Sample comparisons

| Before | After |
|--------|--------|
| ![image](https://github.com/latex3/latex3/assets/6376638/f00b08d0-e6bd-4c91-be83-b518f72cee2f) | ![image](https://github.com/latex3/latex3/assets/6376638/bafcd950-f01b-428a-9d09-ef679abf181a) |
| ![image](https://github.com/latex3/latex3/assets/6376638/f51e9698-641f-43ea-a2ba-6ddb1613c760) | ![image](https://github.com/latex3/latex3/assets/6376638/55df48cd-6c0a-432f-88af-aadb25b32095) |