### PR TITLE
Update number of pages in interface3 and source3

### DIFF
--- a/l3kernel/doc/interface3.tex
+++ b/l3kernel/doc/interface3.tex
@@ -29,7 +29,7 @@ for those people who are interested.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 % This document typesets the LaTeX3 interface descriptions a single document.
-% This produces quite a large file (more than 170 pages currently).
+% This produces quite a large file (more than 360 pages as of Dec 2023).
 %
 % There is also a full version of the sources (source3.tex) which additionally
 % also typesets the command implementations.

--- a/l3kernel/doc/source3.tex
+++ b/l3kernel/doc/source3.tex
@@ -29,7 +29,7 @@ for those people who are interested.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %
 % This document typesets the LaTeX3 sources as a single document.
-% This produces quite a large file (more than 780 pages).
+% This produces quite a large file (more than 1670 pages as of Dec 2023).
 %
 % There is also a shorter version (interface3.tex) that only typesets the
 % command % interface descriptions.


### PR DESCRIPTION
Both `interface.pdf` and `source3.pdf` have more than doubled in thickness, since the last updates of page info, in 7a7a8b8d ([Big bang] Copy the documentation-related stuff into l3kernel, 2011-04-27) and 48e84cbb (Fix a typo in l3tl, 2012-09-05), respectively.