### PR TITLE
Use `.default:n` value for unknown key

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -11,6 +11,7 @@ this project uses date-based 'snapshot' version identifiers.
 - Documentation for `\bitset_show_named_index:N` (issue \#1372)
 - `\bitset_log_named_index:N`
 - `\tl_build_get_intermediate:NN`
+- Support for `.default:n` values for the `unknown` handler (see issue \#67)
 
 ### Changed
 - Improved method to suppress `l3bitset` where required

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -3248,7 +3248,19 @@
       {
         \cs_if_exist:cTF
           { \c_@@_code_root_str \l_@@_module_str / unknown }
-          { \@@_execute:no { \l_@@_module_str / unknown } \l_keys_value_tl }
+          {
+            \bool_if:NT \l_@@_no_value_bool
+              {
+                \cs_if_exist:cT
+                  { \c_@@_default_root_str \l_@@_module_str / unknown }
+                  {
+                    \tl_set_eq:Nc
+                      \l_keys_value_tl
+                      { \c_@@_default_root_str \l_@@_module_str / unknown }
+                  }
+              }
+            \@@_execute:no { \l_@@_module_str / unknown } \l_keys_value_tl
+          }
           {
             \msg_error:nnee { keys } { unknown }
               \l_keys_path_str \l_@@_module_str

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -775,12 +775,14 @@
 % If a key has not previously been defined (is unknown), \cs{keys_set:nn}
 % looks for a special \texttt{unknown} key for the same module, and if this is
 % not defined raises an error indicating that the key name was unknown. This
-% mechanism can be used for example to issue custom error texts.
+% mechanism can be used for example to issue custom error texts. The
+% \texttt{unknown} key also supports the \texttt{.default:n} property.
 % \begin{verbatim}
 %   \keys_define:nn { mymodule }
 %     {
 %       unknown .code:n =
-%         You~tried~to~set~key~'\l_keys_key_str'~to~'#1'.
+%         You~tried~to~set~key~'\l_keys_key_str'~to~'#1'. ,
+%       unknown .default:V = \c_novalue_tl
 %     }
 % \end{verbatim}
 %

--- a/l3kernel/testfiles/m3keys001.lvt
+++ b/l3kernel/testfiles/m3keys001.lvt
@@ -287,6 +287,15 @@
         key-one = value ,
         key-two = value
       }
+    \keys_define:nn { module }
+      {
+        unknown .default:n = foo
+      }
+    \keys_set:nn { module }
+      {
+        key-one,
+        key-two
+      }
   }
 
 \TEST { Unknown~properties,~etc. }

--- a/l3kernel/testfiles/m3keys001.tlg
+++ b/l3kernel/testfiles/m3keys001.tlg
@@ -120,6 +120,8 @@ Check that you have spelled the key name correctly.
 Defining key module/unknown on line ...
 "value"
 I saw "value"
+""
+I saw "foo"
 ============================================================
 ============================================================
 TEST 10: Unknown properties, etc.


### PR DESCRIPTION
This PR changes the unknown-handler invocation to support a default value for unknown keys. This would effectively close #67.