### PR TITLE
Add missing columns in prefix csv

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -123,7 +123,7 @@ intarray,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,ht
 ior,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 iot,iot,Island of TeX,https://islandoftex.gitlab.io,https://gitlab.com/islandoftex/texmf,https://gitlab.com/groups/islandoftex/texmf/-/issues,2023-07-18,2023-07-18,
 iow,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
-iwonamath,iwonamath,Boris Veytsman,https://github.com/borisveytsman/iwonamath,https://github.com/borisveytsman/iwonamath,https://github.com/borisveytsman/iwonamath/issues
+iwonamath,iwonamath,Boris Veytsman,https://github.com/borisveytsman/iwonamath,https://github.com/borisveytsman/iwonamath,https://github.com/borisveytsman/iwonamath/issues,2023-09-04,2023-09-04,
 jiazhu,jiazhu,Qing Lee,https://github.com/CTeX-org/ctex-kit,https://github.com/CTeX-org/ctex-kit.git,https://github.com/CTeX-org/ctex-kit/issues,2020-05-17,2020-05-17,
 job,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2021-04-23,2021-04-23,
 kernel,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -12,7 +12,7 @@ alloc,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https
 ampersand,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 apfs,apfontspec,Qing Lee,https://github.com/CTeX-org/apfontspec,https://github.com/CTeX-org/apfontspec.git,https://github.com/CTeX-org/apfontspec/issues,2020-05-17,2020-05-17,
 arch,archaeologie,Lukas C. Bossert,http://www.biblatex-archaeologie.de,https://github.com/LukasCBossert/biblatex-archaeologie.git,https://github.com/LukasCBossert/biblatex-archaeologie/issues,2017-03-24,2017-03-24,
-arsenal,arsenal,Boris Veytsman,https://github.com/borisveytsman/arsenal,https://github.com/borisveytsman/arsenal,https://github.com/borisveytsman/arsenal/issues
+arsenal,arsenal,Boris Veytsman,https://github.com/borisveytsman/arsenal,https://github.com/borisveytsman/arsenal,https://github.com/borisveytsman/arsenal/issues,2023-09-04,2023-09-04,
 array,hobby,Andrew Stacey,https://github.com/loopspace/hobby,https://github.com/loopspace/hobby,https://github.com/loopspace/hobby/issues,2013-03-16,2020-10-29,
 atsign,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 avm,langsci-avm,Felix Kopecky,https://ctan.org/pkg/langsci-avm,https://github.com/langsci/langsci-avm,https://github.com/langsci/langsci-avm/issues,2020-03-11,2020-03-11,


### PR DESCRIPTION
This PR re-enables rendering of `l3prefixes.csv` on GitHub.

Before
https://github.com/latex3/latex3/blob/dc9f9616ccb3273dea833ea632fa6cf0a8f995cd/l3kernel/doc/l3prefixes.csv
<img width="600" alt="image" src="https://github.com/latex3/latex3/assets/6376638/f515e156-f816-4887-8ca2-049149869216">

After
https://github.com/muzimuzhi/latex3/blob/fix/csv-columns/l3kernel/doc/l3prefixes.csv
<img width="600" alt="image" src="https://github.com/latex3/latex3/assets/6376638/395e0325-090b-4c39-921c-380564dd6d6b">

GitHub Docs https://docs.github.com/en/repositories/working-with-files/using-files/working-with-non-code-files#rendering-csv-and-tsv-data