### PR TITLE
Document default l3doc class options

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -272,6 +272,12 @@ and all files in that bundle must be distributed together.
 % class option. To disable hyphenation of control sequences entirely, use
 % \texttt{cs-break = false}.
 %
+% By default, class options
+% \begin{verbatim}
+%   full , kernel , check = false , checktest = false , lm-default
+% \end{verbatim}
+% are set.
+%
 % \subsection{Partitioning documentation and implementation}
 %
 % \pkg{doc} uses the \cs{OnlyDocumentation}/\cs{AlsoImplementation}

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -237,8 +237,10 @@ and all files in that bundle must be distributed together.
 % encoding (the standard setting) or leaves the font setup unchanged.
 %
 % \DescribeOption{kernel}
-% Determines whether \pkg{l3doc} treats |\__kernel_| commands and
-% |\(c|g|l)__kernel_| variables as allowable in code. In general,
+% Determines whether \pkg{l3doc} treats internal functions and variables
+% belonging to |kernel| module as allowable in code, for instance
+% \cs{__kernel_tl_to_str:w}, \cs{c__kernel_expl_date_tl}, and
+% \cs{l__kernel_expl_bool}. In general,
 % \emph{no} internal material from outside the current module is allowed.
 % However, for bootstrapping the \pkg{expl3} kernel, a small number of
 % cross-module functions are needed. To suppress the error message that


### PR DESCRIPTION
For the typo,
- before
  ![image](https://github.com/latex3/latex3/assets/6376638/43e5b13e-5515-4cf5-889c-9578b6ffed67)
  > `kernel`
  > Determines whether `l3doc` treats `\__kernel_` commands and `\(cgl)__kernel_` variables as allowable in code.
- after (initial proposal)
  ![image](https://github.com/latex3/latex3/assets/6376638/e2a32b86-48bd-4dc1-bab6-f646a8028ec4)
- after (latest)
  > `kernel`
  > Determines whether `l3doc` treats internal functions and variables belong to `kernel` module as allowable in code, for instance `\__kernel_tl_to_str:w`, `\c__kernel_expl_date_tl`, and `\l__kernel_expl_bool`.