### PR TITLE
remove doubled documentation of use_i_ii

### DIFF
--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -966,7 +966,7 @@
 %     \use_i:nnnnnnn, \use_ii:nnnnnnn, \use_iii:nnnnnnn, \use_iv:nnnnnnn ,
 %       \use_v:nnnnnnn , \use_vi:nnnnnnn , \use_vii:nnnnnnn ,
 %     \use_i:nnnnnnnn, \use_ii:nnnnnnnn, \use_iii:nnnnnnnn, \use_iv:nnnnnnnn ,
-%       \use_v:nnnnnnnn , \use_vi:nnnnnnnn , \use_vii:nnnnnnnn , \use_vii:nnnnnnnn ,
+%       \use_v:nnnnnnnn , \use_vi:nnnnnnnn , \use_vii:nnnnnnnn , \use_viii:nnnnnnnn ,
 %     \use_i:nnnnnnnnn, \use_ii:nnnnnnnnn, \use_iii:nnnnnnnnn, \use_iv:nnnnnnnnn ,
 %       \use_v:nnnnnnnnn , \use_vi:nnnnnnnnn , \use_vii:nnnnnnnnn , \use_viii:nnnnnnnnn ,
 %       \use_ix:nnnnnnnnn
@@ -1687,7 +1687,7 @@
 %     \use_i:nnnnnnn, \use_ii:nnnnnnn, \use_iii:nnnnnnn, \use_iv:nnnnnnn ,
 %       \use_v:nnnnnnn , \use_vi:nnnnnnn , \use_vii:nnnnnnn ,
 %     \use_i:nnnnnnnn, \use_ii:nnnnnnnn, \use_iii:nnnnnnnn, \use_iv:nnnnnnnn ,
-%       \use_v:nnnnnnnn , \use_vi:nnnnnnnn , \use_vii:nnnnnnnn ,
+%       \use_v:nnnnnnnn , \use_vi:nnnnnnnn , \use_vii:nnnnnnnn , \use_viii:nnnnnnnn ,
 %     \use_i:nnnnnnnnn, \use_ii:nnnnnnnnn, \use_iii:nnnnnnnnn, \use_iv:nnnnnnnnn ,
 %       \use_v:nnnnnnnnn , \use_vi:nnnnnnnnn , \use_vii:nnnnnnnnn , \use_viii:nnnnnnnnn ,
 %       \use_ix:nnnnnnnnn

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1687,18 +1687,16 @@
 %     \use_i:nnnnnnn, \use_ii:nnnnnnn, \use_iii:nnnnnnn, \use_iv:nnnnnnn ,
 %       \use_v:nnnnnnn , \use_vi:nnnnnnn , \use_vii:nnnnnnn ,
 %     \use_i:nnnnnnnn, \use_ii:nnnnnnnn, \use_iii:nnnnnnnn, \use_iv:nnnnnnnn ,
-%       \use_v:nnnnnnnn , \use_vi:nnnnnnnn , \use_vii:nnnnnnnn , \use_vii:nnnnnnnn ,
+%       \use_v:nnnnnnnn , \use_vi:nnnnnnnn , \use_vii:nnnnnnnn ,
 %     \use_i:nnnnnnnnn, \use_ii:nnnnnnnnn, \use_iii:nnnnnnnnn, \use_iv:nnnnnnnnn ,
 %       \use_v:nnnnnnnnn , \use_vi:nnnnnnnnn , \use_vii:nnnnnnnnn , \use_viii:nnnnnnnnn ,
 %       \use_ix:nnnnnnnnn
 %   }
-% \begin{macro}[EXP]{\use_i_ii:nnn}
 %   We also need something for picking up arguments from a longer list.
 %    \begin{macrocode}
 \cs_set:Npn \use_i:nnn    #1#2#3 {#1}
 \cs_set:Npn \use_ii:nnn   #1#2#3 {#2}
 \cs_set:Npn \use_iii:nnn  #1#2#3 {#3}
-\cs_set:Npn \use_i_ii:nnn #1#2#3 {#1#2}
 \cs_set:Npn \use_i:nnnn   #1#2#3#4 {#1}
 \cs_set:Npn \use_ii:nnnn  #1#2#3#4 {#2}
 \cs_set:Npn \use_iii:nnnn #1#2#3#4 {#3}
@@ -1740,6 +1738,11 @@
 \cs_set:Npn \use_ix:nnnnnnnnn   #1#2#3#4#5#6#7#8#9 {#9} 
 %    \end{macrocode}
 % \end{macro}
+%
+% \begin{macro}[EXP]{\use_i_ii:nnn}
+%    \begin{macrocode}
+\cs_set:Npn \use_i_ii:nnn #1#2#3 {#1#2}
+%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}[EXP]{\use_ii_i:nn}

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -957,7 +957,7 @@
 % \begin{function}[EXP]
 %   {
 %     \use_i:nn, \use_ii:nn ,
-%     \use_i:nnn , \use_ii:nnn , \use_iii:nnn , \use_i_ii:nnn ,
+%     \use_i:nnn , \use_ii:nnn , \use_iii:nnn ,
 %     \use_i:nnnn, \use_ii:nnnn, \use_iii:nnnn, \use_iv:nnnn  ,
 %     \use_i:nnnnn, \use_ii:nnnnn, \use_iii:nnnnn, \use_iv:nnnnn ,
 %       \use_v:nnnnn ,
@@ -1678,7 +1678,7 @@
 %
 % \begin{macro}[EXP]
 %   {
-%     \use_i:nnn , \use_ii:nnn , \use_iii:nnn , \use_i_ii:nnn ,
+%     \use_i:nnn , \use_ii:nnn , \use_iii:nnn ,
 %     \use_i:nnnn, \use_ii:nnnn, \use_iii:nnnn, \use_iv:nnnn  ,
 %     \use_i:nnnnn, \use_ii:nnnnn, \use_iii:nnnnn, \use_iv:nnnnn ,
 %       \use_v:nnnnn ,
@@ -1692,6 +1692,7 @@
 %       \use_v:nnnnnnnnn , \use_vi:nnnnnnnnn , \use_vii:nnnnnnnnn , \use_viii:nnnnnnnnn ,
 %       \use_ix:nnnnnnnnn
 %   }
+% \begin{macro}[EXP]{\use_i_ii:nnn}
 %   We also need something for picking up arguments from a longer list.
 %    \begin{macrocode}
 \cs_set:Npn \use_i:nnn    #1#2#3 {#1}
@@ -1738,6 +1739,7 @@
 \cs_set:Npn \use_viii:nnnnnnnnn #1#2#3#4#5#6#7#8#9 {#8}
 \cs_set:Npn \use_ix:nnnnnnnnn   #1#2#3#4#5#6#7#8#9 {#9} 
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 %
 % \begin{macro}[EXP]{\use_ii_i:nn}


### PR DESCRIPTION
The function `\use_i_ii:nn` shows up in the list of variants of `\use_i:n...`, even though it's documented separately.