### PR TITLE
Revert to \__kernel_tl_gset:Nx

### DIFF
--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -1069,7 +1069,7 @@
 \cs_new_protected:Npn \clist_set_from_seq:NN
   { \@@_set_from_seq:NNNN \clist_clear:N  \__kernel_tl_set:Nx  }
 \cs_new_protected:Npn \clist_gset_from_seq:NN
-  { \@@_set_from_seq:NNNN \clist_gclear:N \__kernel_tl_gset:Ne }
+  { \@@_set_from_seq:NNNN \clist_gclear:N \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_set_from_seq:NNNN #1#2#3#4
   {
     \seq_if_empty:NTF #4
@@ -1110,7 +1110,7 @@
 \cs_new_protected:Npn \clist_concat:NNN
   { \@@_concat:NNNN \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \clist_gconcat:NNN
-  { \@@_concat:NNNN \__kernel_tl_gset:Ne }
+  { \@@_concat:NNNN \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_concat:NNNN #1#2#3#4
   {
     #1 #2
@@ -1157,7 +1157,7 @@
 \cs_new_protected:Npn \clist_set:Nn #1#2
   { \__kernel_tl_set:Nx #1 { \@@_sanitize:n {#2} } }
 \cs_new_protected:Npn \clist_gset:Nn #1#2
-  { \__kernel_tl_gset:Ne #1 { \@@_sanitize:n {#2} } }
+  { \__kernel_tl_gset:Nx #1 { \@@_sanitize:n {#2} } }
 \cs_generate_variant:Nn \clist_set:Nn  { NV , Ne , c , cV , ce }
 \cs_generate_variant:Nn \clist_set:Nn  { No , Nx , co , cx }
 \cs_generate_variant:Nn \clist_gset:Nn { NV , Ne , c , cV , ce }
@@ -1297,7 +1297,7 @@
 \cs_new_protected:Npn \clist_pop:NN
   { \@@_pop:NNN \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \clist_gpop:NN
-  { \@@_pop:NNN \__kernel_tl_gset:Ne }
+  { \@@_pop:NNN \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_pop:NNN #1#2#3
   {
     \if_meaning:w #2 \c_empty_clist
@@ -1344,7 +1344,7 @@
 \prg_new_protected_conditional:Npnn \clist_pop:NN #1#2 { T , F , TF }
   { \@@_pop_TF:NNN \__kernel_tl_set:Nx #1 #2 }
 \prg_new_protected_conditional:Npnn \clist_gpop:NN #1#2 { T , F , TF }
-  { \@@_pop_TF:NNN \__kernel_tl_gset:Ne #1 #2 }
+  { \@@_pop_TF:NNN \__kernel_tl_gset:Nx #1 #2 }
 \cs_new_protected:Npn \@@_pop_TF:NNN #1#2#3
   {
     \if_meaning:w #2 \c_empty_clist
@@ -1475,7 +1475,7 @@
 \cs_new_protected:Npn \clist_remove_all:Nn
   { \@@_remove_all:NNNn \clist_set_from_seq:NN \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \clist_gremove_all:Nn
-  { \@@_remove_all:NNNn \clist_gset_from_seq:NN \__kernel_tl_gset:Ne }
+  { \@@_remove_all:NNNn \clist_gset_from_seq:NN \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_remove_all:NNNn #1#2#3#4
   {
     \@@_if_wrap:nTF {#4}
@@ -1531,7 +1531,7 @@
 \cs_new_protected:Npn \clist_reverse:N #1
   { \__kernel_tl_set:Nx #1 { \exp_args:No \clist_reverse:n {#1} } }
 \cs_new_protected:Npn \clist_greverse:N #1
-  { \__kernel_tl_gset:Ne #1 { \exp_args:No \clist_reverse:n {#1} } }
+  { \__kernel_tl_gset:Nx #1 { \exp_args:No \clist_reverse:n {#1} } }
 \cs_generate_variant:Nn \clist_reverse:N { c }
 \cs_generate_variant:Nn \clist_greverse:N { c }
 %    \end{macrocode}

--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -791,7 +791,7 @@
 %
 %    \begin{macrocode}
 \cs_gset_protected:Npn \__kernel_tl_set:Nx  { \cs_set_nopar:Npe }
-\cs_gset_protected:Npn \__kernel_tl_gset:Ne { \cs_gset_nopar:Npe }
+\cs_gset_protected:Npn \__kernel_tl_gset:Nx { \cs_gset_nopar:Npe }
 %    \end{macrocode}
 %
 % Patching where the first argument to a function needs scope-checking:
@@ -911,7 +911,7 @@
       \str_gset_eq:NN
       \str_gput_left:Nn
       \str_gput_right:Nn
-      \__kernel_tl_gset:Ne
+      \__kernel_tl_gset:Nx
       \tl_gclear:N
       \tl_gset_eq:NN
       \tl_gput_left:Nn

--- a/l3kernel/l3fp-assign.dtx
+++ b/l3kernel/l3fp-assign.dtx
@@ -84,7 +84,7 @@
 \cs_new_protected:Npn \fp_set:Nn   #1#2
   { \__kernel_tl_set:Nx #1 { \exp_not:f { \@@_parse:n {#2} } } }
 \cs_new_protected:Npn \fp_gset:Nn  #1#2
-  { \__kernel_tl_gset:Ne #1 { \exp_not:f { \@@_parse:n {#2} } } }
+  { \__kernel_tl_gset:Nx #1 { \exp_not:f { \@@_parse:n {#2} } } }
 \cs_new_protected:Npn \fp_const:Nn #1#2
   { \tl_const:Ne #1 { \exp_not:f { \@@_parse:n {#2} } } }
 \cs_generate_variant:Nn \fp_set:Nn {c}

--- a/l3kernel/l3kernel-functions.dtx
+++ b/l3kernel/l3kernel-functions.dtx
@@ -498,7 +498,7 @@
 %   only a single expansion.
 % \end{function}
 %
-% \begin{function}{\__kernel_tl_set:Nx, \__kernel_tl_gset:Ne}
+% \begin{function}{\__kernel_tl_set:Nx, \__kernel_tl_gset:Nx}
 %   \begin{syntax}
 %     \cs{__kernel_tl_set:Nx} \meta{tl~var} \Arg{tokens}
 %   \end{syntax}

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -1267,7 +1267,7 @@
 %   in the property list, preserving the order of entries.
 %    \begin{macrocode}
 \cs_new_protected:Npn \prop_put:Nnn  { \@@_put:NNnn \__kernel_tl_set:Nx }
-\cs_new_protected:Npn \prop_gput:Nnn { \@@_put:NNnn \__kernel_tl_gset:Ne }
+\cs_new_protected:Npn \prop_gput:Nnn { \@@_put:NNnn \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_put:NNnn #1#2#3#4
   {
     \tl_set:Nn \l_@@_internal_tl
@@ -1331,7 +1331,7 @@
 \cs_new_protected:Npn \prop_put_if_new:Nnn
   { \@@_put_if_new:NNnn \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \prop_gput_if_new:Nnn
-  { \@@_put_if_new:NNnn \__kernel_tl_gset:Ne }
+  { \@@_put_if_new:NNnn \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_put_if_new:NNnn #1#2#3#4
   {
     \tl_set:Nn \l_@@_internal_tl

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -1726,7 +1726,7 @@
       \cs_set:Npn \@@_escape_escaped:N ##1 { #2 }
       \cs_set:Npn \@@_escape_raw:N ##1 { #3 }
       \@@_standard_escapechar:
-      \__kernel_tl_gset:Ne \g_@@_internal_tl
+      \__kernel_tl_gset:Nx \g_@@_internal_tl
         { \__kernel_str_to_other_fast:n {#4} }
       \tl_put_right:Ne \l_@@_internal_a_tl
         {
@@ -3756,7 +3756,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_compile_u_in_cs:
   {
-    \__kernel_tl_gset:Ne \g_@@_internal_tl
+    \__kernel_tl_gset:Nx \g_@@_internal_tl
       {
         \exp_args:No \__kernel_str_to_other_fast:n
           { \l_@@_internal_a_tl }
@@ -6993,7 +6993,7 @@
       \flag_clear:n { @@_begin }
       \flag_clear:n { @@_end }
       \cs_set_eq:NN \@@_tmp:w \scan_stop:
-      \__kernel_tl_gset:Ne \g_@@_internal_tl
+      \__kernel_tl_gset:Nx \g_@@_internal_tl
         {
           \int_step_function:nnN \l_@@_min_submatch_int
             { \l_@@_submatch_int - \c_one_int } \@@_extract_seq_aux:n
@@ -7004,7 +7004,7 @@
       \int_set:Nn \l_@@_added_end_int
         { \flag_height:n { @@_end } }
       \tex_afterassignment:D \@@_extract_check:w
-      \__kernel_tl_gset:Ne \g_@@_internal_tl
+      \__kernel_tl_gset:Nx \g_@@_internal_tl
         { \g_@@_internal_tl \if_false: { \fi: } }
       \int_compare:nNnT
         { \l_@@_added_begin_int + \l_@@_added_end_int } > \c_zero_int
@@ -7079,17 +7079,17 @@
 %   In \cs{@@_group_end_extract_seq:N} we had to expand
 %   \cs{g_@@_internal_tl} to turn \cs{if_false:} constructions into
 %   actual begin-group and end-group tokens.  This is done with a
-%   \cs{__kernel_tl_gset:Ne} assignment, and \cs{@@_extract_check:w} is
+%   \cs{__kernel_tl_gset:Nx} assignment, and \cs{@@_extract_check:w} is
 %   run immediately after this assignment ends, thanks to the
 %   \tn{afterassignment} primitive.  If all of the items were properly
 %   balanced (enough begin-group tokens before end-group tokens, so |}{|
 %   is not) then \cs{@@_extract_check:w} is called just before the
-%   closing brace of the \cs{__kernel_tl_gset:Ne} (thanks to our sneaky
+%   closing brace of the \cs{__kernel_tl_gset:Nx} (thanks to our sneaky
 %   \cs{if_false:} |{| \cs{fi:} |}| construction), and finds that there
 %   is nothing left to expand.  If any of the items is unbalanced, the
 %   assignment gets ended early by an extra end-group token, and our
 %   check finds more tokens needing to be expanded in a new
-%   \cs{__kernel_tl_gset:Ne} assignment.  We need to add a begin-group
+%   \cs{__kernel_tl_gset:Nx} assignment.  We need to add a begin-group
 %   and an end-group tokens to the unbalanced item, namely to the last
 %   item found so far, which we reach through a loop.
 %    \begin{macrocode}
@@ -7105,7 +7105,7 @@
         \int_incr:N \l_@@_added_begin_int
         \int_incr:N \l_@@_added_end_int
         \tex_afterassignment:D \@@_extract_check:w
-        \__kernel_tl_gset:Ne \g_@@_internal_tl
+        \__kernel_tl_gset:Nx \g_@@_internal_tl
           {
             \exp_after:wN \@@_extract_check_loop:w
             \g_@@_internal_tl
@@ -7331,7 +7331,7 @@
 \cs_new_protected:Npn \@@_group_end_replace_try:
   {
     \tex_afterassignment:D \@@_group_end_replace_check:w
-    \__kernel_tl_gset:Ne \g_@@_internal_tl
+    \__kernel_tl_gset:Nx \g_@@_internal_tl
       {
         \prg_replicate:nn \l_@@_added_begin_int { { \if_false: } \fi: }
         \l_@@_internal_a_tl

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1264,12 +1264,12 @@
   }
 \cs_new_protected:Npn \seq_gset_from_clist:NN #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \s_@@ \clist_map_function:NN #2 \@@_wrap_item:n }
   }
 \cs_new_protected:Npn \seq_gset_from_clist:Nn #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \s_@@ \clist_map_function:nN {#2} \@@_wrap_item:n }
   }
 \cs_generate_variant:Nn \seq_set_from_clist:NN  {     Nc }
@@ -1340,11 +1340,11 @@
 \cs_new_protected:Npn \seq_set_split:Nnn
   { \@@_set_split:NNNnn \__kernel_tl_set:Nx \tl_trim_spaces:n }
 \cs_new_protected:Npn \seq_gset_split:Nnn
-  { \@@_set_split:NNNnn \__kernel_tl_gset:Ne \tl_trim_spaces:n }
+  { \@@_set_split:NNNnn \__kernel_tl_gset:Nx \tl_trim_spaces:n }
 \cs_new_protected:Npn \seq_set_split_keep_spaces:Nnn
   { \@@_set_split:NNNnn \__kernel_tl_set:Nx \exp_not:n }
 \cs_new_protected:Npn \seq_gset_split_keep_spaces:Nnn
-  { \@@_set_split:NNNnn \__kernel_tl_gset:Ne \exp_not:n }
+  { \@@_set_split:NNNnn \__kernel_tl_gset:Nx \exp_not:n }
 \cs_new_protected:Npn \@@_set_split:NNNnn #1#2#3#4#5
   {
     \tl_if_empty:nTF {#4}
@@ -1401,7 +1401,7 @@
 \cs_new_protected:Npn \seq_set_filter:NNn
   { \@@_set_filter:NNNn \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \seq_gset_filter:NNn
-  { \@@_set_filter:NNNn \__kernel_tl_gset:Ne }
+  { \@@_set_filter:NNNn \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_set_filter:NNNn #1#2#3#4
   {
     \@@_push_item_def:n { \bool_if:nT {#4} { \@@_wrap_item:n {##1} } }
@@ -1470,7 +1470,7 @@
   }
 \cs_new_protected:Npn \seq_gput_left:Nn #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       {
         \exp_not:n { \s_@@ \@@_item:n {#2} }
         \exp_not:f { \exp_after:wN \@@_put_left_aux:w #1 }
@@ -1595,7 +1595,7 @@
 \cs_new_protected:Npn \seq_remove_all:Nn
   { \@@_remove_all_aux:NNn \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \seq_gremove_all:Nn
-  { \@@_remove_all_aux:NNn \__kernel_tl_gset:Ne }
+  { \@@_remove_all_aux:NNn \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_remove_all_aux:NNn #1#2#3
   {
     \@@_push_item_def:n
@@ -1641,13 +1641,13 @@
 \cs_new_protected:Npn \seq_set_item:Nnn #1#2#3
   { \@@_set_item:NnnNN #1 {#2} {#3} \__kernel_tl_set:Nx \use_i:nn }
 \cs_new_protected:Npn \seq_gset_item:Nnn #1#2#3
-  { \@@_set_item:NnnNN #1 {#2} {#3} \__kernel_tl_gset:Ne \use_i:nn }
+  { \@@_set_item:NnnNN #1 {#2} {#3} \__kernel_tl_gset:Nx \use_i:nn }
 \cs_generate_variant:Nn \seq_set_item:Nnn { c }
 \cs_generate_variant:Nn \seq_gset_item:Nnn { c }
 \prg_new_protected_conditional:Npnn \seq_set_item:Nnn #1#2#3 { TF , T , F }
   { \@@_set_item:NnnNN #1 {#2} {#3} \__kernel_tl_set:Nx \use_ii:nn }
 \prg_new_protected_conditional:Npnn \seq_gset_item:Nnn #1#2#3 { TF , T , F }
-  { \@@_set_item:NnnNN #1 {#2} {#3} \__kernel_tl_gset:Ne \use_ii:nn }
+  { \@@_set_item:NnnNN #1 {#2} {#3} \__kernel_tl_gset:Nx \use_ii:nn }
 \prg_generate_conditional_variant:Nnn \seq_set_item:Nnn { c } { TF , T , F }
 \prg_generate_conditional_variant:Nnn \seq_gset_item:Nnn { c } { TF , T , F }
 %    \end{macrocode}
@@ -1771,7 +1771,7 @@
 \cs_new_protected:Npn \seq_reverse:N
   { \@@_reverse:NN \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \seq_greverse:N
-  { \@@_reverse:NN \__kernel_tl_gset:Ne }
+  { \@@_reverse:NN \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_reverse:NN #1 #2
   {
     \cs_set_eq:NN \@@_tmp:w \@@_item:n
@@ -2047,7 +2047,7 @@
 \cs_new_protected:Npn \seq_pop_right:NN
   { \@@_pop:NNNN \@@_pop_right:NNN \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \seq_gpop_right:NN
-  { \@@_pop:NNNN \@@_pop_right:NNN \__kernel_tl_gset:Ne }
+  { \@@_pop:NNNN \@@_pop_right:NNN \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_pop_right:NNN #1#2#3
   {
     \cs_set_eq:NN \@@_tmp:w \@@_item:n
@@ -2110,7 +2110,7 @@
   { \@@_pop_TF:NNNN \@@_pop_right:NNN \__kernel_tl_set:Nx #1 #2 }
 \prg_new_protected_conditional:Npnn \seq_gpop_right:NN #1#2
   { T , F , TF }
-  { \@@_pop_TF:NNNN \@@_pop_right:NNN \__kernel_tl_gset:Ne #1 #2 }
+  { \@@_pop_TF:NNNN \@@_pop_right:NNN \__kernel_tl_gset:Nx #1 #2 }
 \prg_generate_conditional_variant:Nnn \seq_pop_left:NN { c }
   { T , F , TF }
 \prg_generate_conditional_variant:Nnn \seq_gpop_left:NN { c }
@@ -2438,7 +2438,7 @@
 \cs_new_protected:Npn \seq_set_map_e:NNn
   { \@@_set_map_e:NNNn \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \seq_gset_map_e:NNn
-  { \@@_set_map_e:NNNn \__kernel_tl_gset:Ne }
+  { \@@_set_map_e:NNNn \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_set_map_e:NNNn #1#2#3#4
   {
     \@@_push_item_def:n { \exp_not:N \@@_item:n {#4} }
@@ -2457,7 +2457,7 @@
 \cs_new_protected:Npn \seq_set_map:NNn
   { \@@_set_map:NNNn \__kernel_tl_set:Nx }
 \cs_new_protected:Npn \seq_gset_map:NNn
-  { \@@_set_map:NNNn \__kernel_tl_gset:Ne }
+  { \@@_set_map:NNNn \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \@@_set_map:NNNn #1#2#3#4
   {
     \@@_push_item_def:n { \exp_not:n { \@@_item:n {#4} } }

--- a/l3kernel/l3sort.dtx
+++ b/l3kernel/l3sort.dtx
@@ -376,7 +376,7 @@
   {
     \group_begin:
       \@@_main:NNNn \tl_map_inline:Nn \tl_map_break:n #2 {#3}
-      \__kernel_tl_gset:Ne \g_@@_internal_tl
+      \__kernel_tl_gset:Nx \g_@@_internal_tl
         { \@@_tl_toks:w \l_@@_min_int ; }
     \group_end:
     #1 #2 \g_@@_internal_tl

--- a/l3kernel/l3str-convert.dtx
+++ b/l3kernel/l3str-convert.dtx
@@ -554,7 +554,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_convert_gmap:N #1
   {
-    \__kernel_tl_gset:Ne \g_@@_result_tl
+    \__kernel_tl_gset:Nx \g_@@_result_tl
       {
         \exp_after:wN \@@_convert_gmap_loop:NN
         \exp_after:wN #1
@@ -579,7 +579,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_convert_gmap_internal:N #1
   {
-    \__kernel_tl_gset:Ne \g_@@_result_tl
+    \__kernel_tl_gset:Nx \g_@@_result_tl
       {
         \exp_after:wN \@@_convert_gmap_internal_loop:Nww
         \exp_after:wN #1
@@ -703,7 +703,7 @@
   {
     \group_begin:
       #1
-      \__kernel_tl_gset:Ne \g_@@_result_tl { \__kernel_str_to_other_fast:n {#4} }
+      \__kernel_tl_gset:Nx \g_@@_result_tl { \__kernel_str_to_other_fast:n {#4} }
       \exp_after:wN \@@_convert:wwwnn
         \tl_to_str:n {#5} /// \s_@@_stop
         { decode } { unescape }
@@ -714,7 +714,7 @@
         { encode } { escape }
         \use_ii_i:nn
         \@@_convert_encode_:
-        \__kernel_tl_gset:Ne \g_@@_result_tl
+        \__kernel_tl_gset:Nx \g_@@_result_tl
           { \tl_to_str:V \g_@@_result_tl }
     \group_end:
     #2 #3 \g_@@_result_tl
@@ -938,7 +938,7 @@
     \cs_new_protected:Npn \@@_convert_unescape_:
       {
         \flag_clear:n { @@_byte }
-        \__kernel_tl_gset:Ne \g_@@_result_tl
+        \__kernel_tl_gset:Nx \g_@@_result_tl
           { \exp_args:No \@@_filter_bytes:n \g_@@_result_tl }
         \@@_if_flag_error:nne { @@_byte } { non-byte } { bytes }
       }
@@ -1034,7 +1034,7 @@
 \cs_new_protected:Npn \@@_convert_decode_clist:
   {
     \clist_gset:No \g_@@_result_tl \g_@@_result_tl
-    \__kernel_tl_gset:Ne \g_@@_result_tl
+    \__kernel_tl_gset:Nx \g_@@_result_tl
       {
         \exp_args:No \clist_map_function:nN
           \g_@@_result_tl \@@_decode_clist_char:n
@@ -1057,7 +1057,7 @@
 \cs_new_protected:Npn \@@_convert_encode_clist:
   {
     \@@_convert_gmap_internal:N \@@_encode_clist_char:n
-    \__kernel_tl_gset:Ne \g_@@_result_tl { \tl_tail:N \g_@@_result_tl }
+    \__kernel_tl_gset:Nx \g_@@_result_tl { \tl_tail:N \g_@@_result_tl }
   }
 \cs_new:Npn \@@_encode_clist_char:n #1 { , #1 }
 %    \end{macrocode}
@@ -1351,7 +1351,7 @@
     \group_begin:
       \flag_clear:n { @@_error }
       \int_set:Nn \tex_escapechar:D { 92 }
-      \__kernel_tl_gset:Ne \g_@@_result_tl
+      \__kernel_tl_gset:Nx \g_@@_result_tl
         {
           \@@_output_byte:w "
             \exp_last_unbraced:Nf \@@_unescape_hex_auxi:N
@@ -1430,7 +1430,7 @@
           \flag_clear:n { @@_byte }
           \flag_clear:n { @@_error }
           \int_set:Nn \tex_escapechar:D { 92 }
-          \__kernel_tl_gset:Ne \g_@@_result_tl
+          \__kernel_tl_gset:Nx \g_@@_result_tl
             {
               \exp_after:wN #3 \g_@@_result_tl
                 #1 ? { ? \prg_break: }
@@ -1516,13 +1516,13 @@
             \flag_clear:n { @@_byte }
             \flag_clear:n { @@_error }
             \int_set:Nn \tex_escapechar:D { 92 }
-            \__kernel_tl_gset:Ne \g_@@_result_tl
+            \__kernel_tl_gset:Nx \g_@@_result_tl
               {
                 \exp_after:wN \@@_unescape_string_newlines:wN
                   \g_@@_result_tl \prg_break: ^^M ?
                 \prg_break_point:
               }
-            \__kernel_tl_gset:Ne \g_@@_result_tl
+            \__kernel_tl_gset:Nx \g_@@_result_tl
               {
                 \exp_after:wN \@@_unescape_string_loop:wNNN
                   \g_@@_result_tl #1 ?? { ? \prg_break: }
@@ -1975,7 +1975,7 @@
     \flag_clear:n { @@_extra }
     \flag_clear:n { @@_overlong }
     \flag_clear:n { @@_overflow }
-    \__kernel_tl_gset:Ne \g_@@_result_tl
+    \__kernel_tl_gset:Nx \g_@@_result_tl
       {
         \exp_after:wN \@@_decode_utf_viii_start:N \g_@@_result_tl
           { \prg_break: \@@_decode_utf_viii_end: }
@@ -2265,7 +2265,7 @@
       \flag_clear:n { @@_extra }
       \flag_clear:n { @@_end }
       \cs_set:Npn \@@_tmp:w ##1 ##2 { ` ## #1 }
-      \__kernel_tl_gset:Ne \g_@@_result_tl
+      \__kernel_tl_gset:Nx \g_@@_result_tl
         {
           \exp_after:wN \@@_decode_utf_xvi_pair:NN
             #2 \q_@@_nil \q_@@_nil
@@ -2553,7 +2553,7 @@
       \flag_clear:n { @@_end }
       \flag_clear:n { @@_error }
       \cs_set:Npn \@@_tmp:w ##1 ##2 { ` ## #1 }
-      \__kernel_tl_gset:Ne \g_@@_result_tl
+      \__kernel_tl_gset:Nx \g_@@_result_tl
         {
           \exp_after:wN \@@_decode_utf_xxxii_loop:NNNN
             #2 \s_@@_stop \s_@@_stop \s_@@_stop \s_@@_stop

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -990,7 +990,7 @@
 %   Similar to corresponding \pkg{l3tl} base functions, except that
 %   \cs{__kernel_exp_not:w} is replaced with \cs{__kernel_tl_to_str:w}.
 %   Just like token list, string constants use \cs{cs_gset_nopar:Npe}
-%   instead of \cs{__kernel_tl_gset:Ne} so that the scope checking for
+%   instead of \cs{__kernel_tl_gset:Nx} so that the scope checking for
 %   |c| is applied when \pkg{l3debug} is used.
 %   To maintain backward compatibility, in
 %     \cs[index=str_put_left:Nn]{str_(g)put_left:Nn} and
@@ -1001,7 +1001,7 @@
 \cs_new_protected:Npn \str_set:Nn #1#2
   { \__kernel_tl_set:Nx #1 { \__kernel_tl_to_str:w {#2} } }
 \cs_gset_protected:Npn \str_gset:Nn #1#2
-  { \__kernel_tl_gset:Ne #1 { \__kernel_tl_to_str:w {#2} } }
+  { \__kernel_tl_gset:Nx #1 { \__kernel_tl_to_str:w {#2} } }
 \cs_new_protected:Npn \str_const:Nn #1#2
   {
     \__kernel_chk_if_free_cs:N #1
@@ -1014,7 +1014,7 @@
   }
 \cs_new_protected:Npn \str_gput_left:Nn #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \__kernel_tl_to_str:w {#2} \__kernel_exp_not:w \exp_after:wN {#1} }
   }
 \cs_new_protected:Npn \str_put_right:Nn #1#2
@@ -1024,7 +1024,7 @@
   }
 \cs_new_protected:Npn \str_gput_right:Nn #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \__kernel_exp_not:w \exp_after:wN {#1} \__kernel_tl_to_str:w {#2} }
   }
 \cs_generate_variant:Nn \str_set:Nn        { NV , Ne , Nx , c , cV , ce , cx }
@@ -1063,11 +1063,11 @@
 \cs_new_protected:Npn \str_replace_once:Nnn
   { \@@_replace:NNNnn \prg_do_nothing: \__kernel_tl_set:Nx  }
 \cs_new_protected:Npn \str_greplace_once:Nnn
-  { \@@_replace:NNNnn \prg_do_nothing: \__kernel_tl_gset:Ne }
+  { \@@_replace:NNNnn \prg_do_nothing: \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \str_replace_all:Nnn
   { \@@_replace:NNNnn \@@_replace_next:w \__kernel_tl_set:Nx  }
 \cs_new_protected:Npn \str_greplace_all:Nnn
-  { \@@_replace:NNNnn \@@_replace_next:w \__kernel_tl_gset:Ne }
+  { \@@_replace:NNNnn \@@_replace_next:w \__kernel_tl_gset:Nx }
 \cs_generate_variant:Nn \str_replace_once:Nnn  { c }
 \cs_generate_variant:Nn \str_greplace_once:Nnn { c }
 \cs_generate_variant:Nn \str_replace_all:Nnn   { c }

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -1142,7 +1142,7 @@ end
 \tl_new:N \g_@@_backend_tl
 \@@_finalise:n
   {
-    \__kernel_tl_gset:Ne \g_@@_backend_tl
+    \__kernel_tl_gset:Nx \g_@@_backend_tl
       {
         \sys_if_engine_xetex:TF
           { xetex }

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -806,7 +806,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_analysis_b:n #1
   {
-    \__kernel_tl_gset:Ne \g_@@_analysis_result_tl
+    \__kernel_tl_gset:Nx \g_@@_analysis_result_tl
       {
         \@@_analysis_b_loop:w 0; #1
         \prg_break_point:

--- a/l3kernel/l3tl-build.dtx
+++ b/l3kernel/l3tl-build.dtx
@@ -298,7 +298,7 @@
   }
 \cs_new_protected:Npn \tl_build_gend:N #1
   {
-    \@@_build_get:NNN \__kernel_tl_gset:Ne #1 #1
+    \@@_build_get:NNN \__kernel_tl_gset:Nx #1 #1
     \exp_args:Nc \@@_build_end_loop:NN { \cs_to_str:N #1 ' } \tl_gclear:N
   }
 \cs_new_protected:Npn \@@_build_end_loop:NN #1#2

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -1346,12 +1346,12 @@
 %
 % \subsection{Functions}
 %
-% \begin{macro}{\__kernel_tl_set:Nx,\__kernel_tl_gset:Ne}
+% \begin{macro}{\__kernel_tl_set:Nx,\__kernel_tl_gset:Nx}
 %   These two are supplied to get better performance for macros which would
 %   otherwise use \cs{tl_set:Ne} or \cs{tl_gset:Ne} internally.
 %    \begin{macrocode}
 \cs_new_eq:NN \__kernel_tl_set:Nx  \cs_set_nopar:Npe
-\cs_new_eq:NN \__kernel_tl_gset:Ne \cs_gset_nopar:Npe
+\cs_new_eq:NN \__kernel_tl_gset:Nx \cs_gset_nopar:Npe
 %    \end{macrocode}
 % \end{macro}
 %
@@ -1374,7 +1374,7 @@
 %     \tl_const:cn, \tl_const:ce, \tl_const:cx
 %   }
 %   Constants are also easy to generate. They use \cs{cs_gset_nopar:Npe} instead
-%   of \cs{__kernel_tl_gset:Ne} so that the correct scope checking for |c|,
+%   of \cs{__kernel_tl_gset:Nx} so that the correct scope checking for |c|,
 %   instead of for |g|, is applied when
 %   \cs{debug_on:n} |{ check-declarations }| is used.
 %   Constant assignment functions are patched specially in \pkg{l3debug} to
@@ -1452,7 +1452,7 @@
   }
 \cs_new_protected:Npn \tl_gconcat:NNN #1#2#3
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       {
         \__kernel_exp_not:w \exp_after:wN {#2}
         \__kernel_exp_not:w \exp_after:wN {#3}
@@ -1523,9 +1523,9 @@
 \cs_new_protected:Npn \tl_set:No #1#2
   { \__kernel_tl_set:Nx #1 { \__kernel_exp_not:w \exp_after:wN {#2} } }
 \cs_new_protected:Npn \tl_gset:Nn #1#2
-  { \__kernel_tl_gset:Ne #1 { \__kernel_exp_not:w {#2} } }
+  { \__kernel_tl_gset:Nx #1 { \__kernel_exp_not:w {#2} } }
 \cs_new_protected:Npn \tl_gset:No #1#2
-  { \__kernel_tl_gset:Ne #1 { \__kernel_exp_not:w \exp_after:wN {#2} } }
+  { \__kernel_tl_gset:Nx #1 { \__kernel_exp_not:w \exp_after:wN {#2} } }
 \cs_generate_variant:Nn \tl_set:Nn  {    NV , Nv , Ne , Nf }
 \cs_generate_variant:Nn \tl_set:Nn  { c, cV , cv , ce , cf }
 \cs_generate_variant:Nn \tl_set:No  { c }
@@ -1587,22 +1587,22 @@
   }
 \cs_new_protected:Npn \tl_gput_left:Nn #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \__kernel_exp_not:w {#2} \__kernel_exp_not:w \exp_after:wN {#1} }
   }
 \cs_new_protected:Npn \tl_gput_left:NV #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \exp_not:V #2 \__kernel_exp_not:w \exp_after:wN {#1} }
   }
 \cs_new_protected:Npn \tl_gput_left:Nv #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \exp_not:v {#2} \__kernel_exp_not:w \exp_after:wN {#1} }
   }
 \cs_new_protected:Npn \tl_gput_left:Ne #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       {
         \__kernel_exp_not:w \tex_expanded:D { {#2} }
         \__kernel_exp_not:w \exp_after:wN {#1}
@@ -1610,7 +1610,7 @@
   }
 \cs_new_protected:Npn \tl_gput_left:No #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       {
         \__kernel_exp_not:w \exp_after:wN {#2}
         \__kernel_exp_not:w \exp_after:wN {#1}
@@ -1677,20 +1677,20 @@
       }
   }
 \cs_new_protected:Npn \tl_gput_right:Nn #1#2
-  { \__kernel_tl_gset:Ne #1 { \__kernel_exp_not:w \exp_after:wN { #1 #2 } } }
+  { \__kernel_tl_gset:Nx #1 { \__kernel_exp_not:w \exp_after:wN { #1 #2 } } }
 \cs_new_protected:Npn \tl_gput_right:NV #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \__kernel_exp_not:w \exp_after:wN {#1} \exp_not:V #2 }
   }
 \cs_new_protected:Npn \tl_gput_right:Nv #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       { \__kernel_exp_not:w \exp_after:wN {#1} \exp_not:v {#2} }
   }
 \cs_new_protected:Npn \tl_gput_right:Ne #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       {
         \__kernel_exp_not:w \exp_after:wN {#1}
         \__kernel_exp_not:w \tex_expanded:D { {#2} }
@@ -1698,7 +1698,7 @@
   }
 \cs_new_protected:Npn \tl_gput_right:No #1#2
   {
-    \__kernel_tl_gset:Ne #1
+    \__kernel_tl_gset:Nx #1
       {
         \__kernel_exp_not:w \exp_after:wN {#1}
         \__kernel_exp_not:w \exp_after:wN {#2}
@@ -2043,11 +2043,11 @@
 \cs_new_protected:Npn \tl_replace_once:Nnn
   { \@@_replace:NnNNNnn \q_@@_mark ? \@@_replace_wrap:w \__kernel_tl_set:Nx  }
 \cs_new_protected:Npn \tl_greplace_once:Nnn
-  { \@@_replace:NnNNNnn \q_@@_mark ? \@@_replace_wrap:w \__kernel_tl_gset:Ne }
+  { \@@_replace:NnNNNnn \q_@@_mark ? \@@_replace_wrap:w \__kernel_tl_gset:Nx }
 \cs_new_protected:Npn \tl_replace_all:Nnn
   { \@@_replace:NnNNNnn \q_@@_mark ? \@@_replace_next:w \__kernel_tl_set:Nx  }
 \cs_new_protected:Npn \tl_greplace_all:Nnn
-  { \@@_replace:NnNNNnn \q_@@_mark ? \@@_replace_next:w \__kernel_tl_gset:Ne }
+  { \@@_replace:NnNNNnn \q_@@_mark ? \@@_replace_next:w \__kernel_tl_gset:Nx }
 \cs_generate_variant:Nn \tl_replace_once:Nnn
   { NnV , Nne , NV , Ne , Nee , c , cnV , cne , cV , ce , cee }
 \cs_generate_variant:Nn \tl_replace_once:Nnn
@@ -2906,7 +2906,7 @@
 \cs_new_protected:Npn \tl_trim_spaces:N #1
   { \__kernel_tl_set:Nx #1 { \exp_args:No \tl_trim_spaces:n {#1} } }
 \cs_new_protected:Npn \tl_gtrim_spaces:N #1
-  { \__kernel_tl_gset:Ne #1 { \exp_args:No \tl_trim_spaces:n {#1} } }
+  { \__kernel_tl_gset:Nx #1 { \exp_args:No \tl_trim_spaces:n {#1} } }
 \cs_generate_variant:Nn \tl_trim_spaces:N  { c }
 \cs_generate_variant:Nn \tl_gtrim_spaces:N { c }
 %    \end{macrocode}
@@ -3483,7 +3483,7 @@
 \cs_new_protected:Npn \tl_reverse:N #1
   { \__kernel_tl_set:Nx #1 { \exp_args:No \tl_reverse:n { #1 } } }
 \cs_new_protected:Npn \tl_greverse:N #1
-  { \__kernel_tl_gset:Ne #1 { \exp_args:No \tl_reverse:n { #1 } } }
+  { \__kernel_tl_gset:Nx #1 { \exp_args:No \tl_reverse:n { #1 } } }
 \cs_generate_variant:Nn \tl_reverse:N  { c }
 \cs_generate_variant:Nn \tl_greverse:N { c }
 %    \end{macrocode}


### PR DESCRIPTION
Together with 1f45ced8bc3c881736ad153a3debf8ada275608b (Revert to \\\_\_kernel\_tl\_set:Nx, 2024-01-10), now the effect of 9dd74fcfd4efff26c479fe78890021d3334cf94f (Swiitch \\\_\_kernel\_tl\_(g)set:Nx to :Ne, 2023-09-25) were totally reverted.