### PR TITLE
Ignore irrelevant pdfs when uploading Documentation artifact

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -66,7 +66,10 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: "**/*.pdf"
+          path: |
+            **/*.pdf
+            !build
+            !**/testfiles*
           # Decide how long to keep the test output artifact:
           retention-days: 21
   # GitHub automatically informs the initiator of any action about the result, but


### PR DESCRIPTION
This PR removes irrelevant pdfs in `./build` directory and any sub-directory `testfiles*` from uploaded "Documentation" artifact. The specific removed pdfs are

```diff
--- a/old.txt
+++ b/new.txt
@@ -1,7 +1,4 @@
 Documentation
-├── build
-│   └── doc
-│       └── l3graphics.pdf
 ├── l3backend
 │   └── l3backend-code.pdf
 ├── l3experimental
@@ -11,13 +8,7 @@ Documentation
 │   │   ├── l3draw-code.pdf
 │   │   └── l3draw.pdf
 │   ├── l3graphics
-│   │   ├── l3graphics.pdf
-│   │   └── testfiles
-│   │       └── support
-│   │           ├── example-image-a4-numbered.pdf
-│   │           ├── folder-a
-│   │           │   └── meow.pdf
-│   │           └── miau.pdf
+│   │   └── l3graphics.pdf
 │   ├── l3opacity
 │   │   └── l3opacity.pdf
 │   ├── l3str
@@ -69,4 +60,4 @@ Documentation
         ├── xo-balance.pdf
         └── xo-pfloat.pdf
 
-26 directories, 44 files
+21 directories, 40 files
```