### PR TITLE
l3expan doc improvements (#1064)

### DIFF
--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -73,11 +73,11 @@
 % in braces. Applying \cs{exp_args:NNo} expands the content of third
 % argument once before any expansion of the first and second arguments.
 % If \cs{seq_gpush:No} was not defined it could be coded in the following way:
-% \begin{verbatim}
-%   \exp_args:NNo \seq_gpush:Nn
-%      \g_file_name_stack
-%      { \l_tmpa_tl }
-% \end{verbatim}
+% \begin{quote}\ttfamily
+%   |\exp_args:NNo \seq_gpush:Nn|\\
+%   |   \g_file_name_stack|\\
+%   |   { \l_tmpa_tl }|
+% \end{quote}
 % In other words, the first argument to \cs{exp_args:NNo} is the base
 % function and the other arguments are preprocessed and then passed to
 % this base function. In the example the first argument to the base
@@ -138,16 +138,16 @@
 %   ingored. For each \meta{variant} given, a function is created
 %   that expands its arguments as detailed and passes them
 %   to the \meta{parent control sequence}. So for example
-%   \begin{verbatim}
-%     \cs_set:Npn \foo:Nn #1#2 { code here }
-%     \cs_generate_variant:Nn \foo:Nn { c }
-%   \end{verbatim}
+%   \begin{quote}\ttfamily
+%     |\cs_set:Npn \foo:Nn #1#2 {|\meta{code here}|}|\\
+%     |\cs_generate_variant:Nn \foo:Nn { c }|
+%   \end{quote}
 %   creates a new function |\foo:cn| which expands its first
 %   argument into a control sequence name and passes the result to
 %   |\foo:Nn|. Similarly
-%   \begin{verbatim}
-%     \cs_generate_variant:Nn \foo:Nn { NV , cV }
-%   \end{verbatim}
+%   \begin{quote}\ttfamily
+%     |\cs_generate_variant:Nn \foo:Nn { NV , cV }|
+%   \end{quote}
 %   generates the functions |\foo:NV| and |\foo:cV| in the same
 %   way. The \cs{cs_generate_variant:Nn} function should only be applied if
 %   the \meta{parent control sequence} is already defined. (This is only
@@ -274,18 +274,18 @@
 % right in their arguments. In particular, |o| type expansion
 % applies to the first \emph{token} in the argument it receives: it
 % is conceptually similar to
-% \begin{verbatim}
-%   \exp_after:wN <base function> \exp_after:wN { <argument> }
-% \end{verbatim}
+% \begin{quote}\ttfamily
+%   |\exp_after:wN |\meta{base function}| \exp_after:wN {|\meta{argument}|}|
+% \end{quote}
 % At the same time, |f| type expansion stops at the \emph{first}
 % non-expandable token. This means for example that both
-% \begin{verbatim}
-%    \tl_set:No \l_tmpa_tl { { \g_tmpb_tl } }
-% \end{verbatim}
+% \begin{quote}\ttfamily
+%    |\tl_set:No \l_tmpa_tl { { \g_tmpb_tl } }|
+% \end{quote}
 % and
-% \begin{verbatim}
-%    \tl_set:Nf \l_tmpa_tl { { \g_tmpb_tl } }
-% \end{verbatim}
+% \begin{quote}\ttfamily
+%    |\tl_set:Nf \l_tmpa_tl { { \g_tmpb_tl } }|
+% \end{quote}
 % leave |\g_tmpb_tl| unchanged: |{| is the first token in the
 % argument and is non-expandable.
 %
@@ -1515,10 +1515,10 @@
 % \begin{macro}[EXP]{\exp_last_two_unbraced:Noo}
 % \begin{macro}[EXP]{\@@_last_two_unbraced:noN}
 %   If |#2| is a single token then this can be implemented as
-%   \begin{verbatim}
-%     \cs_new:Npn \exp_last_two_unbraced:Noo #1 #2 #3
-%      { \exp_after:wN \exp_after:wN \exp_after:wN #1 \exp_after:wN #2 #3 }
-%   \end{verbatim}
+%   \begin{quote}\ttfamily
+%     |\cs_new:Npn \exp_last_two_unbraced:Noo #1 #2 #3|\\
+%     |{ \exp_after:wN \exp_after:wN \exp_after:wN #1 \exp_after:wN #2 #3 }|\\
+%   \end{quote}
 %   However, for robustness this is not suitable. Instead, a bit of a
 %   shuffle is used to ensure that |#2| can be multiple tokens.
 %    \begin{macrocode}

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -130,59 +130,61 @@
 % \begin{function}[updated = 2017-11-28]
 %   {\cs_generate_variant:Nn, \cs_generate_variant:cn}
 %   \begin{syntax}
-%     \cs{cs_generate_variant:Nn} \meta{parent control sequence} \Arg{variant argument specifiers}
+%     \cs{cs_generate_variant:Nn} \cs[no-index]{\meta{name}:\meta{base arg spec}} \Arg{variant argument specifiers}
 %   \end{syntax}
-%   This function is used to define argument-specifier variants of the
-%   \meta{parent control sequence} for \LaTeX3 code-level macros. The
-%   \meta{parent control sequence} is first separated into the
-%   \meta{base name} and \meta{original argument specifier}. The
-%   comma-separated list of \meta{variant argument specifiers} is
-%   then used to define variants of the
-%   \meta{original argument specifier} if these are not already
-%   defined; entries which correspond to existing functions are silently
-%   ingored. For each \meta{variant} given, a function is created
-%   that expands its arguments as detailed and passes them
-%   to the \meta{parent control sequence}. So for example
+%   This function is used to define argument specifier variants of the
+%   base function \cs[no-index]{\meta{name}:\meta{base arg spec}}.
+%   The head of \meta{base arg spec} must consist of |N|, |n| or |p|.
+%   The \meta{variant argument specifiers} is a comma-separated list of
+%   argument specifiers used to build \meta{variant arg spec}'s,
+%   by mapping the heading letters of \meta{base arg spec}.
+%   The only possible mappings are
+%   \begin{itemize}
+%   \item |N| to |c|;
+%   \item |n| to |o|, |V|, |v|, |f|, |e|, or |x|;
+%   \item |p| to |p|;
+%   \end{itemize}
+%   with the restriction that |p| arguments must be followed
+%   \emph{in fine} by a braced group.
+%
+%   If it does not exist, each variant function
+%   \cs[no-index]{\meta{name}|:|\meta{variant arg spec}} is globally
+%   created, as is the function \cs[no-index]{exp_args:N\meta{variant arg spec}}
+%   needed to expand the arguments as necessary before they
+%   are passed to the base function.
+%   So for example
 %   \begin{quote}\ttfamily
 %     |\cs_set:Npn \foo:Nn #1#2 {|\meta{code here}|}|\\
 %     |\cs_generate_variant:Nn \foo:Nn { c }|
 %   \end{quote}
 %   creates a new function |\foo:cn| which expands its first
-%   argument into a control sequence name and passes the result to
+%   argument into a control sequence further passed as first argument to
 %   |\foo:Nn|. Similarly
-%   \begin{quote}\ttfamily
+%   \begin{quote}
 %     |\cs_generate_variant:Nn \foo:Nn { NV , cV }|
 %   \end{quote}
-%   generates the functions |\foo:NV| and |\foo:cV| in the same
-%   way. The \cs{cs_generate_variant:Nn} function should only be applied if
-%   the \meta{parent control sequence} is already defined. (This is only
-%   enforced if debugging support \texttt{check-declarations} is enabled.)
-%   If the \meta{parent
-%   control sequence} is protected or if the \meta{variant} involves any
-%   |x|~argument, then the \meta{variant control sequence} is also
-%   protected.  The \meta{variant} is created globally, as is any
-%   \cs[no-index]{exp_args:N\meta{variant}} function needed to carry out the
-%   expansion. There is no need to re-apply \cs{cs_generate_variant:Nn} after
-%   changing the definition of the parent function: the variant will always
-%   use the current definition of the parent. Providing variants repeatedly is
-%   safe as \cs{cs_generate_variant:Nn} will only create new definitions if
-%   there is not already one available.
+%   generates the variants |\foo:NV| and |\foo:cV| in the same
+%   way. Notice that
+%   \begin{quote}
+%     |\cs_generate_variant:Nn \foo:cn { cV }|
+%   \end{quote}
+%   is an error to generate |\foo:cV| because |cn| is not a
+%   \meta{base arg spec}. On the contrary
+%   \begin{quote}
+%     |\cs_generate_variant:Nn \foo:nc { Vc }|
+%   \end{quote}
+%   is allowed because |c| is not part of the \meta{base arg spec} head.
 %
-%   Only |n|~and |N| arguments can be changed to other types.  The only
-%   allowed changes are
-%   \begin{itemize}
-%   \item |c|~variant of an |N|~parent;
-%   \item |o|, |V|, |v|, |f|, |e|, or~|x| variant of an |n|~parent;
-%   \item |N|, |n|, |T|, |F|, or |p| argument unchanged.
-%   \end{itemize}
-%   This means the \meta{parent} of a \meta{variant} form is always
-%   unambiguous, even in cases where both an |n| type parent and an
-%   |N| type parent exist, such as for \cs{tl_count:n} and
-%   \cs{tl_count:N}.
-%
-%   When creating variants for conditional functions,
-%   \cs{prg_generate_conditional_variant:Nnn} provides a convenient way
-%   of handling the related function set.
+%   The \cs{cs_generate_variant:Nn} function should only be applied to
+%   already defined base functions\footnotemark{}.
+%   If the base function is protected or if the \meta{variant arg spec} contains
+%   |x|, then the variant is
+%   protected. There is no need to re-apply \cs{cs_generate_variant:Nn} after
+%   changing the definition of the base function: the variant will always
+%   use the current definition of the base.
+%   As \cs{cs_generate_variant:Nn} does nothing when the variant
+%   is already available, generating the same variants repeatedly is 
+%   safe.
 %
 %   For backward compatibility it is currently possible to make |n|,
 %   |o|, |V|, |v|, |f|, |e|, or |x| type variants of an |N| type argument or
@@ -195,22 +197,25 @@
 %   using the lower-level \cs{exp_args:No} or \cs{exp_args:Nc}
 %   functions explicitly is preferred to defining confusing variants.
 % \end{function}
+% \footnotetext{This is only
+%   enforced if debugging support \texttt{check-declarations} is enabled.}
 %
 % \begin{function}[added = 2018-04-04, updated = 2019-02-08]
 %   {\exp_args_generate:n}
 %   \begin{syntax}
 %     \cs{exp_args_generate:n} \Arg{variant argument specifiers}
 %   \end{syntax}
-%   Defines \cs[no-index]{exp_args:N\meta{variant}} functions for each
-%   \meta{variant} given in the comma list \Arg{variant argument
-%   specifiers}.  Each \meta{variant} should consist of the letters |N|,
+%   Defines \cs[no-index]{exp_args:N\meta{variant arg spec}} functions for each
+%   \meta{variant arg spec} given in the comma list \meta{variant argument
+%   specifiers}.  Each \meta{variant arg spec} should consist of the letters |N|,
 %   |c|, |n|, |V|, |v|, |o|, |f|, |e|, |x|, |p| and the resulting function is
-%   protected if the letter |x| appears in the \meta{variant}.  This is
-%   only useful for cases where \cs{cs_generate_variant:Nn} is not
+%   protected if the letter |x| appears in the \meta{variant arg spec}.
+%   This is
+%   only useful for cases where the function \cs{cs_generate_variant:Nn} is not
 %   applicable.
 % \end{function}
 %
-% \section{Introducing the variants}
+% \section{The variant letter types}
 %
 % The |V| type returns the value of a register, which can be one of
 % |tl|, |clist|, |int|, |skip|, |dim|, |muskip|, or built-in \TeX{}

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -108,15 +108,15 @@
 % \begin{itemize}
 % \item |N|~is used for single-token arguments while |c|~constructs a
 %   control sequence from its name and passes it to a parent function as
-%   an |N|-type argument.
+%   an |N| type argument.
 % \item Many argument types extract or expand some tokens and provide it
-%   as an |n|-type argument, namely a braced multiple-token argument:
+%   as an |n| type argument, namely a braced multiple-token argument:
 %   |V|~extracts the value of a variable, |v|~extracts the value from
 %   the name of a variable, |n|~uses the argument as it is, |o|~expands
 %   once, |f|~expands fully the front of the token list, |e| and
 %   |x|~expand fully all tokens (differences are explained later).
 % \item A few odd argument types remain: |T|~and |F|~for conditional
-%   processing, otherwise identical to |n|-type arguments,
+%   processing, otherwise identical to |n| type arguments,
 %   |p|~for the parameter text
 %   in definitions, |w|~for arguments with a specific syntax, and |D|~to
 %   denote primitives that should not be used directly.
@@ -171,8 +171,8 @@
 %   \item |N|, |n|, |T|, |F|, or |p| argument unchanged.
 %   \end{itemize}
 %   This means the \meta{parent} of a \meta{variant} form is always
-%   unambiguous, even in cases where both an |n|-type parent and an
-%   |N|-type parent exist, such as for \cs{tl_count:n} and
+%   unambiguous, even in cases where both an |n| type parent and an
+%   |N| type parent exist, such as for \cs{tl_count:n} and
 %   \cs{tl_count:N}.
 %
 %   When creating variants for conditional functions,
@@ -180,13 +180,13 @@
 %   of handling the related function set.
 %
 %   For backward compatibility it is currently possible to make |n|,
-%   |o|, |V|, |v|, |f|, |e|, or |x|-type variants of an |N|-type argument or
-%   |N| or |c|-type variants of an |n|-type argument.  Both are
+%   |o|, |V|, |v|, |f|, |e|, or |x| type variants of an |N| type argument or
+%   |N| or |c| type variants of an |n| type argument.  Both are
 %   deprecated.  The first because passing more than one token to an
-%   |N|-type argument will typically break the parent function's code.
+%   |N| type argument will typically break the parent function's code.
 %   The second because programmers who use that most often want to
 %   access the value of a variable given its name, hence should use a
-%   |V|-type or |v|-type variant instead of |c|-type.  In those cases,
+%   |V| type or |v| type variant instead of |c| type.  In those cases,
 %   using the lower-level \cs{exp_args:No} or \cs{exp_args:Nc}
 %   functions explicitly is preferred to defining confusing variants.
 % \end{function}
@@ -230,7 +230,7 @@
 % and omitting this leads to low-level errors.  In addition this type of
 % expansion is not expandable, namely functions that have |x| in their
 % signature do not themselves expand when appearing inside |e| or |x|
-% expansion.
+% type expansion.
 %
 % The |f| type is so special that it deserves an example.  It is
 % typically used in contexts where only expandable commands are allowed.
@@ -264,20 +264,20 @@
 % \begin{quote}
 %   |\example:n { 3 , 7 }|
 % \end{quote}
-% at the cost of being protected for |x|-type.
+% at the cost of being protected for |x| type.
 % If you use |f| type expansion in conditional processing then
 % you should stick to using |TF|  type functions only as the expansion
 % does not finish any |\if... \fi:| itself!
 %
-% It is important to note that both \texttt{f}- and \texttt{o}-type
+% It is important to note that both \texttt{f} and |o| type
 % expansion are concerned with the expansion of tokens from left to
-% right in their arguments. In particular, \texttt{o}-type expansion
+% right in their arguments. In particular, |o| type expansion
 % applies to the first \emph{token} in the argument it receives: it
 % is conceptually similar to
 % \begin{verbatim}
 %   \exp_after:wN <base function> \exp_after:wN { <argument> }
 % \end{verbatim}
-% At the same time, \texttt{f}-type expansion stops at the \emph{first}
+% At the same time, |f| type expansion stops at the \emph{first}
 % non-expandable token. This means for example that both
 % \begin{verbatim}
 %    \tl_set:No \l_tmpa_tl { { \g_tmpb_tl } }
@@ -293,11 +293,11 @@
 % forms.
 % \begin{itemize}
 %   \item
-%     Variants with |x|-type arguments (that are fully expanded before
-%     being passed to the |n|-type base function) are never expandable
+%     Variants with |x| type arguments (that are fully expanded before
+%     being passed to the |n| type base function) are never expandable
 %     even when the base function is.  Such variants cannot work
 %     correctly in arguments that are themselves subject to expansion.
-%     Consider using |f| or |e| expansion.
+%     Consider using |f| or |e| type expansion.
 %   \item
 %     In contrast, |e|~expansion (full expansion, almost like~|x| except
 %     for the treatment of~|#|) does not prevent variants from being
@@ -314,11 +314,11 @@
 % expand the arguments of a base function depend on what needs doing
 % with each argument and where this happens in the list of arguments:
 % \begin{itemize}
-%   \item for fastest processing any |c|-type arguments should come first
+%   \item for fastest processing any |c| type arguments should come first
 %     followed by all other modified arguments;
-%   \item unchanged |N|-type args that appear before modified ones have
+%   \item unchanged |N| type args that appear before modified ones have
 %     a small performance hit;
-%  \item unchanged |n|-type args that appear before modified ones have
+%  \item unchanged |n| type args that appear before modified ones have
 %    a relative larger performance hit.
 % \end{itemize}
 %
@@ -482,7 +482,7 @@
 %   third as detailed by their argument specifier. The first argument
 %   of the function is then the next item on the input stream, followed
 %   by the expansion of the second and third arguments. These functions
-%   are not expandable due to their |x|-type argument.
+%   are not expandable due to their |x| type argument.
 % \end{function}
 %
 % \section{Manipulating three arguments}
@@ -594,7 +594,7 @@
 %     of those functions before expansion. This can cause problems
 %     if the argument is empty: for instance,
 %     \cs{exp_last_unbraced:Nf} |\foo_bar:w| |{ }| \cs{q_stop}
-%     leads to an infinite loop, as the quark is \texttt{f}-expanded.
+%     leads to an infinite loop, as the quark is |f| type expanded.
 %   \end{texnote}
 % \end{function}
 %
@@ -649,11 +649,11 @@
 %     \cs{exp_not:N} \meta{token}
 %   \end{syntax}
 %   Prevents expansion of the \meta{token} in a context where it would
-%   otherwise be expanded, for example an |e|-type or |x|-type argument or
-%   the first token in an |o|-type or |f|-type argument.
+%   otherwise be expanded, for example an |e| type or |x| type argument or
+%   the first token in an |o| type or |f| type argument.
 %   \begin{texnote}
 %     This is the \TeX{} primitive \tn{noexpand}.  It only prevents
-%     expansion.  At the beginning of an |f|-type argument, a space
+%     expansion.  At the beginning of an |f| type argument, a space
 %     \meta{token} is removed even if it appears as \cs{exp_not:N}
 %     \cs{c_space_token}.  In an |e|-expanding definition
 %     (\cs{cs_new:Npe}), a macro parameter introduces an argument even
@@ -676,7 +676,7 @@
 %   \begin{syntax}
 %     \cs{exp_not:n} \Arg{tokens}
 %   \end{syntax}
-%   Prevents expansion of the \meta{tokens} in an |e|-type or |x|-type argument.
+%   Prevents expansion of the \meta{tokens} in an |e| type or |x| type argument.
 %   In all other cases the \meta{tokens} continue to be expanded, for
 %   example in the input stream or in other types of arguments such as
 %   \texttt{c}, \texttt{f}, \texttt{v}.  The argument of \cs{exp_not:n}
@@ -696,7 +696,7 @@
 %     \cs{exp_not:o} \Arg{tokens}
 %   \end{syntax}
 %   Expands the \meta{tokens} once, then prevents any further expansion
-%   in |e|-type or |x|-type arguments using \cs{exp_not:n}.
+%   in |e| type or |x| type arguments using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:V}
@@ -704,7 +704,7 @@
 %     \cs{exp_not:V} \meta{variable}
 %   \end{syntax}
 %   Recovers the content of the \meta{variable}, then prevents expansion
-%   of this material in |e|-type or |x|-type arguments using \cs{exp_not:n}.
+%   of this material in |e| type or |x| type arguments using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:v}
@@ -715,7 +715,7 @@
 %   converts this into a control sequence which should be a \meta{variable}
 %   name.
 %   The content of the \meta{variable} is recovered, and further
-%   expansion in |e|-type or |x|-type arguments is prevented using \cs{exp_not:n}.
+%   expansion in |e| type or |x| type arguments is prevented using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:e}
@@ -724,7 +724,7 @@
 %   \end{syntax}
 %   Expands \meta{tokens} exhaustively, then protects the result of the
 %   expansion (including any tokens which were not expanded) from
-%   further expansion in |e|-type or |x|-type arguments using \cs{exp_not:n}.
+%   further expansion in |e| type or |x| type arguments using \cs{exp_not:n}.
 %   This is very rarely useful but is provided for consistency.
 % \end{function}
 %
@@ -735,7 +735,7 @@
 %   Expands \meta{tokens} fully until the first unexpandable token is
 %   found (if it is a space it is removed). Expansion then stops, and
 %   the result of the expansion (including any tokens which were not
-%   expanded) is protected from further expansion in |e|-type or |x|-type arguments
+%   expanded) is protected from further expansion in |e| type or |x| type arguments
 %   using \cs{exp_not:n}.
 % \end{function}
 %
@@ -743,12 +743,12 @@
 %   \begin{syntax}
 %     |\foo_bar:f| \{ \meta{tokens} \cs{exp_stop_f:} \meta{more tokens} \}
 %   \end{syntax}
-%   This function terminates an \texttt{f}-type expansion. Thus if
-%   a function |\foo_bar:f| starts an \texttt{f}-type expansion
+%   This function terminates an |f| type expansion. Thus if
+%   a function |\foo_bar:f| starts an |f| type expansion
 %   and all of \meta{tokens} are expandable \cs{exp_stop_f:}
 %   terminates the expansion of tokens even if \meta{more tokens}
 %   are also expandable. The function itself is an implicit space
-%   token. Inside an \texttt{e}-type or \texttt{x}-type expansion, it retains its
+%   token. Inside an |e| type or |x| type expansion, it retains its
 %   form, but when typeset it produces the underlying space (\verb*| |).
 % \end{function}
 %
@@ -823,10 +823,10 @@
 %     \cs{exp:w} \meta{expandable-tokens} \cs{exp_end_continue_f:w} \meta{further-tokens}
 %   \end{syntax}
 %   Expands \meta{expandable-tokens} until reaching \cs{exp_end_continue_f:w} at
-%   which point expansion continues as an \texttt{f}-type expansion expanding
+%   which point expansion continues as an |f| type expansion expanding
 %   \meta{further-tokens} until an unexpandable token is encountered (or
-%   the \texttt{f}-type expansion is explicitly terminated by
-%   \cs{exp_stop_f:}). As with all \texttt{f}-type expansions a space ending
+%   the |f| type expansion is explicitly terminated by
+%   \cs{exp_stop_f:}). As with all |f| type expansions a space ending
 %   the expansion gets removed.
 %
 %   The full expansion of \meta{expandable-tokens} has to be empty.
@@ -841,7 +841,7 @@
 %\begin{verbatim}
 %    \exp_after:wN { \exp:w \exp_end_continue_f:w #2 }
 %\end{verbatim}
-%   where the \cs{exp_after:wN} triggers an \texttt{f}-expansion of the tokens
+%   where the \cs{exp_after:wN} triggers an |f| type expansion of the tokens
 %   in |#2|. For technical reasons this has to happen using two tokens
 %   (if they would be hidden inside another command \cs{exp_after:wN}
 %   would only expand the command but not trigger any additional
@@ -852,7 +852,7 @@
 %   \begin{quote}
 %     \cs{exp:w} \meta{expandable-tokens} \cs{exp_end:}
 %   \end{quote}
-%   can be alternatively achieved through an \texttt{f}-type expansion by using
+%   can be alternatively achieved through an |f| type expansion by using
 %   \cs{exp_stop_f:}, i.e.
 %   \begin{quote}
 %     \cs{exp:w} \cs{exp_end_continue_f:w} \meta{expandable-tokens} \cs{exp_stop_f:}
@@ -879,7 +879,7 @@
 %   \meta{further-tokens} starts with space tokens then these space
 %   tokens are removed while searching for the argument.  If it starts
 %   with a brace group then the braces are removed. Thus such spaces or
-%   braces will not terminate the \texttt{f}-type expansion.
+%   braces will not terminate the |f| type expansion.
 % \end{function}
 %
 % \section{Internal functions}
@@ -920,7 +920,7 @@
 %
 % \begin{variable}{\l_@@_internal_tl}
 %   The |\exp_| module has its private variable to temporarily store the
-%   result of |x|-type argument expansion. This is done to avoid interference
+%   result of |x| type argument expansion. This is done to avoid interference
 %   with other functions using temporary variables.
 % \end{variable}
 %
@@ -1086,7 +1086,7 @@
 %   expects a single token whereas |v| like |c| creates a csname from
 %   its argument given in braces and then evaluates it as if it was a
 %   |V|. The \cs{exp:w} sets off an expansion
-%   similar to an |f|-type expansion, which we terminate using
+%   similar to an |f| type expansion, which we terminate using
 %   \cs{exp_end:}. The argument is returned in braces.
 %    \begin{macrocode}
 \cs_new:Npn \::V #1 \::: #2#3
@@ -1125,7 +1125,7 @@
     \exp_after:wN \if_meaning:w \exp_not:N #1 #1
 %    \end{macrocode}
 %   If the token was not a macro it may be a malformed variable from a
-%   |c| expansion in which case it is equal to the primitive
+%   |c| type expansion in which case it is equal to the primitive
 %   \cs{scan_stop:}. In that case we throw an error. We could let \TeX{}
 %   do it for us but that would result in the rather obscure
 %   \begin{quote}
@@ -1606,7 +1606,7 @@
 %   a mistake.)
 %
 %   If on the other hand we want to stop the initial expansion sequence
-%   but continue with an \texttt{f}-type expansion we provide the
+%   but continue with an |f| type expansion we provide the
 %   alphabetic constant |`^^@| that also represents |0| but this time
 %   \TeX's syntax for a \meta{number} continues searching for an
 %   optional space (and it continues expansion doing that) --- see
@@ -1682,7 +1682,7 @@
 %   protected or not and define \cs{@@_tmp:w} as either
 %   \cs{cs_new:Npe} or \cs{cs_new_protected:Npe}, which is
 %   then used to define all the variants (except those involving
-%   \texttt{x}-expansion, always protected).  Split up the original base
+%   |x| type expansion, always protected).  Split up the original base
 %   function only once, to grab its name and signature.  Then we wish to
 %   iterate through the comma list of variant argument specifiers, which
 %   we first convert to a string: the reason is explained later.
@@ -1803,18 +1803,18 @@
 %       variant signature.
 %     \item In \cs{cs_generate_variant:Nn} |\foo:on| |{ox}|, the
 %       function |\foo:ox| must be defined using |\exp_args:Nnx|, not
-%       |\exp_args:Nox|, to avoid double |o| expansion.
+%       |\exp_args:Nox|, to avoid double |o| type expansion.
 %     \item Lastly, \cs{cs_generate_variant:Nn} |\foo:on| |{xn}| must
 %       trigger an error, because we do not have a means to replace
 %       |o|-expansion by |x|-expansion.
 %       More generally, we can only convert |N| to |c|, or convert |n|
 %       to |V|, |v|, |o|, |e|, |f|, or |x|.
 %     \end{itemize}
-%     All this boils down to a few rules.  Only |n| and |N|-type
+%     All this boils down to a few rules.  Only |n| and |N| type
 %     arguments can be replaced by \cs{cs_generate_variant:Nn}.  Other
 %     argument types are allowed to be passed unchanged from the base
 %     form to the variant: in the process they are changed to |n|
-%     except for |N| and |p|-type arguments.  A common trailing
+%     except for |N| and |p| type arguments.  A common trailing
 %     part is ignored.
 %
 %     We compare the base and variant signatures one character at a time
@@ -2013,9 +2013,9 @@
 %
 % \begin{macro}[rEXP]{\@@_generate_variant_same:N}
 %   When the base and variant letters are identical, don't do any
-%   expansion.  For most argument types, we can use the |n|-type
+%   expansion.  For most argument types, we can use the |n| type
 %   no-expansion, but the |N| and |p| types require a slightly different
-%   behaviour with respect to braces.  For |V|-type this function could
+%   behaviour with respect to braces.  For |V| type this function could
 %   output |N| to avoid adding useless braces but that is not a problem.
 %    \begin{macrocode}
 \cs_new:Npn \@@_generate_variant_same:N #1

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -63,32 +63,37 @@
 % \label{sec:l3expan:defining-variants}
 %
 % The definition of variant forms for base functions may be necessary
-% when writing new functions or when applying a kernel function in a
-% situation that we haven't thought of before.
+% when writing new functions or when applying a function in a
+% new situation.
 %
-% Internally preprocessing of arguments is done with functions of the form
-% \cs[no-index]{exp_\ldots{}}.  They all look alike, an example would be
+% Internally preprocessing of arguments is done with functions
+% \cs[no-index]{exp_\meta{\ldots}}.  They all look alike, an example would be
 % \cs{exp_args:NNo}. This function has three arguments, the first and the
 % second are a single tokens, while the third argument should be given
-% in braces. Applying \cs{exp_args:NNo} expands the content of third
-% argument once before any expansion of the first and second arguments.
-% If \cs{seq_gpush:No} was not defined it could be coded in the following way:
+% in braces. Applying \cs{exp_args:NNo} only expands the content of
+% third argument once, the first and second arguments will eventually
+% be expanded  after.
+% If \cs{seq_gpush:No} was not defined it could be emulated in the following way.
 % \begin{quote}\ttfamily
 %   |\exp_args:NNo \seq_gpush:Nn|\\
-%   |   \g_file_name_stack|\\
-%   |   { \l_tmpa_tl }|
+%   |   \g_path_seq|\\
+%   |   { \l_dir_path_tl / \l_base_name_tl }|
 % \end{quote}
+% where |\g_path_seq| contains a sequence of paths,
+% |\l_dir_name_tl| contains the path to a directory and
+% |\l_base_name_tl| contains a file name.
 % In other words, the first argument to \cs{exp_args:NNo} is the base
 % function and the other arguments are preprocessed and then passed to
 % this base function. In the example the first argument to the base
-% function should be a single token which is left unchanged while the
-% second argument is expanded once. From this example we can also see
+% function is the single token |\g_path_seq| which is left unchanged.
+% The second argument is expanded once as the path to a file.
+% From this example we can also see
 % how the variants are defined. They just expand into the appropriate
 % |\exp_| function followed by the desired base function, \emph{e.g.}
 % \begin{quote}
 %   |\cs_generate_variant:Nn \seq_gpush:Nn { No } |
 % \end{quote}
-% results in the definition of |\seq_gpush:No|
+% results in the definition of |\seq_gpush:No| by
 % \begin{quote}
 %   |\cs_new:Npn \seq_gpush:No { \exp_args:NNo \seq_gpush:Nn }|
 % \end{quote}

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -67,29 +67,29 @@
 % new situation.
 %
 % Internally preprocessing of arguments is done with functions
-% \cs[no-index]{exp_\meta{\ldots}}.  They all look alike, an example would be
+% \cs[no-index]{exp_args:N}\ldots. They all look alike, an example would be
 % \cs{exp_args:NNo}. This function has three arguments, the first and the
 % second are a single tokens, while the third argument should be given
-% in braces. Applying \cs{exp_args:NNo} only expands the content of
-% third argument once, the first and second arguments will eventually
-% be expanded  after.
+% in braces. Applying \cs{exp_args:NNo} expands one level the content of
+% the third argument, leaving unchanged the other arguments
+% ( nevertheless they may also get expanded at a later stage).
 % If \cs{seq_gpush:No} was not defined it could be emulated in the following way.
 % \begin{quote}\ttfamily
 %   |\exp_args:NNo \seq_gpush:Nn|\\
-%   |   \g_path_seq|\\
-%   |   { \l_dir_path_tl / \l_base_name_tl }|
+%   |   \g_file_name_seq|\\
+%   |   { \l_name_tl .tex }|
 % \end{quote}
-% where |\g_path_seq| contains a sequence of paths,
-% |\l_dir_name_tl| contains the path to a directory and
-% |\l_base_name_tl| contains a file name.
+% where the global variable |\g_file_name_seq| contains a sequence of file names,
+% and the local token list variable |\l_name_tl| contains a name.
 % In other words, the first argument to \cs{exp_args:NNo} is the base
 % function and the other arguments are preprocessed and then passed to
 % this base function. In the example the first argument to the base
-% function is the single token |\g_path_seq| which is left unchanged.
-% The second argument is expanded once as the path to a file.
+% function is the single token |\g_file_name_seq| which is left unchanged.
+% The second argument is expanded once as a file name.
 % From this example we can also see
-% how the variants are defined. They just expand into the appropriate
-% |\exp_| function followed by the desired base function, \emph{e.g.}
+% how the variants are generally defined:~they just expand into the appropriate
+% \cs[no-index]{exp_args:N}\ldots\ function followed by the desired base function\footnote{Some variants, such as
+% \cs[no-index]{str_if_eq:eeTF}, are defined directly without expanding to the base function.}, \emph{e.g.}
 % \begin{quote}
 %   |\cs_generate_variant:Nn \seq_gpush:Nn { No } |
 % \end{quote}
@@ -103,8 +103,8 @@
 % such definition to later releases of the kernel will not make such
 % style files obsolete.
 %
-% The steps above may be automated by using the function
-% \cs{cs_generate_variant:Nn}, described next.
+% The function \cs{cs_generate_variant:Nn} described next allows to
+% automate the steps above.
 %
 % \section{Methods for defining variants}
 % \label{sec:l3expan:variants-method}
@@ -112,16 +112,16 @@
 % We recall the set of available argument specifiers.
 % \begin{itemize}
 % \item |N|~is used for single-token arguments while |c|~constructs a
-%   control sequence from its name and passes it to a parent function as
-%   an |N| type argument.
+%   control sequence from its name and passes it to a function as
+%   an |N|-type argument.
 % \item Many argument types extract or expand some tokens and provide it
-%   as an |n| type argument, namely a braced multiple-token argument:
+%   as an |n|-type argument, namely a braced multiple-token argument:
 %   |V|~extracts the value of a variable, |v|~extracts the value from
 %   the name of a variable, |n|~uses the argument as it is, |o|~expands
 %   once, |f|~expands fully the front of the token list, |e| and
 %   |x|~expand fully all tokens (differences are explained later).
 % \item A few odd argument types remain: |T|~and |F|~for conditional
-%   processing, otherwise identical to |n| type arguments,
+%   processing, otherwise identical to |n|-type arguments,
 %   |p|~for the parameter text
 %   in definitions, |w|~for arguments with a specific syntax, and |D|~to
 %   denote primitives that should not be used directly.
@@ -130,26 +130,26 @@
 % \begin{function}[updated = 2017-11-28]
 %   {\cs_generate_variant:Nn, \cs_generate_variant:cn}
 %   \begin{syntax}
-%     \cs{cs_generate_variant:Nn} \cs[no-index]{\meta{name}:\meta{base arg spec}} \Arg{variant argument specifiers}
+%     \cs{cs_generate_variant:Nn} \cs[no-index]{\meta{name}:\meta{base arg-spec}} \{\meta{arg-spec_1},\meta{arg-spec_2},...\}
 %   \end{syntax}
 %   This function is used to define argument specifier variants of the
-%   base function \cs[no-index]{\meta{name}:\meta{base arg spec}}.
-%   The head of \meta{base arg spec} must consist of |N|, |n| or |p|.
-%   The \meta{variant argument specifiers} is a comma-separated list of
-%   argument specifiers used to build \meta{variant arg spec}'s,
-%   by mapping the heading letters of \meta{base arg spec}.
+%   base function \cs[no-index]{\meta{name}:\meta{base arg-spec}}.
+%   Each argument specifier \meta{arg-spec_i} is used to build a
+%   \meta{variant arg-spec_i} from \meta{base arg-spec},
+%   by mapping its heading letters to
+%   the letters of \meta{arg-spec_i}, one after the other.
 %   The only possible mappings are
 %   \begin{itemize}
-%   \item |N| to |c|;
-%   \item |n| to |o|, |V|, |v|, |f|, |e|, or |x|;
+%   \item |N| to |N| or |c|;
+%   \item |n| to |n|, |o|, |V|, |v|, |f|, |e|, or |x|;
 %   \item |p| to |p|;
 %   \end{itemize}
-%   with the restriction that |p| arguments must be followed
+%   with the restriction that |p| arguments may be followed
 %   \emph{in fine} by a braced group.
 %
 %   If it does not exist, each variant function
-%   \cs[no-index]{\meta{name}|:|\meta{variant arg spec}} is globally
-%   created, as is the function \cs[no-index]{exp_args:N\meta{variant arg spec}}
+%   \cs[no-index]{\meta{name}|:|\meta{variant arg-spec_i}} is created globally,
+%   as is the function \cs[no-index]{exp_args:N\meta{variant arg-spec_i}}
 %   needed to expand the arguments as necessary before they
 %   are passed to the base function.
 %   So for example
@@ -159,7 +159,8 @@
 %   \end{quote}
 %   creates a new function |\foo:cn| which expands its first
 %   argument into a control sequence further passed as first argument to
-%   |\foo:Nn|. Similarly
+%   |\foo:Nn|. It does not create \cs[no-index]{exp_args:Nc}
+%   because it already exists. Similarly
 %   \begin{quote}
 %     |\cs_generate_variant:Nn \foo:Nn { NV , cV }|
 %   \end{quote}
@@ -169,16 +170,16 @@
 %     |\cs_generate_variant:Nn \foo:cn { cV }|
 %   \end{quote}
 %   is an error to generate |\foo:cV| because |cn| is not a
-%   \meta{base arg spec}. On the contrary
+%   \meta{base arg-spec}. On the contrary
 %   \begin{quote}
 %     |\cs_generate_variant:Nn \foo:nc { Vc }|
 %   \end{quote}
-%   is allowed because |c| is not part of the \meta{base arg spec} head.
+%   is allowed because |c| is not part of the \meta{base arg-spec} head.
 %
 %   The \cs{cs_generate_variant:Nn} function should only be applied to
 %   already defined base functions\footnotemark{}.
-%   If the base function is protected or if the \meta{variant arg spec} contains
-%   |x|, then the variant is
+%   If the base function is protected or if the \meta{arg-spec_i} contains
+%   |x|, then the generated variant is
 %   protected. There is no need to re-apply \cs{cs_generate_variant:Nn} after
 %   changing the definition of the base function: the variant will always
 %   use the current definition of the base.
@@ -187,13 +188,13 @@
 %   safe.
 %
 %   For backward compatibility it is currently possible to make |n|,
-%   |o|, |V|, |v|, |f|, |e|, or |x| type variants of an |N| type argument or
-%   |N| or |c| type variants of an |n| type argument.  Both are
+%   |o|, |V|, |v|, |f|, |e|, or |x|-type variants of an |N|-type argument or
+%   |N|-type or |c|-type variants of an |n|-type argument.  Both are
 %   deprecated.  The first because passing more than one token to an
-%   |N| type argument will typically break the parent function's code.
+%   |N|-type argument will typically break the parent function's code.
 %   The second because programmers who use that most often want to
 %   access the value of a variable given its name, hence should use a
-%   |V| type or |v| type variant instead of |c| type.  In those cases,
+%   |V|-type or |v|-type variant instead of |c|-type.  In those cases,
 %   using the lower-level \cs{exp_args:No} or \cs{exp_args:Nc}
 %   functions explicitly is preferred to defining confusing variants.
 % \end{function}
@@ -203,23 +204,23 @@
 % \begin{function}[added = 2018-04-04, updated = 2019-02-08]
 %   {\exp_args_generate:n}
 %   \begin{syntax}
-%     \cs{exp_args_generate:n} \Arg{variant argument specifiers}
+%     \cs{exp_args_generate:n} \{\meta{arg-spec_1},\meta{arg-spec_2},...\}
 %   \end{syntax}
-%   Defines \cs[no-index]{exp_args:N\meta{variant arg spec}} functions for each
-%   \meta{variant arg spec} given in the comma list \meta{variant argument
-%   specifiers}.  Each \meta{variant arg spec} should consist of the letters |N|,
-%   |c|, |n|, |V|, |v|, |o|, |f|, |e|, |x|, |p| and the resulting function is
-%   protected if the letter |x| appears in the \meta{variant arg spec}.
+%   Defines function \cs[no-index]{exp_args:N\meta{arg-spec_i}} for each
+%   given argument specifier \meta{arg-spec_i}.
+%   Each argument specifier should consist of the letters |N|,
+%   |c|, |n|, |V|, |v|, |o|, |f|, |e|, |x|, |p| and if it contains the letter |x|,
+%   the resulting function is protected.
 %   This is
-%   only useful for cases where the function \cs{cs_generate_variant:Nn} is not
+%   only useful when the function \cs{cs_generate_variant:Nn} is not
 %   applicable.
 % \end{function}
 %
 % \section{The variant letter types}
 %
-% The |V| type returns the value of a register, which can be one of
+% The |V|-type returns the value of a register, which can be one of
 % |tl|, |clist|, |int|, |skip|, |dim|, |muskip|, or built-in \TeX{}
-% registers. The |v| type is the same except it first creates a
+% registers. The |v|-type is the same except it first creates a
 % control sequence out of its argument before returning the
 % value.
 %
@@ -230,19 +231,19 @@
 % specific expansion steps are needed, such as when using delimited
 % arguments, should the lower-level functions with |o| specifiers be employed.
 %
-% The |e| type expands all tokens fully, starting from the first.  More
+% The |e|-type expands all tokens fully, starting from the first.  More
 % precisely the expansion is identical to that of \TeX{}'s \tn{message}
 % (in particular |#| needs not be doubled).  It relies on the
 % primitive \tn{expanded} hence is fast.
 %
-% The |x| type expands all tokens fully, starting from the first.  In
+% The |x|-type expands all tokens fully, starting from the first.  In
 % contrast to |e|, all macro parameter characters |#| must be doubled,
 % and omitting this leads to low-level errors.  In addition this type of
 % expansion is not expandable, namely functions that have |x| in their
-% signature do not themselves expand when appearing inside |e| or |x|
-% type expansion.
+% signature do not themselves expand when appearing inside |e|-type
+% or |x|-type expansion.
 %
-% The |f| type is so special that it deserves an example.  It is
+% The |f|-type is so special that it deserves an example.  It is
 % typically used in contexts where only expandable commands are allowed.
 % Then |x|-expansion cannot be used, and |f|-expansion provides an
 % alternative that expands the front of the token list
@@ -274,20 +275,20 @@
 % \begin{quote}
 %   |\example:n { 3 , 7 }|
 % \end{quote}
-% at the cost of being protected for |x| type.
-% If you use |f| type expansion in conditional processing then
-% you should stick to using |TF|  type functions only as the expansion
+% at the cost of being protected for |x|-type.
+% If you use |f|-type expansion in conditional processing then
+% you should stick to using |TF|-type functions only as the expansion
 % does not finish any |\if... \fi:| itself!
 %
-% It is important to note that both \texttt{f} and |o| type
+% It is important to note that both \texttt{f} and |o|-type
 % expansion are concerned with the expansion of tokens from left to
-% right in their arguments. In particular, |o| type expansion
-% applies to the first \emph{token} in the argument it receives: it
+% right in their arguments. In particular, |o|-type expansion
+% only applies to the first \emph{token} in the argument it receives: it
 % is conceptually similar to
 % \begin{quote}\ttfamily
-%   |\exp_after:wN |\meta{base function}| \exp_after:wN {|\meta{argument}|}|
+%   |\exp_after:wN |\meta{base function}| \exp_after:wN { |\meta{argument}| }|
 % \end{quote}
-% At the same time, |f| type expansion stops at the \emph{first}
+% At the same time, |f|-type expansion stops at the \emph{first}
 % non-expandable token. This means for example that both
 % \begin{quote}\ttfamily
 %    |\tl_set:No \l_tmpa_tl { { \g_tmpb_tl } }|
@@ -303,19 +304,20 @@
 % forms.
 % \begin{itemize}
 %   \item
-%     Variants with |x| type arguments (that are fully expanded before
-%     being passed to the |n| type base function) are never expandable
+%     Variants with |x|-type arguments (that are fully expanded before
+%     being passed to the |n|-type base function) are never expandable
 %     even when the base function is.  Such variants cannot work
 %     correctly in arguments that are themselves subject to expansion.
-%     Consider using |f| or |e| type expansion.
+%     Consider using |f|-type or |e|-type expansion.
 %   \item
 %     In contrast, |e|~expansion (full expansion, almost like~|x| except
 %     for the treatment of~|#|) does not prevent variants from being
 %     expandable (if the base function is).
 %   \item
-%     Finally |f|~expansion only expands the front of the token list,
-%     stopping at the first non-expandable token.  This may fail to
-%     fully expand the argument.
+%     Finally |f|~expansion only expands the front of the token list
+%     fully,
+%     stopping at the first non-expandable token. This may fail to
+%     fully expand the whole argument.
 % \end{itemize}
 %
 % When speed is essential (for functions that do very little work and
@@ -324,11 +326,11 @@
 % expand the arguments of a base function depend on what needs doing
 % with each argument and where this happens in the list of arguments:
 % \begin{itemize}
-%   \item for fastest processing any |c| type arguments should come first
+%   \item for fastest processing any |c|-type arguments should come first
 %     followed by all other modified arguments;
-%   \item unchanged |N| type args that appear before modified ones have
+%   \item unchanged |N|-type arguments that appear before modified ones have
 %     a small performance hit;
-%  \item unchanged |n| type args that appear before modified ones have
+%  \item unchanged |n|-type arguments that appear before modified ones have
 %    a relative larger performance hit.
 % \end{itemize}
 %
@@ -492,7 +494,7 @@
 %   third as detailed by their argument specifier. The first argument
 %   of the function is then the next item on the input stream, followed
 %   by the expansion of the second and third arguments. These functions
-%   are not expandable due to their |x| type argument.
+%   are not expandable due to their |x|-type argument.
 % \end{function}
 %
 % \section{Manipulating three arguments}
@@ -604,7 +606,7 @@
 %     of those functions before expansion. This can cause problems
 %     if the argument is empty: for instance,
 %     \cs{exp_last_unbraced:Nf} |\foo_bar:w| |{ }| \cs{q_stop}
-%     leads to an infinite loop, as the quark is |f| type expanded.
+%     leads to an infinite loop, as the quark is |f|-type expanded.
 %   \end{texnote}
 % \end{function}
 %
@@ -659,11 +661,11 @@
 %     \cs{exp_not:N} \meta{token}
 %   \end{syntax}
 %   Prevents expansion of the \meta{token} in a context where it would
-%   otherwise be expanded, for example an |e| type or |x| type argument or
-%   the first token in an |o| type or |f| type argument.
+%   otherwise be expanded, for example an |e|-type or |x|-type argument or
+%   the first token in an |o|-type or |f|-type argument.
 %   \begin{texnote}
 %     This is the \TeX{} primitive \tn{noexpand}.  It only prevents
-%     expansion.  At the beginning of an |f| type argument, a space
+%     expansion.  At the beginning of an |f|-type argument, a space
 %     \meta{token} is removed even if it appears as \cs{exp_not:N}
 %     \cs{c_space_token}.  In an |e|-expanding definition
 %     (\cs{cs_new:Npe}), a macro parameter introduces an argument even
@@ -686,7 +688,7 @@
 %   \begin{syntax}
 %     \cs{exp_not:n} \Arg{tokens}
 %   \end{syntax}
-%   Prevents expansion of the \meta{tokens} in an |e| type or |x| type argument.
+%   Prevents expansion of the \meta{tokens} in an |e|-type or |x|-type argument.
 %   In all other cases the \meta{tokens} continue to be expanded, for
 %   example in the input stream or in other types of arguments such as
 %   \texttt{c}, \texttt{f}, \texttt{v}.  The argument of \cs{exp_not:n}
@@ -706,7 +708,7 @@
 %     \cs{exp_not:o} \Arg{tokens}
 %   \end{syntax}
 %   Expands the \meta{tokens} once, then prevents any further expansion
-%   in |e| type or |x| type arguments using \cs{exp_not:n}.
+%   in |e|-type or |x|-type arguments using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:V}
@@ -714,7 +716,7 @@
 %     \cs{exp_not:V} \meta{variable}
 %   \end{syntax}
 %   Recovers the content of the \meta{variable}, then prevents expansion
-%   of this material in |e| type or |x| type arguments using \cs{exp_not:n}.
+%   of this material in |e|-type or |x|-type arguments using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:v}
@@ -725,7 +727,7 @@
 %   converts this into a control sequence which should be a \meta{variable}
 %   name.
 %   The content of the \meta{variable} is recovered, and further
-%   expansion in |e| type or |x| type arguments is prevented using \cs{exp_not:n}.
+%   expansion in |e|-type or |x|-type arguments is prevented using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[EXP]{\exp_not:e}
@@ -734,7 +736,7 @@
 %   \end{syntax}
 %   Expands \meta{tokens} exhaustively, then protects the result of the
 %   expansion (including any tokens which were not expanded) from
-%   further expansion in |e| type or |x| type arguments using \cs{exp_not:n}.
+%   further expansion in |e|-type or |x|-type arguments using \cs{exp_not:n}.
 %   This is very rarely useful but is provided for consistency.
 % \end{function}
 %
@@ -745,20 +747,20 @@
 %   Expands \meta{tokens} fully until the first unexpandable token is
 %   found (if it is a space it is removed). Expansion then stops, and
 %   the result of the expansion (including any tokens which were not
-%   expanded) is protected from further expansion in |e| type or |x| type arguments
+%   expanded) is protected from further expansion in |e|-type or |x|-type arguments
 %   using \cs{exp_not:n}.
 % \end{function}
 %
 % \begin{function}[updated = 2011-06-03, EXP]{\exp_stop_f:}
 %   \begin{syntax}
-%     |\foo_bar:f| \{ \meta{tokens} \cs{exp_stop_f:} \meta{more tokens} \}
+%     |\foo_bar:f| \{\meta{tokens} \cs{exp_stop_f:} \meta{more tokens}\}
 %   \end{syntax}
-%   This function terminates an |f| type expansion. Thus if
-%   a function |\foo_bar:f| starts an |f| type expansion
+%   This function terminates an |f|-type expansion. Thus if
+%   a function |\foo_bar:f| starts an |f|-type expansion
 %   and all of \meta{tokens} are expandable \cs{exp_stop_f:}
 %   terminates the expansion of tokens even if \meta{more tokens}
 %   are also expandable. The function itself is an implicit space
-%   token. Inside an |e| type or |x| type expansion, it retains its
+%   token. Inside an |e|-type or |x|-type expansion, it retains its
 %   form, but when typeset it produces the underlying space (\verb*| |).
 % \end{function}
 %
@@ -833,10 +835,10 @@
 %     \cs{exp:w} \meta{expandable-tokens} \cs{exp_end_continue_f:w} \meta{further-tokens}
 %   \end{syntax}
 %   Expands \meta{expandable-tokens} until reaching \cs{exp_end_continue_f:w} at
-%   which point expansion continues as an |f| type expansion expanding
+%   which point expansion continues as an |f|-type expansion expanding
 %   \meta{further-tokens} until an unexpandable token is encountered (or
-%   the |f| type expansion is explicitly terminated by
-%   \cs{exp_stop_f:}). As with all |f| type expansions a space ending
+%   the |f|-type expansion is explicitly terminated by
+%   \cs{exp_stop_f:}). As with all |f|-type expansions a space ending
 %   the expansion gets removed.
 %
 %   The full expansion of \meta{expandable-tokens} has to be empty.
@@ -851,7 +853,7 @@
 %\begin{verbatim}
 %    \exp_after:wN { \exp:w \exp_end_continue_f:w #2 }
 %\end{verbatim}
-%   where the \cs{exp_after:wN} triggers an |f| type expansion of the tokens
+%   where the \cs{exp_after:wN} triggers an |f|-type expansion of the tokens
 %   in |#2|. For technical reasons this has to happen using two tokens
 %   (if they would be hidden inside another command \cs{exp_after:wN}
 %   would only expand the command but not trigger any additional
@@ -862,7 +864,7 @@
 %   \begin{quote}
 %     \cs{exp:w} \meta{expandable-tokens} \cs{exp_end:}
 %   \end{quote}
-%   can be alternatively achieved through an |f| type expansion by using
+%   can be alternatively achieved through an |f|-type expansion by using
 %   \cs{exp_stop_f:}, i.e.
 %   \begin{quote}
 %     \cs{exp:w} \cs{exp_end_continue_f:w} \meta{expandable-tokens} \cs{exp_stop_f:}
@@ -889,7 +891,7 @@
 %   \meta{further-tokens} starts with space tokens then these space
 %   tokens are removed while searching for the argument.  If it starts
 %   with a brace group then the braces are removed. Thus such spaces or
-%   braces will not terminate the |f| type expansion.
+%   braces will not terminate the |f|-type expansion.
 % \end{function}
 %
 % \section{Internal functions}
@@ -898,8 +900,8 @@
 %   \begin{syntax}
 %     |\cs_new:Npn \exp_args:Ncof { \::c \::o \::f \::: }|
 %   \end{syntax}
-%   Internal forms for the base expansion types. These names do \emph{not}
-%   conform to the general \LaTeX3 approach as this makes them more readily
+%   Internal forms for the base expansion types. These names \emph{do not
+%   conform} to the general \LaTeX3 naming scheme as this makes them more readily
 %   visible in the log and so forth.  They should not be used outside this module.
 % \end{function}
 %
@@ -909,8 +911,8 @@
 %     |\cs_new:Npn \exp_last_unbraced:Nno { \::n \::o_unbraced \::: }|
 %   \end{syntax}
 %   Internal forms for the expansion types which leave the terminal argument
-%   unbraced. These names do \emph{not}
-%   conform to the general \LaTeX3 approach as this makes them more readily
+%   unbraced. These names \emph{do not
+%   conform} to the general \LaTeX3 naming scheme as this makes them more readily
 %   visible in the log and so forth.  They should not be used outside this module.
 % \end{function}
 %
@@ -929,8 +931,8 @@
 %    \end{macrocode}
 %
 % \begin{variable}{\l_@@_internal_tl}
-%   The |\exp_| module has its private variable to temporarily store the
-%   result of |x| type argument expansion. This is done to avoid interference
+%   The \pkg{l3expan} module has its private variable to temporarily store the
+%   result of |x|-type argument expansion. This is done to avoid interference
 %   with other functions using temporary variables.
 % \end{variable}
 %
@@ -938,7 +940,7 @@
 % \begin{macro}{\exp_not:N}
 % \begin{macro}{\exp_not:n}
 %   These are defined in \pkg{l3basics}, as they are needed
-%   \enquote{early}.  This is just a reminder of that fact!
+%   earlier. Here is just a reminder of that fact.
 % \end{macro}
 % \end{macro}
 % \end{macro}
@@ -960,7 +962,7 @@
 %   This scratch token list variable is defined in \pkg{l3basics}.
 % \end{variable}
 %
-% This code uses internal functions with names that start with |\::| to
+% This code uses internal functions with names that start with |::| to
 % perform the expansions. All macros are |long| since the tokens
 % undergoing expansion may be arbitrary user input.
 %
@@ -1096,7 +1098,7 @@
 %   expects a single token whereas |v| like |c| creates a csname from
 %   its argument given in braces and then evaluates it as if it was a
 %   |V|. The \cs{exp:w} sets off an expansion
-%   similar to an |f| type expansion, which we terminate using
+%   similar to an |f|-type expansion, which we terminate using
 %   \cs{exp_end:}. The argument is returned in braces.
 %    \begin{macrocode}
 \cs_new:Npn \::V #1 \::: #2#3
@@ -1135,7 +1137,7 @@
     \exp_after:wN \if_meaning:w \exp_not:N #1 #1
 %    \end{macrocode}
 %   If the token was not a macro it may be a malformed variable from a
-%   |c| type expansion in which case it is equal to the primitive
+%   |c|-type expansion in which case it is equal to the primitive
 %   \cs{scan_stop:}. In that case we throw an error. We could let \TeX{}
 %   do it for us but that would result in the rather obscure
 %   \begin{quote}
@@ -1616,7 +1618,7 @@
 %   a mistake.)
 %
 %   If on the other hand we want to stop the initial expansion sequence
-%   but continue with an |f| type expansion we provide the
+%   but continue with an |f|-type expansion we provide the
 %   alphabetic constant |`^^@| that also represents |0| but this time
 %   \TeX's syntax for a \meta{number} continues searching for an
 %   optional space (and it continues expansion doing that) --- see
@@ -1692,7 +1694,7 @@
 %   protected or not and define \cs{@@_tmp:w} as either
 %   \cs{cs_new:Npe} or \cs{cs_new_protected:Npe}, which is
 %   then used to define all the variants (except those involving
-%   |x| type expansion, always protected).  Split up the original base
+%   |x|-type expansion, always protected).  Split up the original base
 %   function only once, to grab its name and signature.  Then we wish to
 %   iterate through the comma list of variant argument specifiers, which
 %   we first convert to a string: the reason is explained later.
@@ -1813,18 +1815,18 @@
 %       variant signature.
 %     \item In \cs{cs_generate_variant:Nn} |\foo:on| |{ox}|, the
 %       function |\foo:ox| must be defined using |\exp_args:Nnx|, not
-%       |\exp_args:Nox|, to avoid double |o| type expansion.
+%       |\exp_args:Nox|, to avoid double |o|-type expansion.
 %     \item Lastly, \cs{cs_generate_variant:Nn} |\foo:on| |{xn}| must
 %       trigger an error, because we do not have a means to replace
 %       |o|-expansion by |x|-expansion.
 %       More generally, we can only convert |N| to |c|, or convert |n|
 %       to |V|, |v|, |o|, |e|, |f|, or |x|.
 %     \end{itemize}
-%     All this boils down to a few rules.  Only |n| and |N| type
+%     All this boils down to a few rules.  Only |n| and |N|-type
 %     arguments can be replaced by \cs{cs_generate_variant:Nn}.  Other
 %     argument types are allowed to be passed unchanged from the base
 %     form to the variant: in the process they are changed to |n|
-%     except for |N| and |p| type arguments.  A common trailing
+%     except for |N| and |p|-type arguments.  A common trailing
 %     part is ignored.
 %
 %     We compare the base and variant signatures one character at a time
@@ -2023,9 +2025,9 @@
 %
 % \begin{macro}[rEXP]{\@@_generate_variant_same:N}
 %   When the base and variant letters are identical, don't do any
-%   expansion.  For most argument types, we can use the |n| type
+%   expansion.  For most argument types, we can use the |n|-type
 %   no-expansion, but the |N| and |p| types require a slightly different
-%   behaviour with respect to braces.  For |V| type this function could
+%   behaviour with respect to braces.  For |V|-type this function could
 %   output |N| to avoid adding useless braces but that is not a problem.
 %    \begin{macrocode}
 \cs_new:Npn \@@_generate_variant_same:N #1


### PR DESCRIPTION
Changes are spread over 4 commits, 2 for cosmetic changes mainly related to consistency of the notations, 1 to update the example introducing variants, and 1 to improve the documentation of `\cs_generate_variant:Nn` after issue #1064 