### PR TITLE
l3keys: Speed up property_find

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1835,7 +1835,7 @@
       \s_@@_nil \@@_property_find_auxii:w
       . \s_@@_nil \@@_property_find_err:w
   }
-\cs_new_protected:Npn \@@_property_find_auxi:w #1 . #2 \s_@@_nil #3
+\cs_new:Npn \@@_property_find_auxi:w #1 . #2 \s_@@_nil #3
   {
     #3 #1 \s_@@_mark #2 \s_@@_nil #3
   }

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1826,11 +1826,12 @@
 %   in aux functions. \cs{cs_set_nopar:Npe} instead of \cs{tl_set:Ne} or
 %   \cs{str_set:Ne} is used to gain some speed.
 %   Space trimming on key path is done only once, after the last |.| is found.
+%   Since spaces will already be trimmed from the module we can omit it from the
+%   argument to \cs{@@_trim_spaces:n}.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_property_find:n #1
   {
-    \str_set:Nn \l_@@_property_str { #1 }
-    \exp_after:wN \@@_property_find_auxi:w \l_@@_property_str
+    \exp_after:wN \@@_property_find_auxi:w \tl_to_str:n {#1}
       \s_@@_nil \@@_property_find_auxii:w
       . \s_@@_nil \@@_property_find_err:w
   }
@@ -1843,22 +1844,24 @@
     \@@_property_find_err:w
   {
     \cs_set_nopar:Npe \l_keys_path_str
-      { \str_if_empty:NF \l_@@_module_str { \l_@@_module_str / } #1 }
-    \@@_property_find_auxi:w #2 \s_@@_nil \@@_property_find_auxiii:w . \s_@@_nil
-      \@@_property_find_auxiv:w
+      {
+        \str_if_empty:NF \l_@@_module_str { \l_@@_module_str / }
+        \exp_after:wN \@@_trim_spaces:n \tex_expanded:D {{
+        #1
+        \if_false: }}} \fi:
+        \@@_property_find_auxi:w #2 \s_@@_nil \@@_property_find_auxiii:w
+          . \s_@@_nil \@@_property_find_auxiv:w
   }
-\cs_new_protected:Npn \@@_property_find_auxiii:w #1 \s_@@_mark
+\cs_new:Npn \@@_property_find_auxiii:w #1 \s_@@_mark #2 . #3 \s_@@_nil #4
   {
-    \cs_set_nopar:Npe \l_keys_path_str { \l_keys_path_str . #1 }
-    \@@_property_find_auxi:w
+    . #1 #4 #2 \s_@@_mark #3 \s_@@_nil #4
   }
-\cs_new_protected:Npn \@@_property_find_auxiv:w
+\cs_new:Npn \@@_property_find_auxiv:w
     #1 \s_@@_nil \@@_property_find_auxiii:w
     \s_@@_mark \s_@@_nil \@@_property_find_auxiv:w
   {
+    \if_false: {{{ \fi: }}}
     \cs_set_nopar:Npe \l_@@_property_str { . #1 }
-    \cs_set_nopar:Npe \l_keys_path_str
-      { \exp_after:wN \@@_trim_spaces:n \exp_after:wN { \l_keys_path_str } }
     \tl_set_eq:NN \l_keys_path_tl \l_keys_path_str
   }
 \cs_new_protected:Npn \@@_property_find_err:w


### PR DESCRIPTION
This commit speeds up the `\@@_property_find:n` function of `l3keys` by roughly 20% - 30%.