### PR TITLE
Faster align_safe_end

### DIFF
--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -1789,9 +1789,10 @@
 \tex_catcode:D `\^^@ = 2 \exp_stop_f:
 \cs_new:Npn \group_align_safe_begin:
   { \exp:w \if_false: { \fi: `^^@ \exp_stop_f: }
-\group_end:
+\tex_catcode:D `\^^@ = 1 \exp_stop_f:
 \cs_new:Npn \group_align_safe_end:
-  { \if_int_compare:w `{ = \c_zero_int } \fi: }
+  { \exp:w `^^@ \if_false: } \fi: \exp_stop_f: }
+\group_end:
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
I'm not sure why I didn't think of that when I sped up `\group_align_safe_begin:`, but this here speeds up `\group_align_safe_end:` in the same way.