### PR TITLE
Small cleanup in l3keys

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -109,8 +109,8 @@
 % Key names may contain any tokens, as they are handled internally
 % using \cs{tl_to_str:n}. As discussed in
 % section~\ref{sec:l3keys:subdivision}, it is suggested that the character
-% |/| is reserved for sub-division of keys into logical
-% groups. Functions and variables are \emph{not} expanded when creating
+% |/| is reserved for sub-division of keys into different subsets.
+% Functions and variables are \emph{not} expanded when creating
 % key names, and so
 % \begin{verbatim}
 %   \tl_set:Nn \l_mymodule_tmp_tl { key }
@@ -340,7 +340,7 @@
 %   \end{syntax}
 %   Specifies that the \meta{key} path should inherit the keys listed
 %   as any of the \meta{parents} (a comma list), which can be a module
-%   or a subgroup. For example, after setting
+%   or a sub-division thereof. For example, after setting
 %   \begin{verbatim}
 %     \keys_define:nn { foo } { test .code:n = \tl_show:n {#1} }
 %     \keys_define:nn { } { bar .inherit:n = foo }
@@ -547,21 +547,21 @@
 % \label{sec:l3keys:subdivision}
 %
 % When creating large numbers of keys, it may be desirable to divide
-% them into several sub-groups for a given module. This can be achieved
+% them into several subsets for a given module. This can be achieved
 % either by adding a sub-division to the module name:
 % \begin{verbatim}
-%   \keys_define:nn { mymodule / subgroup }
+%   \keys_define:nn { mymodule / subset }
 %     { key .code:n = code }
 % \end{verbatim}
 % or to the key name:
 % \begin{verbatim}
 %   \keys_define:nn { mymodule }
-%     { subgroup / key .code:n = code }
+%     { subset / key .code:n = code }
 % \end{verbatim}
 % As illustrated, the best choice of token for sub-dividing keys in
 % this way is |/|. This is because of the method that is
 % used to represent keys internally. Both of the above code fragments
-% set the same key, which has full name \texttt{mymodule/subgroup/key}.
+% set the same key, which has full name \texttt{mymodule/subset/key}.
 %
 % As illustrated in the next section, this subdivision is
 % particularly relevant to making multiple choices.

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -323,9 +323,15 @@
 %   \begin{syntax}
 %     \meta{key} .groups:n = \Arg{groups}
 %   \end{syntax}
-%   Defines \meta{key} as belonging to the \meta{groups} declared. Groups
+%   Defines \meta{key} as belonging to the \meta{groups} (a
+%   comma-separated list). Groups
 %   provide a \enquote{secondary axis} for selectively setting keys, and are
 %   described in Section~\ref{sec:l3keys:selective}.
+%   \begin{texnote}
+%     The \meta{groups} argument is turned into a string then
+%     interpreted as a comma-separated list, so group names cannot
+%     contain commas nor start or end with a space character.
+%   \end{texnote}
 % \end{function}
 %
 % \begin{function}[added = 2016-11-22]{.inherit:n}
@@ -2084,7 +2090,7 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_groups_set:n #1
   {
-    \clist_set:Nn \l_@@_groups_clist {#1}
+    \clist_set:Ne \l_@@_groups_clist { \tl_to_str:n {#1} }
     \clist_if_empty:NTF \l_@@_groups_clist
       {
         \cs_set_eq:cN { \c_@@_groups_root_str \l_keys_path_str }
@@ -2981,7 +2987,8 @@
   { \exp_args:No \@@_set_selective:nnnn \l_@@_selective_seq }
 \cs_new_protected:Npn \@@_set_selective:nnnn #1#2#3#4
   {
-    \seq_set_from_clist:Nn \l_@@_selective_seq {#3}
+    \exp_args:NNe \seq_set_from_clist:Nn
+      \l_@@_selective_seq { \tl_to_str:n {#3} }
     \@@_set:nn {#2} {#4}
     \tl_set:Nn \l_@@_selective_seq {#1}
   }
@@ -3118,23 +3125,21 @@
 %    of groups which apply to a key with the list of those which have been
 %    set active. That requires two mappings, and again a different outcome
 %    depending on whether opt-in or opt-out is set.
-%    We cannot replace the clist mapping by \cs{clist_if_in:NnTF} because
-%    catcodes may not be the same; they cannot be normalized easily in the
-%    clist because of the remote possibility that some items need braces
-%    if they involve commas or leading/trailing spaces.
+%    It is safe to use \cs{clist_if_in:NnTF} because
+%    both \cs{l_@@_selective_seq} and \cs{l_@@_groups_clist} contain the
+%    groups as strings, without leading/trailing spaces in any item,
+%    since the \pkg{l3clist} functions were applied to the result of
+%    applying \cs{tl_to_str:n}.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_check_groups:
   {
     \bool_set_false:N \l_@@_tmp_bool
     \seq_map_inline:Nn \l_@@_selective_seq
       {
-        \clist_map_inline:Nn \l_@@_groups_clist
+        \clist_if_in:NnT \l_@@_groups_clist {##1}
           {
-            \str_if_eq:nnT {##1} {####1}
-              {
-                \bool_set_true:N \l_@@_tmp_bool
-                \clist_map_break:n \seq_map_break:
-              }
+            \bool_set_true:N \l_@@_tmp_bool
+            \seq_map_break:
           }
       }
     \bool_if:NTF \l_@@_tmp_bool

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1761,6 +1761,21 @@
 %    \end{macrocode}
 % \end{macro}
 %
+% \begin{macro}{\@@_cs_undefine:c}
+%   Local version of \cs{cs_undefine:c} to avoid sprinkling
+%   \cs{tex_undefined:D} everywhere.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_cs_undefine:c #1
+  {
+    \if_cs_exist:w #1 \cs_end:
+    \else:
+      \use_i:nnnn
+    \fi:
+    \cs_set_eq:cN {#1} \tex_undefined:D
+  }
+%    \end{macrocode}
+% \end{macro}
+%
 % \subsection{The key defining mechanism}
 %
 % \begin{macro}{\keys_define:nn, \keys_define:ne, \keys_define:nx}
@@ -2067,9 +2082,8 @@
   {
     \tl_if_empty:nTF {#1}
       {
-        \cs_set_eq:cN
+        \@@_cs_undefine:c
           { \c_@@_default_root_str \l_keys_path_str }
-          \tex_undefined:D
       }
       {
         \cs_set_nopar:cpe
@@ -2093,8 +2107,8 @@
     \clist_set:Ne \l_@@_groups_clist { \tl_to_str:n {#1} }
     \clist_if_empty:NTF \l_@@_groups_clist
       {
-        \cs_set_eq:cN { \c_@@_groups_root_str \l_keys_path_str }
-          \tex_undefined:D
+        \@@_cs_undefine:c
+          { \c_@@_groups_root_str \l_keys_path_str }
       }
       {
         \cs_set_eq:cN { \c_@@_groups_root_str \l_keys_path_str }
@@ -2228,9 +2242,8 @@
     \clist_map_inline:nn
       { code , default , groups , inherit , type , check }
       {
-        \cs_set_eq:cN
+        \@@_cs_undefine:c
           { \tl_use:c { c_@@_ ##1 _root_str } \l_keys_path_str }
-          \tex_undefined:D
       }
   }
 %    \end{macrocode}
@@ -2260,9 +2273,8 @@
               { \c_@@_check_root_str \l_keys_path_str }
               { @@_check_ #1 : }
               {
-                \cs_set_eq:cN
+                \@@_cs_undefine:c
                   { \c_@@_check_root_str \l_keys_path_str }
-                  \tex_undefined:D
               }
           }
       }


### PR DESCRIPTION
This ends up being a couple of marginally-related changes to `l3keys.dtx`, starting from the observation that comparing groups was being done in a messy way due to too much freedom in what their name can contain.

- The `groups` comma list argument of `\keys_set_groups:nnn` and related functions was allowed to be for instance `name 1, name 2, { name with ,,,, commas }` where the last one would end up containing leading/trailing spaces an commas.  This made comparisons more difficult, requiring a loop over the clist of groups.  To speed this up I opted to apply `\tl_to_str:n` right away, which makes sure that group names are strings without leading/trailing spaces nor commas.  Comparison is easier.

- The documentation used the word group or subgroup in a few places to talk about the sub-division of a module using the `module/subset/key` syntax.  This could be pretty confusing since `groups` is used as a transverse system to organize the keys.

- I came across uses of explicit `\cs_set_eq:cN { ... } \tex_undefined:D` so I introduced an auxiliary to hide that and avoid filling the hash table when unnecessary.  It is a local `\cs_undefine:c` (which by the way I optimized in a recent tiny commit to the main branch).