### PR TITLE
Mention DocStrip instead of l3docstrip

### DIFF
--- a/l3kernel/doc/l3styleguide.tex
+++ b/l3kernel/doc/l3styleguide.tex
@@ -187,7 +187,7 @@ The only exception is where a \enquote{family} of modules share some
 Any internal functions or variables \emph{must} be documented in the same way
 as public ones.
 
-The \pkg{l3docstrip} method should be used for internal functions in a module.
+The \pkg{DocStrip} method should be used for internal functions in a module.
 This requires a line
 \begin{quote}
   \ttfamily

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -330,7 +330,7 @@ and all files in that bundle must be distributed together.
 %   it doesn't rely on catcodes being \enquote{correct} and is therefore
 %   recommended.
 %
-%   These commands are aware of the |@@| \pkg{l3docstrip} syntax and
+%   These commands are aware of the |@@| \pkg{DocStrip} syntax and
 %   replace such instances correctly in the typeset documentation.
 %   This only happens after a |%<@@=|\meta{module}|>| declaration.
 %
@@ -351,7 +351,7 @@ and all files in that bundle must be distributed together.
 %       main index.  By default, the \meta{module} is deduced
 %       automatically from the command name.
 %     \item |replace| is a boolean key (\texttt{true} by default) which
-%       indicates whether to replace |@@| as \pkg{l3docstrip} does.
+%       indicates whether to replace |@@| as \pkg{DocStrip} does.
 %   \end{itemize}
 %   These commands allow hyphenation of control sequences after (most) underscores.
 %   By default, a hyphen is used to mark the hyphenation, but this can be changed with

--- a/l3kernel/l3quark.dtx
+++ b/l3kernel/l3quark.dtx
@@ -970,7 +970,7 @@
 %   Can't use \cs{scan_new:N} yet because \pkg{l3tl} isn't loaded,
 %   so define \cs{s_stop} by hand and add it to \cs{g_@@_marks_tl}.
 %   We also add the scan marks declared earlier to the pool here.
-%   Since they lives in a different namespace, a little \pkg{l3docstrip}
+%   Since they lives in a different namespace, a little \pkg{DocStrip}
 %   cheating is necessary.
 %    \begin{macrocode}
 \cs_new_eq:NN \s_stop \scan_stop:

--- a/l3packages/l3doc/examples/testing.dtx
+++ b/l3packages/l3doc/examples/testing.dtx
@@ -52,7 +52,7 @@
 %   it doesn't rely on catcodes being \enquote{correct} and is therefore
 %   recommended.
 %
-%   These commands are aware of the |@@| \pkg{l3docstrip} syntax and
+%   These commands are aware of the |@@| \pkg{DocStrip} syntax and
 %   replace such instances correctly in the typeset documentation.
 %   This only happens after a |%<@@=|\meta{module}|>| declaration.
 %
@@ -73,7 +73,7 @@
 %       main index.  By default, the \meta{module} is deduced
 %       automatically from the command name.
 %     \item |replace| is a boolean key (\texttt{true} by default) which
-%       indicates whether to replace |@@| as \pkg{l3docstrip} does.
+%       indicates whether to replace |@@| as \pkg{DocStrip} does.
 %   \end{itemize}
 % \end{function}
 %

--- a/xpackages/xor/xotrace.ins
+++ b/xpackages/xor/xotrace.ins
@@ -43,7 +43,7 @@
 %
 %
 
-\input l3docstrip
+\input docstrip
 \keepsilent
 \askforoverwritefalse
 


### PR DESCRIPTION
Being reminded by 1b79c4e3 (Update expl3 for DocStrip support of @@ convention, 2023-10-09).