### PR TITLE
Avoid trimming spaces twice on (raw) key names

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1822,14 +1822,14 @@
 %   }
 %   Searching for a property means finding the last |.| in the input,
 %   and storing the text before and after it. Everything is turned into
-%   strings, so there is no problem using an \texttt{e}-type expansion. Since
-%   \cs{@@_trim_spaces:n} will turn its argument into a string anyway, this
-%   function uses \cs{cs_set_nopar:Npe} instead of \cs{tl_set:Ne} to gain some
-%   speed.
+%   strings at first, so there is no problem using an \texttt{e}-type expansion
+%   in aux functions. \cs{cs_set_nopar:Npe} instead of \cs{tl_set:Ne} or
+%   \cs{str_set:Ne} is used to gain some speed.
+%   Space trimming on key path is done only once, after the last |.| is found.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_property_find:n #1
   {
-    \cs_set_nopar:Npe \l_@@_property_str { \@@_trim_spaces:n { #1 } }
+    \str_set:Nn \l_@@_property_str { #1 }
     \exp_after:wN \@@_property_find_auxi:w \l_@@_property_str
       \s_@@_nil \@@_property_find_auxii:w
       . \s_@@_nil \@@_property_find_err:w


### PR DESCRIPTION
`\__keys_trim_spaces:n` is now applied only once, after the last `.` is found.

This is a refactor (found in my almost lost `git stash`) that simplifies `\__keys_property_find:n` a little bit.