### PR TITLE
Implement N-type flag variables

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 - `\keys_set_exclude_groups:nnn(nN)` to replace `\keys_set_filter:nnn(nN)`
+- Flags with N-type names, like other variable types
 
 ### Changed
 - Set `l3doc` option `kernel` off as-standard (issue \#1403)

--- a/l3kernel/doc/source3body.tex
+++ b/l3kernel/doc/source3body.tex
@@ -321,7 +321,7 @@ following variable types:
   \item[\texttt{box}] Box register.
   \item[\texttt{coffin}] A \enquote{box with handles} --- a higher-level
     data type for carrying out \texttt{box} alignment operations.
-  \item[\texttt{flag}] Integer that can be incremented expandably.
+  \item[\texttt{flag}] Non-negative integer that can be incremented expandably.
   \item[\texttt{fparray}] Fixed-size array of floating point values.
   \item[\texttt{intarray}] Fixed-size array of integers.
   \item[\texttt{ior}/\texttt{iow}] An input or output stream, for

--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -99,13 +99,16 @@
 %   different.
 % \end{function}
 %
-% \begin{function}[EXP]{\__kernel_chk_flag_exist:n}
+% \begin{function}[EXP]{\__kernel_chk_flag_exist:NN}
 %   \begin{syntax}
-%     \cs{__kernel_chk_flag_exist:n} \Arg{flag}
+%     \cs{__kernel_chk_flag_exist:NN}
+%     \meta{function} \meta{flag}
 %   \end{syntax}
 %   This function is only created if debugging is enabled.  It checks
 %   that the \meta{flag} is defined according to the criterion for
-%   \cs{flag_if_exist_p:n}, and if not raises a kernel-level error.
+%   \cs{flag_if_exist_p:N}, and if not raises a kernel-level error and
+%   calls the function with the argument \cs{l_tmpa_flag} to proceed
+%   somehow without producing too many errors.
 % \end{function}
 %
 % \begin{function}{\__kernel_debug_log:e}
@@ -241,7 +244,7 @@
 %     \__kernel_chk_cs_exist:N,
 %     \__kernel_chk_cs_exist:c
 %   }
-% \begin{macro}[EXP]{\__kernel_chk_flag_exist:n}
+% \begin{macro}[EXP]{\__kernel_chk_flag_exist:NN}
 % \begin{macro}{\__kernel_chk_var_local:N, \__kernel_chk_var_global:N}
 % \begin{macro}{\__kernel_chk_var_scope:NN}
 %   When debugging is enabled these two functions set up functions that
@@ -258,7 +261,7 @@
 \cs_new_protected:Npn \__kernel_chk_var_exist:N #1 { }
 \cs_new_protected:Npn \__kernel_chk_cs_exist:N #1 { }
 \cs_generate_variant:Nn \__kernel_chk_cs_exist:N { c }
-\cs_new:Npn \__kernel_chk_flag_exist:n #1 { }
+\cs_new:Npn \__kernel_chk_flag_exist:NN { }
 \cs_new_protected:Npn \__kernel_chk_var_local:N #1 { }
 \cs_new_protected:Npn \__kernel_chk_var_global:N #1 { }
 \cs_new_protected:Npn \__kernel_chk_var_scope:NN #1#2 { }
@@ -282,13 +285,14 @@
               { \token_to_str:N ##1 }
           }
       }
-    \cs_set:Npn \__kernel_chk_flag_exist:n ##1
+    \cs_set:Npn \__kernel_chk_flag_exist:NN ##1##2
       {
-        \@@_suspended:T \use_none:nnn
-        \flag_if_exist:nF {##1}
+        \@@_suspended:T \use_iii:nnnn
+        \flag_if_exist:NTF ##2
+          { ##1 ##2 }
           {
-            \msg_expandable_error:nnn
-              { kernel } { bad-variable } { flag~##1~ }
+            \msg_expandable_error:nnn { kernel } { bad-variable } {##2}
+            ##1 \l_tmpa_flag
           }
       }
     \cs_set_protected:Npn \__kernel_chk_var_scope:NN
@@ -313,7 +317,7 @@
   {
     \cs_set_protected:Npn \__kernel_chk_var_exist:N ##1 { }
     \cs_set_protected:Npn \__kernel_chk_cs_exist:N ##1 { }
-    \cs_set:Npn \__kernel_chk_flag_exist:N ##1 { }
+    \cs_set:Npn \__kernel_chk_flag_exist:NN { }
     \cs_set_protected:Npn \__kernel_chk_var_local:N ##1 { }
     \cs_set_protected:Npn \__kernel_chk_var_global:N ##1 { }
     \cs_set_protected:Npn \__kernel_chk_var_scope:NN ##1##2 { }
@@ -957,16 +961,17 @@
 % Flag functions.
 %    \begin{macrocode}
   \__kernel_patch:nnn
-    { \__kernel_chk_flag_exist:n {#1} }
+    { \__kernel_chk_flag_exist:NN }
     { }
     {
-      \flag_if_raised:nT
-      \flag_if_raised:nF
-      \flag_if_raised:nTF
-      \flag_if_raised_p:n
-      \flag_height:n
-      \flag_ensure_raised:n
-      \flag_clear:n
+      \flag_clear:N
+      \flag_ensure_raised:N
+      \flag_height:N
+      \flag_if_raised:NT
+      \flag_if_raised:NF
+      \flag_if_raised:NTF
+      \flag_if_raised_p:N
+      \flag_raise:N
     }
 %    \end{macrocode}
 %
@@ -980,6 +985,10 @@
     { \__kernel_chk_var_scope:NN g #1 }
     { }
     { \cctab_new:N }
+  \__kernel_patch:nnn
+    { \__kernel_chk_var_scope:NN l #1 }
+    { }
+    { \flag_new:N }
   \__kernel_patch:nnn
     { \__kernel_chk_var_scope:NN g #1 }
     { }

--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -964,7 +964,6 @@
     { \__kernel_chk_flag_exist:NN }
     { }
     {
-      \flag_clear:N
       \flag_ensure_raised:N
       \flag_height:N
       \flag_if_raised:NT
@@ -989,6 +988,13 @@
     { \__kernel_chk_var_scope:NN l #1 }
     { }
     { \flag_new:N }
+  \__kernel_patch:nnn
+    {
+      \__kernel_chk_var_scope:NN l #1
+      \__kernel_chk_flag_exist:NN
+    }
+    { }
+    { \flag_clear:N }
   \__kernel_patch:nnn
     { \__kernel_chk_var_scope:NN g #1 }
     { }

--- a/l3kernel/l3flag.dtx
+++ b/l3kernel/l3flag.dtx
@@ -79,7 +79,11 @@
 % \meta{flag name} such as \texttt{fp_overflow}, used as part of
 % \cs{use:c} constructions.  All of the commands described below have
 % \texttt{n}-type analogues that can still appear in old code, but the
-% \texttt{N}-type commands are to be preferred moving forward.
+% \texttt{N}-type commands are to be preferred moving forward.  The
+% \texttt{n}-type \meta{flag name} is simply mapped to
+% \cs[no-index]{l_\meta{flag name}_flag}, which makes it easier for
+% packages using public flags (such as \pkg{l3fp}) to retain backwards
+% compatibility.
 %
 % \section{Setting up flags}
 %
@@ -338,144 +342,48 @@
 %
 % \subsection{Old \texttt{n}-type flag commands}
 %
-% Here we keep the old flag commands unchanged since our policy is to no
-% longer delete depecrated functions.
+% Here we keep the old flag commands since our policy is to no longer
+% delete deprecated functions.  The idea is to simply map \meta{flag
+% name} to \cs[no-index]{l_\meta{flag name}_flag}.  When the debugging
+% code is activated, it checks existence of the \texttt{N}-type flag
+% variables that result.
 %
-% The height $h$ of a flag (initially zero) is stored by setting control
-% sequences of the form \cs[no-index]{flag \meta{name} \meta{integer}}
-% to \tn{relax} for $0\leq\meta{integer}<h$.  When a flag is raised, a
-% \enquote{trap} function \cs[no-index]{flag \meta{name}} is called.
-% The existence of this function is also used to test for the existence
-% of a flag.
-%
-% \begin{macro}{\flag_new:n}
-%   For each flag, we define a \enquote{trap} function, which by default
-%   simply increases the flag by $1$ by letting the appropriate control
-%   sequence to \tn{relax}.  This can be done expandably!
+% \begin{macro}{\flag_new:n, \flag_clear:n, \flag_clear_new:n}
+% \begin{macro}[EXP, pTF]{\flag_if_exist:n, \flag_if_raised:n}
+% \begin{macro}[EXP]{\flag_height:n, \flag_raise:n, \flag_ensure_raised:n}
 %   \begin{macrocode}
-\cs_new_protected:Npn \flag_new:n #1
-  {
-    \cs_new:cpn { flag~#1 } ##1 ;
-      { \exp_after:wN \use_none:n \cs:w flag~#1~##1 \cs_end: }
-  }
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}{\flag_clear:n}
-% \begin{macro}{\@@_clear:wn}
-%   Undefine control sequences, starting from the |0| flag, upwards,
-%   until reaching an undefined control sequence.  We don't use
-%   \cs{cs_undefine:c} because that would act globally.
-%   When the option \texttt{check-declarations} is used, check for the
-%   function defined by \cs{flag_new:n}.
-%    \begin{macrocode}
-\cs_new_protected:Npn \flag_clear:n #1 { \@@_clear:wn 0 ; {#1} }
-\cs_new_protected:Npn \@@_clear:wn #1 ; #2
-  {
-    \if_cs_exist:w flag~#2~#1 \cs_end:
-      \exp_after:wN \use:n
-    \else:
-      \exp_after:wN \use_none:n
-    \fi:
-    {
-      \cs_set_eq:cN { flag~#2~#1 } \tex_undefined:D
-      \exp_after:wN \@@_clear:wn
-      \int_value:w \int_eval:w 1 + #1 ; {#2}
-    }
-  }
+\cs_new_protected:Npn \flag_new:n #1 { \flag_new:c { l_#1_flag } }
+\cs_new_protected:Npn \flag_clear:n #1 { \flag_clear:c { l_#1_flag } }
+\cs_new_protected:Npn \flag_clear_new:n #1 { \flag_clear_new:c { l_#1_flag } }
+\cs_new:Npn \flag_if_exist_p:n #1 { \flag_if_exist_p:c { l_#1_flag } }
+\cs_new:Npn \flag_if_exist:nT #1 { \flag_if_exist:cT { l_#1_flag } }
+\cs_new:Npn \flag_if_exist:nF #1 { \flag_if_exist:cF { l_#1_flag } }
+\cs_new:Npn \flag_if_exist:nTF #1 { \flag_if_exist:cTF { l_#1_flag } }
+\cs_new:Npn \flag_if_raised_p:n #1 { \flag_if_raised_p:c { l_#1_flag } }
+\cs_new:Npn \flag_if_raised:nT #1 { \flag_if_raised:cT { l_#1_flag } }
+\cs_new:Npn \flag_if_raised:nF #1 { \flag_if_raised:cF { l_#1_flag } }
+\cs_new:Npn \flag_if_raised:nTF #1 { \flag_if_raised:cTF { l_#1_flag } }
+\cs_new:Npn \flag_height:n #1 { \flag_height:c { l_#1_flag } }
+\cs_new:Npn \flag_raise:n #1 { \flag_raise:c { l_#1_flag } }
+\cs_new:Npn \flag_ensure_raised:n #1 { \flag_ensure_raised:c { l_#1_flag } }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
-%
-% \begin{macro}{\flag_clear_new:n}
-%   As for other datatypes, clear the \meta{flag} or create a new one,
-%   as appropriate.
-%    \begin{macrocode}
-\cs_new_protected:Npn \flag_clear_new:n #1
-  { \flag_if_exist:nTF {#1} { \flag_clear:n } { \flag_new:n } {#1} }
-%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{\flag_show:n, \flag_log:n, \@@_show:Nn}
-%   Show the height (terminal or log file) using appropriate \pkg{l3msg}
-%   auxiliaries.
+%   To avoid changing the output here we mostly keep the old code.
 %    \begin{macrocode}
 \cs_new_protected:Npn \flag_show:n { \@@_show:Nn \tl_show:n }
 \cs_new_protected:Npn \flag_log:n { \@@_show:Nn \tl_log:n }
 \cs_new_protected:Npn \@@_show:Nn #1#2
   {
-    \exp_args:Nc \__kernel_chk_defined:NT { flag~#2 }
+    \exp_args:Nc \__kernel_chk_defined:NT { l_#2_flag }
       {
         \exp_args:Ne #1
           { \tl_to_str:n { flag~#2~height } = \flag_height:n {#2} }
       }
   }
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}[EXP, pTF]{\flag_if_exist:n}
-%   A flag exist if the corresponding trap \cs[no-index]{flag \meta{flag
-%   name}:n} is defined.
-%    \begin{macrocode}
-\prg_new_conditional:Npnn \flag_if_exist:n #1 { p , T , F , TF }
-  {
-    \cs_if_exist:cTF { flag~#1 }
-      { \prg_return_true: } { \prg_return_false: }
-  }
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}[EXP, pTF]{\flag_if_raised:n}
-%   Test if the flag has a non-zero height, by checking the |0| control sequence.
-%    \begin{macrocode}
-\prg_new_conditional:Npnn \flag_if_raised:n #1 { p , T , F , TF }
-  {
-    \if_cs_exist:w flag~#1~0 \cs_end:
-      \prg_return_true:
-    \else:
-      \prg_return_false:
-    \fi:
-  }
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}[EXP]{\flag_height:n}
-% \begin{macro}[EXP]{\@@_height_loop:wn, \@@_height_end:wn}
-%   Extract the value of the flag by going through all of the
-%   control sequences starting from |0|.
-%    \begin{macrocode}
-\cs_new:Npn \flag_height:n #1 { \@@_height_loop:wn 0; {#1} }
-\cs_new:Npn \@@_height_loop:wn #1 ; #2
-  {
-    \if_cs_exist:w flag~#2~#1 \cs_end:
-      \exp_after:wN \@@_height_loop:wn \int_value:w \int_eval:w 1 +
-    \else:
-      \exp_after:wN \@@_height_end:wn
-    \fi:
-    #1 ; {#2}
-  }
-\cs_new:Npn \@@_height_end:wn #1 ; #2 {#1}
-%    \end{macrocode}
-% \end{macro}
-% \end{macro}
-%
-% \begin{macro}[EXP]{\flag_raise:n}
-%   Simply apply the trap to the height, after expanding the latter.
-%    \begin{macrocode}
-\cs_new:Npn \flag_raise:n #1
-  {
-    \cs:w flag~#1 \exp_after:wN \cs_end:
-    \int_value:w \flag_height:n {#1} ;
-  }
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}[EXP]{\flag_ensure_raised:n}
-%   It is simplest to just call the \enquote{trap} function in all
-%   cases.
-%    \begin{macrocode}
-\cs_new:Npn \flag_ensure_raised:n #1
-  { \cs:w flag~#1 \cs_end: 0 ; }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3flag.dtx
+++ b/l3kernel/l3flag.dtx
@@ -212,13 +212,15 @@
 \cs_new_protected:Npn \@@_clear:wn #1 ; #2
   {
     \if_cs_exist:w flag~#2~#1 \cs_end:
+      \exp_after:wN \use:n
+    \else:
+      \exp_after:wN \use_none:n
+    \fi:
+    {
       \cs_set_eq:cN { flag~#2~#1 } \tex_undefined:D
       \exp_after:wN \@@_clear:wn
-      \int_value:w \int_eval:w 1 + #1
-    \else:
-      \use_i:nnn
-    \fi:
-    ; {#2}
+      \int_value:w \int_eval:w 1 + #1 ; {#2}
+    }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -310,18 +312,11 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]{\flag_ensure_raised:n}
-%   It might be faster to just call the \enquote{trap} function in all
-%   cases but conceptually the function name suggests we should only run
-%   it if the flag is zero in case the \enquote{trap} made customizable
-%   in the future.
+%   It is simplest to just call the \enquote{trap} function in all
+%   cases.
 %    \begin{macrocode}
 \cs_new:Npn \flag_ensure_raised:n #1
-  {
-    \if_cs_exist:w flag~#1~0 \cs_end:
-    \else:
-      \cs:w flag~#1 \cs_end: 0 ;
-    \fi:
-  }
+  { \cs:w flag~#1 \cs_end: 0 ; }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3flag.dtx
+++ b/l3kernel/l3flag.dtx
@@ -54,16 +54,13 @@
 % cases, booleans or integers should be preferred to flags because they
 % are very significantly faster.
 %
-% A flag can hold any non-negative value, which we call its
+% A flag can hold any (small) non-negative value, which we call its
 % \meta{height}. In expansion-only contexts, a flag can only be
 % \enquote{raised}: this increases the \meta{height} by $1$. The \meta{height}
 % can also be queried expandably. However, decreasing it, or setting it
 % to zero requires non-expandable assignments.
 %
-% Flag variables are always local. They are referenced by a \meta{flag
-% name} such as \texttt{fp_overflow}.  The \meta{flag name} is used as
-% part of \cs{use:c} constructions hence is expanded at point of use.
-% It must expand to character tokens only, with no spaces.
+% Flag variables are always local.
 %
 % A typical use case of flags would be to keep track of whether an
 % exceptional condition has occurred during expandable processing, and
@@ -74,93 +71,106 @@
 % error message describing incorrect inputs that were encountered.
 %
 % Flags should not be used without carefully considering the fact that
-% raising a flag takes a time and memory proportional to its height.
-% Flags should not be used unless unavoidable.
+% raising a flag takes a time and memory proportional to its height and
+% that the memory cannot be reclaimed even if the flag is cleared.
+% Flags should not be used unless it is unavoidable.
+%
+% In earlier versions, flags were referenced by an \texttt{n}-type
+% \meta{flag name} such as \texttt{fp_overflow}, used as part of
+% \cs{use:c} constructions.  All of the commands described below have
+% \texttt{n}-type analogues that can still appear in old code, but the
+% \texttt{N}-type commands are to be preferred moving forward.
 %
 % \section{Setting up flags}
 %
-% \begin{function}{\flag_new:n}
+% \begin{function}[added = 2024-01-15]{\flag_new:N, \flag_new:c}
 %   \begin{syntax}
-%     \cs{flag_new:n} \Arg{flag name}
+%     \cs{flag_new:N} \meta{flag~var}
 %   \end{syntax}
-%   Creates a new flag with a name given by \meta{flag name}, or raises
-%   an error if the name is already taken. The \meta{flag name} may not
-%   contain spaces. The declaration is global, but flags are always
-%   local variables. The \meta{flag} initially has zero height.
+%   Creates a new \meta{flag~var}, or raises an error if the name is
+%   already taken. The declaration is global, but flags are always local
+%   variables. The \meta{flag~var} initially has zero height.
 % \end{function}
 %
-% \begin{function}{\flag_clear:n}
+% \begin{function}[added = 2024-01-15]{\flag_clear:N, \flag_clear:c}
 %   \begin{syntax}
-%     \cs{flag_clear:n} \Arg{flag name}
+%     \cs{flag_clear:N} \meta{flag~var}
 %   \end{syntax}
-%   The \meta{flag}'s height is set to zero. The assignment is local.
+%   Sets the height of the \meta{flag~var} to zero. The assignment is local.
 % \end{function}
 %
-% \begin{function}{\flag_clear_new:n}
+% \begin{function}[added = 2024-01-15]{\flag_clear_new:N, \flag_clear_new:c}
 %   \begin{syntax}
-%     \cs{flag_clear_new:n} \Arg{flag name}
+%     \cs{flag_clear_new:N} \meta{flag~var}
 %   \end{syntax}
-%   Ensures that the \meta{flag} exists globally by applying
-%   \cs{flag_new:n} if necessary, then applies \cs{flag_clear:n}, setting
+%   Ensures that the \meta{flag~var} exists globally by applying
+%   \cs{flag_new:N} if necessary, then applies \cs{flag_clear:N}, setting
 %   the height to zero locally.
 % \end{function}
 %
-% \begin{function}{\flag_show:n}
+% \begin{function}[added = 2024-01-15]{\flag_show:N, \flag_show:c}
 %   \begin{syntax}
-%     \cs{flag_show:n} \Arg{flag name}
+%     \cs{flag_show:N} \meta{flag~var}
 %   \end{syntax}
-%   Displays the \meta{flag}'s height in the terminal.
+%   Displays the height of the \meta{flag~var} in the terminal.
 % \end{function}
 %
-% \begin{function}{\flag_log:n}
+% \begin{function}[added = 2024-01-15]{\flag_log:N, \flag_log:c}
 %   \begin{syntax}
-%     \cs{flag_log:n} \Arg{flag name}
+%     \cs{flag_log:N} \meta{flag~var}
 %   \end{syntax}
-%   Writes the \meta{flag}'s height to the log file.
+%   Writes the height of the \meta{flag~var} in the log file.
 % \end{function}
 %
 % \section{Expandable flag commands}
 %
-% \begin{function}[EXP,pTF]{\flag_if_exist:n}
+% \begin{function}[EXP, pTF, added = 2024-01-15]{\flag_if_exist:N, \flag_if_exist:c}
 %   \begin{syntax}
-%     \cs{flag_if_exist_p:n} \Arg{flag name}
-%     \cs{flag_if_exist:nTF} \Arg{flag name} \Arg{true code} \Arg{false code}
+%     \cs{flag_if_exist_p:N} \meta{flag~var}
+%     \cs{flag_if_exist:NTF} \meta{flag~var} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   This function returns \texttt{true} if the \meta{flag name}
-%   references a flag that has been defined previously, and
-%   \texttt{false} otherwise.
+%   This function returns \texttt{true} if the \meta{flag~var} is
+%   currently defined, and \texttt{false} otherwise. This does not check
+%   that the \meta{flag~var} really is a flag variable.
 % \end{function}
 %
-% \begin{function}[EXP,pTF]{\flag_if_raised:n}
+% \begin{function}[EXP, pTF, added = 2024-01-15]{\flag_if_raised:N, \flag_if_raised:c}
 %   \begin{syntax}
-%     \cs{flag_if_raised_p:n} \Arg{flag name}
-%     \cs{flag_if_raised:nTF} \Arg{flag name} \Arg{true code} \Arg{false code}
+%     \cs{flag_if_raised_p:N} \meta{flag~var}
+%     \cs{flag_if_raised:NTF} \meta{flag~var} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   This function returns \texttt{true} if the \meta{flag} has non-zero
-%   height, and \texttt{false} if the \meta{flag} has zero height.
+%   This function returns \texttt{true} if the \meta{flag~var} has non-zero
+%   height, and \texttt{false} if the \meta{flag~var} has zero height.
 % \end{function}
 %
-% \begin{function}[EXP]{\flag_height:n}
+% \begin{function}[EXP, added = 2024-01-15]{\flag_height:N, \flag_height:c}
 %   \begin{syntax}
-%     \cs{flag_height:n} \Arg{flag name}
+%     \cs{flag_height:N} \meta{flag~var}
 %   \end{syntax}
-%   Expands to the height of the \meta{flag} as an integer denotation.
+%   Expands to the height of the \meta{flag~var} as an integer denotation.
 % \end{function}
 %
-% \begin{function}[EXP]{\flag_raise:n}
+% \begin{function}[EXP, added = 2024-01-15]{\flag_raise:N, \flag_raise:c}
 %   \begin{syntax}
-%     \cs{flag_raise:n} \Arg{flag name}
+%     \cs{flag_raise:N} \meta{flag~var}
 %   \end{syntax}
-%   The \meta{flag}'s height is increased by $1$ locally.
+%   The height of \meta{flag~var} is increased by $1$ locally.
 % \end{function}
 %
-% \begin{function}[EXP, added = 2023-04-25]{\flag_ensure_raised:n}
+% \begin{function}[EXP, added = 2024-01-15]{\flag_ensure_raised:N, \flag_ensure_raised:c}
 %   \begin{syntax}
-%     \cs{flag_ensure_raised:n} \Arg{flag name}
+%     \cs{flag_ensure_raised:N} \meta{flag~var}
 %   \end{syntax}
-%   Ensures the \meta{flag} is raised by making its height at least~$1$,
+%   Ensures the \meta{flag~var} is raised by making its height at least~$1$,
 %   locally.
 % \end{function}
+%
+% \begin{variable}[added = 2024-01-15]{\l_tmpa_flag, \l_tmpb_flag}
+%   Scratch flag for local assignment. These are never used by
+%   the kernel code, and so are safe for use with any \LaTeX3-defined
+%   function. However, they may be overwritten by other non-kernel
+%   code and so should only be used for short-term storage.
+% \end{variable}
 %
 % \end{documentation}
 %
@@ -178,7 +188,158 @@
 %
 % \TestFiles{m3flag001}
 %
-% \subsection{Non-expandable flag commands}
+% \subsection{Protected flag commands}
+%
+% The height $h$ of a flag (which is initially zero) is stored by
+% setting control sequences of the form \cs[no-index]{\meta{flag
+% name}\meta{integer}} to \tn{relax} for $0\leq\meta{integer}<h$.  These
+% control sequences are produced by \cs{cs:w} \meta{flag~var}
+% \meta{integer} \cs{cs_end:}, namely the \meta{flag~var} is actually a
+% (protected) macro expanding to its own csname.
+%
+% \begin{macro}{\flag_new:N, \flag_new:c}
+%   Evaluate the csname of~|#1| for use in constructing the various
+%   indexed macros.
+%   \begin{macrocode}
+\cs_new_protected:Npn \flag_new:N #1
+  { \cs_new_protected:Npe #1 { \cs_to_str:N #1 } }
+\cs_generate_variant:Nn \flag_new:N { c }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{variable}{\l_tmpa_flag, \l_tmpb_flag}
+%   Two flag variables for scratch use.
+%    \begin{macrocode}
+\flag_new:N \l_tmpa_flag
+\flag_new:N \l_tmpb_flag
+%    \end{macrocode}
+% \end{variable}
+%
+% \begin{macro}{\flag_clear:N, \flag_clear:c}
+% \begin{macro}{\@@_clear:wN}
+%   Undefine control sequences, starting from the |0| flag, upwards,
+%   until reaching an undefined control sequence.  We don't use
+%   \cs{cs_undefine:c} because that would act globally.
+%    \begin{macrocode}
+\cs_new_protected:Npn \flag_clear:N #1
+  {
+    \@@_clear:wN 0 ; #1
+    \prg_break_point:
+  }
+\cs_generate_variant:Nn \flag_clear:N { c }
+\cs_new_protected:Npn \@@_clear:wN #1 ; #2
+  {
+    \if_cs_exist:w #2 #1 \cs_end: \else:
+      \prg_break:n
+    \fi:
+    \cs_set_eq:cN { #2 #1 } \tex_undefined:D
+    \exp_after:wN \@@_clear:wN
+    \int_value:w \int_eval:w \c_one_int + #1 ; #2
+  }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\flag_clear_new:N, \flag_clear_new:c}
+%   As for other datatypes, clear the \meta{flag~var} or create a new one,
+%   as appropriate.
+%    \begin{macrocode}
+\cs_new_protected:Npn \flag_clear_new:N #1
+  { \flag_if_exist:NTF #1 { \flag_clear:N } { \flag_new:N } #1 }
+\cs_generate_variant:Nn \flag_clear_new:N { c }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\flag_show:N, \flag_show:c, \flag_log:N, \flag_log:c, \@@_show:NN}
+%   Show the height (terminal or log file) using appropriate \pkg{l3msg}
+%   auxiliaries.
+%    \begin{macrocode}
+\cs_new_protected:Npn \flag_show:N { \@@_show:NN \tl_show:n }
+\cs_generate_variant:Nn \flag_show:N { c }
+\cs_new_protected:Npn \flag_log:N { \@@_show:NN \tl_log:n }
+\cs_generate_variant:Nn \flag_log:N { c }
+\cs_new_protected:Npn \@@_show:NN #1#2
+  {
+    \__kernel_chk_defined:NT #2
+      { \exp_args:Ne #1 { \tl_to_str:n { #2 height } = \flag_height:N #2 } }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \subsection{Expandable flag commands}
+%
+% \begin{macro}[EXP, pTF]{\flag_if_exist:N, \flag_if_exist:c}
+%   Copies of the \texttt{cs} functions defined in \pkg{l3basics}.
+%    \begin{macrocode}
+\prg_new_eq_conditional:NNn \flag_if_exist:N \cs_if_exist:N
+  { TF , T , F , p }
+\prg_new_eq_conditional:NNn \flag_if_exist:c \cs_if_exist:c
+  { TF , T , F , p }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP, pTF]{\flag_if_raised:N, \flag_if_raised:c}
+%   Test if the flag has a non-zero height, by checking the |0| control sequence.
+%    \begin{macrocode}
+\prg_new_conditional:Npnn \flag_if_raised:N #1 { p , T , F , TF }
+  {
+    \if_cs_exist:w #1 0 \cs_end:
+      \prg_return_true:
+    \else:
+      \prg_return_false:
+    \fi:
+  }
+\prg_generate_conditional_variant:Nnn \flag_if_raised:N
+  { c } { p , T , F , TF }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\flag_height:N, \flag_height:c}
+% \begin{macro}[EXP]{\@@_height_loop:wN, \@@_height_end:wN}
+%   Extract the value of the flag by going through all of the
+%   control sequences starting from |0|.
+%    \begin{macrocode}
+\cs_new:Npn \flag_height:N #1 { \@@_height_loop:wN 0; #1 }
+\cs_new:Npn \@@_height_loop:wN #1 ; #2
+  {
+    \if_cs_exist:w #2 #1 \cs_end: \else:
+      \exp_after:wN \@@_height_end:wN
+    \fi:
+    \exp_after:wN \@@_height_loop:wN
+    \int_value:w \int_eval:w \c_one_int + #1 ; #2
+  }
+\cs_new:Npn \@@_height_end:wN #1 + #2 ; #3 {#2}
+\cs_generate_variant:Nn \flag_height:N { c }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\flag_raise:N, \flag_raise:c}
+%   Change the appropriate control sequence to \tn{relax} by expanding a
+%   \cs{cs:w} \ldots{} \cs{cs_end:} construction, then pass it to
+%   \cs{use_none:n} to avoid leaving anything in the input stream.
+%    \begin{macrocode}
+\cs_new:Npn \flag_raise:N #1
+  { \exp_after:wN \use_none:n \cs:w #1 \flag_height:N #1 \cs_end: }
+\cs_generate_variant:Nn \flag_raise:N { c }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP]{\flag_ensure_raised:N, \flag_ensure_raised:c}
+%   Pass the control sequence with name \meta{flag name}\texttt{0} to
+%   \cs{use_none:n}.  Constructing the control sequence ensures that it
+%   changes from being undefined (if it was so) to being \tn{relax}.
+%    \begin{macrocode}
+\cs_new:Npn \flag_ensure_raised:N #1
+  { \exp_after:wN \use_none:n \cs:w #1 0 \cs_end: }
+\cs_generate_variant:Nn \flag_ensure_raised:N { c }
+%    \end{macrocode}
+% \end{macro}
+%
+% \subsection{Old \texttt{n}-type flag commands}
+%
+% Here we keep the old flag commands unchanged since our policy is to no
+% longer delete depecrated functions.
 %
 % The height $h$ of a flag (initially zero) is stored by setting control
 % sequences of the form \cs[no-index]{flag \meta{name} \meta{integer}}
@@ -251,8 +412,6 @@
   }
 %    \end{macrocode}
 % \end{macro}
-%
-% \subsection{Expandable flag commands}
 %
 % \begin{macro}[EXP, pTF]{\flag_if_exist:n}
 %   A flag exist if the corresponding trap \cs[no-index]{flag \meta{flag

--- a/l3kernel/l3flag.dtx
+++ b/l3kernel/l3flag.dtx
@@ -87,7 +87,7 @@
 %
 % \section{Setting up flags}
 %
-% \begin{function}[added = 2024-01-15]{\flag_new:N, \flag_new:c}
+% \begin{function}[added = 2024-01-12]{\flag_new:N, \flag_new:c}
 %   \begin{syntax}
 %     \cs{flag_new:N} \meta{flag~var}
 %   \end{syntax}
@@ -96,14 +96,14 @@
 %   variables. The \meta{flag~var} initially has zero height.
 % \end{function}
 %
-% \begin{function}[added = 2024-01-15]{\flag_clear:N, \flag_clear:c}
+% \begin{function}[added = 2024-01-12]{\flag_clear:N, \flag_clear:c}
 %   \begin{syntax}
 %     \cs{flag_clear:N} \meta{flag~var}
 %   \end{syntax}
 %   Sets the height of the \meta{flag~var} to zero. The assignment is local.
 % \end{function}
 %
-% \begin{function}[added = 2024-01-15]{\flag_clear_new:N, \flag_clear_new:c}
+% \begin{function}[added = 2024-01-12]{\flag_clear_new:N, \flag_clear_new:c}
 %   \begin{syntax}
 %     \cs{flag_clear_new:N} \meta{flag~var}
 %   \end{syntax}
@@ -112,14 +112,14 @@
 %   the height to zero locally.
 % \end{function}
 %
-% \begin{function}[added = 2024-01-15]{\flag_show:N, \flag_show:c}
+% \begin{function}[added = 2024-01-12]{\flag_show:N, \flag_show:c}
 %   \begin{syntax}
 %     \cs{flag_show:N} \meta{flag~var}
 %   \end{syntax}
 %   Displays the height of the \meta{flag~var} in the terminal.
 % \end{function}
 %
-% \begin{function}[added = 2024-01-15]{\flag_log:N, \flag_log:c}
+% \begin{function}[added = 2024-01-12]{\flag_log:N, \flag_log:c}
 %   \begin{syntax}
 %     \cs{flag_log:N} \meta{flag~var}
 %   \end{syntax}
@@ -128,7 +128,7 @@
 %
 % \section{Expandable flag commands}
 %
-% \begin{function}[EXP, pTF, added = 2024-01-15]{\flag_if_exist:N, \flag_if_exist:c}
+% \begin{function}[EXP, pTF, added = 2024-01-12]{\flag_if_exist:N, \flag_if_exist:c}
 %   \begin{syntax}
 %     \cs{flag_if_exist_p:N} \meta{flag~var}
 %     \cs{flag_if_exist:NTF} \meta{flag~var} \Arg{true code} \Arg{false code}
@@ -138,7 +138,7 @@
 %   that the \meta{flag~var} really is a flag variable.
 % \end{function}
 %
-% \begin{function}[EXP, pTF, added = 2024-01-15]{\flag_if_raised:N, \flag_if_raised:c}
+% \begin{function}[EXP, pTF, added = 2024-01-12]{\flag_if_raised:N, \flag_if_raised:c}
 %   \begin{syntax}
 %     \cs{flag_if_raised_p:N} \meta{flag~var}
 %     \cs{flag_if_raised:NTF} \meta{flag~var} \Arg{true code} \Arg{false code}
@@ -147,21 +147,21 @@
 %   height, and \texttt{false} if the \meta{flag~var} has zero height.
 % \end{function}
 %
-% \begin{function}[EXP, added = 2024-01-15]{\flag_height:N, \flag_height:c}
+% \begin{function}[EXP, added = 2024-01-12]{\flag_height:N, \flag_height:c}
 %   \begin{syntax}
 %     \cs{flag_height:N} \meta{flag~var}
 %   \end{syntax}
 %   Expands to the height of the \meta{flag~var} as an integer denotation.
 % \end{function}
 %
-% \begin{function}[EXP, added = 2024-01-15]{\flag_raise:N, \flag_raise:c}
+% \begin{function}[EXP, added = 2024-01-12]{\flag_raise:N, \flag_raise:c}
 %   \begin{syntax}
 %     \cs{flag_raise:N} \meta{flag~var}
 %   \end{syntax}
 %   The height of \meta{flag~var} is increased by $1$ locally.
 % \end{function}
 %
-% \begin{function}[EXP, added = 2024-01-15]{\flag_ensure_raised:N, \flag_ensure_raised:c}
+% \begin{function}[EXP, added = 2024-01-12]{\flag_ensure_raised:N, \flag_ensure_raised:c}
 %   \begin{syntax}
 %     \cs{flag_ensure_raised:N} \meta{flag~var}
 %   \end{syntax}
@@ -169,7 +169,7 @@
 %   locally.
 % \end{function}
 %
-% \begin{variable}[added = 2024-01-15]{\l_tmpa_flag, \l_tmpb_flag}
+% \begin{variable}[added = 2024-01-12]{\l_tmpa_flag, \l_tmpb_flag}
 %   Scratch flag for local assignment. These are never used by
 %   the kernel code, and so are safe for use with any \LaTeX3-defined
 %   function. However, they may be overwritten by other non-kernel

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -599,7 +599,7 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{variable}{@@_symbolic}
+% \begin{variable}{\l_@@_symbolic_flag}
 % \begin{macro}{\fp_set_variable:nn, \@@_set_variable:nn}
 %   Refuse invalid identifiers.  If the variable does not exist yet,
 %   define it just as in \cs{fp_new_variable:n} (but without unnecessary
@@ -615,7 +615,7 @@
 %   raised, |#1|~was present in \cs{l_@@_symbolic_fp}.  In all cases,
 %   the |#1|-free result ends up in |\l__fp_variable_#1_fp|.
 %    \begin{macrocode}
-\flag_new:n { @@_symbolic }
+\flag_new:N \l_@@_symbolic_flag
 \cs_new_protected:Npn \fp_set_variable:nn #1
   {
     \exp_args:No \@@_set_variable:nn { \tl_to_str:n {#1} }
@@ -628,10 +628,10 @@
         \@@_variable_set_parsing:Nn \cs_set_eq:NN {#1}
         \fp_set:Nn \l_@@_symbolic_fp {#2}
         \cs_set_nopar:cpn { l_@@_variable_#1_fp }
-          { \flag_ensure_raised:n { @@_symbolic } \c_nan_fp }
-        \flag_clear:n { @@_symbolic }
+          { \flag_ensure_raised:N \l_@@_symbolic_flag \c_nan_fp }
+        \flag_clear:N \l_@@_symbolic_flag
         \fp_set:cn { l_@@_variable_#1_fp } { \l_@@_symbolic_fp }
-        \flag_if_raised:nT { @@_symbolic }
+        \flag_if_raised:NT \l_@@_symbolic_flag
           {
             \msg_error:nneee { fp } { id-loop }
               { #1 }

--- a/l3kernel/l3fp-traps.dtx
+++ b/l3kernel/l3fp-traps.dtx
@@ -74,17 +74,17 @@
 %
 % \begin{variable}[module = fp]
 %   {
-%     fp_invalid_operation,
-%     fp_division_by_zero,
-%     fp_overflow,
-%     fp_underflow
+%     \l_fp_invalid_operation_flag,
+%     \l_fp_division_by_zero_flag,
+%     \l_fp_overflow_flag,
+%     \l_fp_underflow_flag
 %   }
 %   Flags to denote exceptions.
 %    \begin{macrocode}
-\flag_new:n { fp_invalid_operation }
-\flag_new:n { fp_division_by_zero }
-\flag_new:n { fp_overflow }
-\flag_new:n { fp_underflow }
+\flag_new:N \l_fp_invalid_operation_flag
+\flag_new:N \l_fp_division_by_zero_flag
+\flag_new:N \l_fp_overflow_flag
+\flag_new:N \l_fp_underflow_flag
 %    \end{macrocode}
 % \end{variable}
 %
@@ -167,7 +167,7 @@
       {
         #1
         \@@_error:nnfn { invalid } {##2} { \fp_to_tl:n { ##3; } } { }
-        \flag_ensure_raised:n { fp_invalid_operation }
+        \flag_ensure_raised:N \l_fp_invalid_operation_flag
         ##1
       }
     \exp_args:Nno \use:n
@@ -176,7 +176,7 @@
         #1
         \@@_error:nffn { invalid-ii }
           { \fp_to_tl:n { ##2; } } { \fp_to_tl:n { ##3; } } {##1}
-        \flag_ensure_raised:n { fp_invalid_operation }
+        \flag_ensure_raised:N \l_fp_invalid_operation_flag
         \exp_after:wN \c_nan_fp
       }
     \exp_args:Nno \use:n
@@ -184,7 +184,7 @@
       {
         #1
         \@@_error:nffn { invalid } {##1} {##2} { }
-        \flag_ensure_raised:n { fp_invalid_operation }
+        \flag_ensure_raised:N \l_fp_invalid_operation_flag
         \exp_after:wN \c_nan_fp
       }
   }
@@ -217,7 +217,7 @@
       {
         #1
         \@@_error:nnfn { zero-div } {##2} { \fp_to_tl:n { ##3; } } { }
-        \flag_ensure_raised:n { fp_division_by_zero }
+        \flag_ensure_raised:N \l_fp_division_by_zero_flag
         \exp_after:wN ##1
       }
     \exp_args:Nno \use:n
@@ -226,7 +226,7 @@
         #1
         \@@_error:nffn { zero-div-ii }
           { \fp_to_tl:n { ##3; } } { \fp_to_tl:n { ##4; } } {##2}
-        \flag_ensure_raised:n { fp_division_by_zero }
+        \flag_ensure_raised:N \l_fp_division_by_zero_flag
         \exp_after:wN ##1
       }
   }
@@ -289,7 +289,7 @@
           { \fp_to_tl:n { \s_@@ \@@_chk:w ##1##2##3; } }
           { \token_if_eq_meaning:NNF 0 ##2 { - } #4 }
           {#2}
-        \flag_ensure_raised:n { fp_#2 }
+        \flag_ensure_raised:c { l_fp_#2_flag }
         #3 ##2
       }
   }

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -874,9 +874,9 @@
 %   a computation is not exact, in other words, almost always.  At the
 %   moment, this exception is entirely ignored in \LaTeX3.
 % \end{itemize}
-% To each exception we associate a \enquote{flag}: \texttt{fp_overflow},
-% \texttt{fp_underflow}, \texttt{fp_invalid_operation} and
-% \texttt{fp_division_by_zero}.  The state of these flags can be tested
+% To each exception we associate a \enquote{flag}: \cs{l_fp_overflow_flag},
+% \cs{l_fp_underflow_flag}, \cs{l_fp_invalid_operation_flag} and
+% \cs{l_fp_division_by_zero_flag}.  The state of these flags can be tested
 % and modified with commands from \pkg{l3flag}
 %
 % By default, the \enquote{invalid operation} exception triggers an
@@ -907,12 +907,12 @@
 %   \emph{This function is experimental, and may be altered or removed.}
 % \end{function}
 %
-% \begin{variable}[module = fp]
+% \begin{variable}
 %   {
-%     fp_overflow,
-%     fp_underflow,
-%     fp_invalid_operation,
-%     fp_division_by_zero
+%     \l_fp_overflow_flag,
+%     \l_fp_underflow_flag,
+%     \l_fp_invalid_operation_flag,
+%     \l_fp_division_by_zero_flag
 %   }
 %   Flags denoting the occurrence of various floating-point exceptions.
 % \end{variable}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1662,7 +1662,7 @@
 % \end{variable}
 %
 % \begin{variable}{\l_@@_selective_bool, \l_@@_filtered_bool}
-%   Two flags for using key groups: one to indicate that \enquote{selective}
+%   Two booleans for using key groups: one to indicate that \enquote{selective}
 %   setting is active, a second to specify which type (\enquote{opt-in}
 %   or \enquote{opt-out}).
 %    \begin{macrocode}
@@ -2831,7 +2831,7 @@
 %     \keys_set_known:no
 %   }
 %  \begin{macro}{\@@_set_known:nnn}
-%   Setting known keys simply means setting the appropriate flag, then
+%   Setting known keys simply means setting the appropriate boolean, then
 %   running the standard code. To allow for nested setting, any existing
 %   value of \cs{l_@@_unused_clist} is saved on the stack and reset
 %   afterwards. Note that for speed/simplicity reasons we use a \texttt{tl}
@@ -2909,7 +2909,7 @@
 %   }
 %  \begin{macro}{\@@_set_selective:nnn}
 %  \begin{macro}{\@@_set_selective:nnnn}
-%   The idea of setting keys in a selective manner again uses flags
+%   The idea of setting keys in a selective manner again uses booleans
 %   wrapped around the basic code. The comments on \cs{keys_set_known:nnN}
 %   also apply here. We have a bit more shuffling to do to keep everything
 %   nestable.

--- a/l3kernel/l3pdf.dtx
+++ b/l3kernel/l3pdf.dtx
@@ -275,7 +275,7 @@
 % \end{variable}
 %
 % \begin{variable}{\g_@@_init_bool}
-%   A flag so we have some chance of avoiding setting things we are not
+%   A boolean so we have some chance of avoiding setting things we are not
 %   allowed to. As we are potentially early in the format, we have to work
 %   a bit harder than ideal.
 %    \begin{macrocode}

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -3508,7 +3508,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{variable}{@@_cs}
+% \begin{variable}{\l_@@_cs_flag}
 % \begin{macro}+\@@_compile_}:+
 % \begin{macro}{\@@_compile_end_cs:}
 % \begin{macro}[EXP]{\@@_compile_cs_aux:Nn, \@@_compile_cs_aux:NNnnnN}
@@ -3522,7 +3522,7 @@
 %   \cs{@@_item_exact_cs:n} with an argument consisting of all
 %   possibilities separated by \cs{scan_stop:}.
 %    \begin{macrocode}
-\flag_new:n { @@_cs }
+\flag_new:N \l_@@_cs_flag
 \cs_new_protected:cpn { @@_compile_ \c_right_brace_str : }
   {
     \@@_if_in_cs:TF
@@ -3532,7 +3532,7 @@
 \cs_new_protected:Npn \@@_compile_end_cs:
   {
     \@@_compile_end:
-    \flag_clear:n { @@_cs }
+    \flag_clear:N \l_@@_cs_flag
     \__kernel_tl_set:Nx \l_@@_internal_a_tl
       {
         \exp_after:wN \@@_compile_cs_aux:Nn \l_@@_internal_regex
@@ -3540,7 +3540,7 @@
       }
     \exp_args:Ne \@@_compile_one:n
       {
-        \flag_if_raised:nTF { @@_cs }
+        \flag_if_raised:NTF \l_@@_cs_flag
           { \@@_item_cs:n { \exp_not:o \l_@@_internal_regex } }
           {
             \@@_item_exact_cs:n
@@ -3559,7 +3559,7 @@
         \@@_compile_cs_aux:Nn
       }
       {
-        \@@_quark_if_nil:NF #1 { \flag_ensure_raised:n { @@_cs } }
+        \@@_quark_if_nil:NF #1 { \flag_ensure_raised:N \l_@@_cs_flag }
         \@@_use_none_delimit_by_q_recursion_stop:w
       }
   }
@@ -3581,7 +3581,7 @@
       {
         \@@_quark_if_nil:NF #1
           {
-            \flag_ensure_raised:n { @@_cs }
+            \flag_ensure_raised:N \l_@@_cs_flag
             \@@_use_i_delimit_by_q_recursion_stop:nw
           }
         \@@_use_none_delimit_by_q_recursion_stop:w
@@ -6720,12 +6720,12 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{@@_begin, @@_end}
+% \begin{variable}{\l_@@_begin_flag, \l_@@_end_flag}
 %   Those flags are raised to indicate begin-group or end-group tokens
 %   that had to be added when extracting submatches.
 %    \begin{macrocode}
-\flag_new:n { @@_begin }
-\flag_new:n { @@_end }
+\flag_new:N \l_@@_begin_flag
+\flag_new:N \l_@@_end_flag
 %    \end{macrocode}
 % \end{variable}
 %
@@ -6990,8 +6990,8 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_group_end_extract_seq:N #1
   {
-      \flag_clear:n { @@_begin }
-      \flag_clear:n { @@_end }
+      \flag_clear:N \l_@@_begin_flag
+      \flag_clear:N \l_@@_end_flag
       \cs_set_eq:NN \@@_tmp:w \scan_stop:
       \__kernel_tl_gset:Nx \g_@@_internal_tl
         {
@@ -7000,9 +7000,9 @@
           \@@_tmp:w
         }
       \int_set:Nn \l_@@_added_begin_int
-        { \flag_height:n { @@_begin } }
+        { \flag_height:N \l_@@_begin_flag }
       \int_set:Nn \l_@@_added_end_int
-        { \flag_height:n { @@_end } }
+        { \flag_height:N \l_@@_end_flag }
       \tex_afterassignment:D \@@_extract_check:w
       \__kernel_tl_gset:Nx \g_@@_internal_tl
         { \g_@@_internal_tl \if_false: { \fi: } }
@@ -7055,7 +7055,7 @@
     \if_int_compare:w #1 < \c_zero_int
       \prg_replicate:nn {-#1}
         {
-          \flag_raise:n { @@_begin }
+          \flag_raise:N \l_@@_begin_flag
           \exp_not:n { { \if_false: } \fi: }
         }
     \fi:
@@ -7063,7 +7063,7 @@
     \if_int_compare:w #1 > \c_zero_int
       \prg_replicate:nn {#1}
         {
-          \flag_raise:n { @@_end }
+          \flag_raise:N \l_@@_end_flag
           \exp_not:n { \if_false: { \fi: } }
         }
     \fi:

--- a/l3kernel/l3str-convert.dtx
+++ b/l3kernel/l3str-convert.dtx
@@ -343,13 +343,13 @@
 %    \end{macrocode}
 % \end{variable}
 %
-% \begin{variable}{@@_byte, @@_error}
+% \begin{variable}{\l_@@_byte_flag, \l_@@_error_flag}
 %   Conversions from one \meta{encoding}/\meta{escaping} pair to another
 %   are done within \texttt{e}-expanding assignments. Errors are
 %   signalled by raising the relevant flag.
 %    \begin{macrocode}
-\flag_new:n { @@_byte }
-\flag_new:n { @@_error }
+\flag_new:N \l_@@_byte_flag
+\flag_new:N \l_@@_error_flag
 %    \end{macrocode}
 % \end{variable}
 %
@@ -599,8 +599,8 @@
 %
 % \subsubsection{Error-reporting during conversion}
 %
-% \begin{macro}{\@@_if_flag_error:nne}
-% \begin{macro}{\@@_if_flag_no_error:nne}
+% \begin{macro}{\@@_if_flag_error:Nne}
+% \begin{macro}{\@@_if_flag_no_error:Nne}
 %   When converting using the function \cs{str_set_convert:Nnnn}, errors
 %   should be reported to the user after each step in the
 %   conversion. Errors are signalled by raising some flag (typically
@@ -608,30 +608,30 @@
 %   give the user an error, otherwise remove the arguments. On the other
 %   hand, in the conditional functions \cs{str_set_convert:NnnnTF},
 %   errors should be suppressed. This is done by changing
-%   \cs{@@_if_flag_error:nne} into \cs{@@_if_flag_no_error:nne}
+%   \cs{@@_if_flag_error:Nne} into \cs{@@_if_flag_no_error:Nne}
 %   locally.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_if_flag_error:nne #1
+\cs_new_protected:Npn \@@_if_flag_error:Nne #1
   {
-    \flag_if_raised:nTF {#1}
+    \flag_if_raised:NTF #1
       { \msg_error:nne { str } }
       { \use_none:nn }
   }
-\cs_new_protected:Npn \@@_if_flag_no_error:nne #1#2#3
-  { \flag_if_raised:nT {#1} { \bool_gset_true:N \g_@@_error_bool } }
+\cs_new_protected:Npn \@@_if_flag_no_error:Nne #1#2#3
+  { \flag_if_raised:NT #1 { \bool_gset_true:N \g_@@_error_bool } }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}[rEXP]{\@@_if_flag_times:nT}
+% \begin{macro}[rEXP]{\@@_if_flag_times:NT}
 %   At the end of each conversion step, we raise all relevant errors as
 %   one error message, built on the fly. The height of each flag
 %   indicates how many times a given error was encountered. This
 %   function prints |#2| followed by the number of occurrences of an
 %   error if it occurred, nothing otherwise.
 %    \begin{macrocode}
-\cs_new:Npn \@@_if_flag_times:nT #1#2
-  { \flag_if_raised:nT {#1} { #2~(x \flag_height:n {#1} ) } }
+\cs_new:Npn \@@_if_flag_times:NT #1#2
+  { \flag_if_raised:NT #1 { #2~(x \flag_height:N #1 ) } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -675,7 +675,7 @@
 %   unescape and decode; encode and escape; exit the group and store the
 %   result in the user's variable. The various conversion functions all
 %   act on \cs{g_@@_result_tl}. Errors are silenced for the conditional
-%   functions by redefining \cs{@@_if_flag_error:nne} locally.
+%   functions by redefining \cs{@@_if_flag_error:Nne} locally.
 %    \begin{macrocode}
 \cs_new_protected:Npn \str_set_convert:Nnnn
   { \@@_convert:nNNnnn { } \tl_set_eq:NN }
@@ -686,7 +686,7 @@
   {
     \bool_gset_false:N \g_@@_error_bool
     \@@_convert:nNNnnn
-      { \cs_set_eq:NN \@@_if_flag_error:nne \@@_if_flag_no_error:nne }
+      { \cs_set_eq:NN \@@_if_flag_error:Nne \@@_if_flag_no_error:Nne }
       \tl_set_eq:NN #1 {#2} {#3} {#4}
     \bool_if:NTF \g_@@_error_bool \prg_return_false: \prg_return_true:
   }
@@ -695,7 +695,7 @@
   {
     \bool_gset_false:N \g_@@_error_bool
     \@@_convert:nNNnnn
-      { \cs_set_eq:NN \@@_if_flag_error:nne \@@_if_flag_no_error:nne }
+      { \cs_set_eq:NN \@@_if_flag_error:Nne \@@_if_flag_no_error:Nne }
       \tl_gset_eq:NN #1 {#2} {#3} {#4}
     \bool_if:NTF \g_@@_error_bool \prg_return_false: \prg_return_true:
   }
@@ -893,7 +893,7 @@
 % \begin{macro}[rEXP]{\@@_filter_bytes_aux:N}
 %   In the case of 8-bit engines, every character is a byte.  For
 %   Unicode-aware engines, test the character code; non-bytes cause us
-%   to raise the flag \texttt{@@_byte}.  Spaces have already been given
+%   to raise the flag \cs{l_@@_byte_flag}.  Spaces have already been given
 %   the correct category code when this function is called.
 %    \begin{macrocode}
 \bool_lazy_any:nTF
@@ -914,7 +914,7 @@
         \if_int_compare:w `#1 < 256 \exp_stop_f:
           #1
         \else:
-          \flag_raise:n { @@_byte }
+          \flag_raise:N \l_@@_byte_flag
         \fi:
         \@@_filter_bytes_aux:N
       }
@@ -937,10 +937,10 @@
   {
     \cs_new_protected:Npn \@@_convert_unescape_:
       {
-        \flag_clear:n { @@_byte }
+        \flag_clear:N \l_@@_byte_flag
         \__kernel_tl_gset:Nx \g_@@_result_tl
           { \exp_args:No \@@_filter_bytes:n \g_@@_result_tl }
-        \@@_if_flag_error:nne { @@_byte } { non-byte } { bytes }
+        \@@_if_flag_error:Nne \l_@@_byte_flag { non-byte } { bytes }
       }
   }
   { \cs_new_protected:Npn \@@_convert_unescape_: { } }
@@ -997,15 +997,15 @@
   {
     \cs_new_protected:Npn \@@_convert_encode_:
       {
-        \flag_clear:n { @@_error }
+        \flag_clear:N \l_@@_error_flag
         \@@_convert_gmap_internal:N \@@_encode_native_char:n
-        \@@_if_flag_error:nne { @@_error }
+        \@@_if_flag_error:Nne \l_@@_error_flag
           { native-overflow } { }
       }
     \cs_new:Npn \@@_encode_native_char:n #1
       {
         \if_int_compare:w #1 > \c_@@_max_byte_int
-          \flag_raise:n { @@_error }
+          \flag_raise:N \l_@@_error_flag
           ?
         \else:
           \char_generate:nn {#1} {12}
@@ -1186,9 +1186,9 @@
         \exp_not:N \@@_decode_eight_bit_aux:Nn
         \exp_not:c { g_@@_decode_#1_intarray }
       }
-    \flag_clear:n { @@_error }
+    \flag_clear:N \l_@@_error_flag
     \@@_convert_gmap:N \@@_tmp:w
-    \@@_if_flag_error:nne { @@_error } { decode-8-bit } {#1}
+    \@@_if_flag_error:Nne \l_@@_error_flag { decode-8-bit } {#1}
   }
 \cs_new:Npn \@@_decode_eight_bit_aux:Nn #1#2
   {
@@ -1200,7 +1200,7 @@
 \cs_new:Npn \@@_decode_eight_bit_aux:n #1
   {
     \if_int_compare:w #1 < \c_zero_int
-      \flag_raise:n { @@_error }
+      \flag_raise:N \l_@@_error_flag
       \int_value:w \c_@@_replacement_char_int
     \else:
       #1
@@ -1230,9 +1230,9 @@
         \exp_not:c { g_@@_encode_#1_intarray }
         \exp_not:c { g_@@_decode_#1_intarray }
       }
-    \flag_clear:n { @@_error }
+    \flag_clear:N \l_@@_error_flag
     \@@_convert_gmap_internal:N \@@_tmp:w
-    \@@_if_flag_error:nne { @@_error } { encode-8-bit } {#1}
+    \@@_if_flag_error:Nne \l_@@_error_flag { encode-8-bit } {#1}
   }
 \cs_new:Npn \@@_encode_eight_bit_aux:NNn #1#2#3
   {
@@ -1248,7 +1248,7 @@
   {
     \int_compare:nNnTF { \intarray_item:Nn #3 { 1 + #1 } } = {#2}
       { \@@_output_byte:n {#1} }
-      { \flag_raise:n { @@_error } }
+      { \flag_raise:N \l_@@_error_flag }
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1349,7 +1349,7 @@
 \cs_new_protected:Npn \@@_convert_unescape_hex:
   {
     \group_begin:
-      \flag_clear:n { @@_error }
+      \flag_clear:N \l_@@_error_flag
       \int_set:Nn \tex_escapechar:D { 92 }
       \__kernel_tl_gset:Nx \g_@@_result_tl
         {
@@ -1360,7 +1360,7 @@
             \prg_break_point:
           \@@_output_end:
         }
-      \@@_if_flag_error:nne { @@_error } { unescape-hex } { }
+      \@@_if_flag_error:Nne \l_@@_error_flag { unescape-hex } { }
     \group_end:
   }
 \cs_new:Npn \@@_unescape_hex_auxi:N #1
@@ -1369,7 +1369,7 @@
     \@@_hexadecimal_use:NTF #1
       { \@@_unescape_hex_auxii:N }
       {
-        \flag_raise:n { @@_error }
+        \flag_raise:N \l_@@_error_flag
         \@@_unescape_hex_auxi:N
       }
   }
@@ -1382,7 +1382,7 @@
         \@@_output_byte:w " \@@_unescape_hex_auxi:N
       }
       {
-        \flag_raise:n { @@_error }
+        \flag_raise:N \l_@@_error_flag
         \@@_unescape_hex_auxii:N
       }
   }
@@ -1427,8 +1427,8 @@
     \cs_new_protected:cpn { @@_convert_unescape_#2: }
       {
         \group_begin:
-          \flag_clear:n { @@_byte }
-          \flag_clear:n { @@_error }
+          \flag_clear:N \l_@@_byte_flag
+          \flag_clear:N \l_@@_error_flag
           \int_set:Nn \tex_escapechar:D { 92 }
           \__kernel_tl_gset:Nx \g_@@_result_tl
             {
@@ -1436,8 +1436,8 @@
                 #1 ? { ? \prg_break: }
               \prg_break_point:
             }
-          \@@_if_flag_error:nne { @@_byte } { non-byte } { #2 }
-          \@@_if_flag_error:nne { @@_error } { unescape-#2 } { }
+          \@@_if_flag_error:Nne \l_@@_byte_flag { non-byte } { #2 }
+          \@@_if_flag_error:Nne \l_@@_error_flag { unescape-#2 } { }
         \group_end:
       }
     \cs_new:Npn #3 ##1#1##2##3
@@ -1450,12 +1450,12 @@
               \@@_hexadecimal_use:NTF ##3
                 { }
                 {
-                  \flag_raise:n { @@_error }
+                  \flag_raise:N \l_@@_error_flag
                   * 0 + `#1 \use_i:nn
                 }
             }
             {
-              \flag_raise:n { @@_error }
+              \flag_raise:N \l_@@_error_flag
               0 + `#1 \use_i:nn
             }
         \@@_output_end:
@@ -1513,8 +1513,8 @@
       \cs_new_protected:Npn \@@_convert_unescape_string:
         {
           \group_begin:
-            \flag_clear:n { @@_byte }
-            \flag_clear:n { @@_error }
+            \flag_clear:N \l_@@_byte_flag
+            \flag_clear:N \l_@@_error_flag
             \int_set:Nn \tex_escapechar:D { 92 }
             \__kernel_tl_gset:Nx \g_@@_result_tl
               {
@@ -1528,8 +1528,8 @@
                   \g_@@_result_tl #1 ?? { ? \prg_break: }
                 \prg_break_point:
               }
-            \@@_if_flag_error:nne { @@_byte } { non-byte } { string }
-            \@@_if_flag_error:nne { @@_error } { unescape-string } { }
+            \@@_if_flag_error:Nne \l_@@_byte_flag { non-byte } { string }
+            \@@_if_flag_error:Nne \l_@@_error_flag { unescape-string } { }
           \group_end:
         }
     }
@@ -1569,7 +1569,7 @@
                     { ^^J } { 0 - 1 }
                   }
                   {
-                    \flag_raise:n { @@_error }
+                    \flag_raise:N \l_@@_error_flag
                     0 - 1 \use_i:nn
                   }
               }
@@ -1825,8 +1825,8 @@
 %   }
 %   When decoding a string that is purportedly in the \textsc{utf-8}
 %   encoding, four different errors can occur, signalled by a specific
-%   flag for each (we define those flags using \cs{flag_clear_new:n}
-%   rather than \cs{flag_new:n}, because they are shared with other
+%   flag for each (we define those flags using \cs{flag_clear_new:N}
+%   rather than \cs{flag_new:N}, because they are shared with other
 %   encoding definition files).
 %   \begin{itemize}
 %     \item \enquote{Missing continuation byte}: a leading byte is not
@@ -1846,19 +1846,19 @@
 %   first remind the user what a correct \textsc{utf-8} string should
 %   look like, then add error-specific information.
 %    \begin{macrocode}
-\flag_clear_new:n { @@_missing }
-\flag_clear_new:n { @@_extra }
-\flag_clear_new:n { @@_overlong }
-\flag_clear_new:n { @@_overflow }
+\flag_clear_new:N \l_@@_missing_flag
+\flag_clear_new:N \l_@@_extra_flag
+\flag_clear_new:N \l_@@_overlong_flag
+\flag_clear_new:N \l_@@_overflow_flag
 \msg_new:nnnn { str } { utf8-decode }
   {
     Invalid~UTF-8~string:
     \exp_last_unbraced:Nf \use_none:n
       {
-        \@@_if_flag_times:nT { @@_missing }  { ,~missing~continuation~byte }
-        \@@_if_flag_times:nT { @@_extra }    { ,~extra~continuation~byte }
-        \@@_if_flag_times:nT { @@_overlong } { ,~overlong~form }
-        \@@_if_flag_times:nT { @@_overflow } { ,~code~point~too~large }
+        \@@_if_flag_times:NT \l_@@_missing_flag  { ,~missing~continuation~byte }
+        \@@_if_flag_times:NT \l_@@_extra_flag    { ,~extra~continuation~byte }
+        \@@_if_flag_times:NT \l_@@_overlong_flag { ,~overlong~form }
+        \@@_if_flag_times:NT \l_@@_overflow_flag { ,~code~point~too~large }
       }
     .
   }
@@ -1873,25 +1873,25 @@
         Code~point~    <~1114112:~11110xxx~10xxxxxx~10xxxxxx~10xxxxxx \\
       }
     Bytes~of~the~form~10xxxxxx~are~called~continuation~bytes.
-    \flag_if_raised:nT { @@_missing }
+    \flag_if_raised:NT \l_@@_missing_flag
       {
         \\\\
         A~leading~byte~(in~the~range~[192,255])~was~not~followed~by~
         the~appropriate~number~of~continuation~bytes.
       }
-    \flag_if_raised:nT { @@_extra }
+    \flag_if_raised:NT \l_@@_extra_flag
       {
         \\\\
         LaTeX~came~across~a~continuation~byte~when~it~was~not~expected.
       }
-    \flag_if_raised:nT { @@_overlong }
+    \flag_if_raised:NT \l_@@_overlong_flag
       {
         \\\\
         Every~Unicode~code~point~must~be~expressed~in~the~shortest~
         possible~form.~For~instance,~'0xC0'~'0x83'~is~not~a~valid~
         representation~for~the~code~point~3.
       }
-    \flag_if_raised:nT { @@_overflow }
+    \flag_if_raised:NT \l_@@_overflow_flag
       {
         \\\\
         Unicode~limits~code~points~to~the~range~[0,1114111].
@@ -1970,18 +1970,18 @@
 %    \begin{macrocode}
 \cs_new_protected:cpn { @@_convert_decode_utf8: }
   {
-    \flag_clear:n { @@_error }
-    \flag_clear:n { @@_missing }
-    \flag_clear:n { @@_extra }
-    \flag_clear:n { @@_overlong }
-    \flag_clear:n { @@_overflow }
+    \flag_clear:N \l_@@_error_flag
+    \flag_clear:N \l_@@_missing_flag
+    \flag_clear:N \l_@@_extra_flag
+    \flag_clear:N \l_@@_overlong_flag
+    \flag_clear:N \l_@@_overflow_flag
     \__kernel_tl_gset:Nx \g_@@_result_tl
       {
         \exp_after:wN \@@_decode_utf_viii_start:N \g_@@_result_tl
           { \prg_break: \@@_decode_utf_viii_end: }
         \prg_break_point:
       }
-    \@@_if_flag_error:nne { @@_error } { utf8-decode } { }
+    \@@_if_flag_error:Nne \l_@@_error_flag { utf8-decode } { }
   }
 \cs_new:Npn \@@_decode_utf_viii_start:N #1
   {
@@ -1991,8 +1991,8 @@
       \if_int_compare:w `#1 < "80 \exp_stop_f:
         \int_value:w `#1
       \else:
-        \flag_raise:n { @@_extra }
-        \flag_raise:n { @@_error }
+        \flag_raise:N \l_@@_extra_flag
+        \flag_raise:N \l_@@_error_flag
         \int_use:N \c_@@_replacement_char_int
       \fi:
     \else:
@@ -2015,8 +2015,8 @@
       \int_value:w \int_eval:n { #1 * "40 + `#3 - "80 } \exp_after:wN
     \else:
       \s_@@
-      \flag_raise:n { @@_missing }
-      \flag_raise:n { @@_error }
+      \flag_raise:N \l_@@_missing_flag
+      \flag_raise:N \l_@@_error_flag
       \int_use:N \c_@@_replacement_char_int
     \fi:
     \s_@@
@@ -2029,8 +2029,8 @@
     \if_int_compare:w #1 < #4 \exp_stop_f:
       \s_@@
       \if_int_compare:w #1 < #3 \exp_stop_f:
-        \flag_raise:n { @@_overlong }
-        \flag_raise:n { @@_error }
+        \flag_raise:N \l_@@_overlong_flag
+        \flag_raise:N \l_@@_error_flag
         \int_use:N \c_@@_replacement_char_int
       \else:
         #1
@@ -2049,15 +2049,15 @@
 \cs_new:Npn \@@_decode_utf_viii_overflow:w #1 \fi: #2 \fi:
   {
     \fi: \fi:
-    \flag_raise:n { @@_overflow }
-    \flag_raise:n { @@_error }
+    \flag_raise:N \l_@@_overflow_flag
+    \flag_raise:N \l_@@_error_flag
     \int_use:N \c_@@_replacement_char_int
   }
 \cs_new:Npn \@@_decode_utf_viii_end:
   {
     \s_@@
-    \flag_raise:n { @@_missing }
-    \flag_raise:n { @@_error }
+    \flag_raise:N \l_@@_missing_flag
+    \flag_raise:N \l_@@_error_flag
     \int_use:N \c_@@_replacement_char_int \s_@@
     \prg_break:
   }
@@ -2119,10 +2119,10 @@
     { \@@_encode_utf_xvi_aux:N \@@_output_byte_pair_le:n }
   \cs_new_protected:Npn \@@_encode_utf_xvi_aux:N #1
     {
-      \flag_clear:n { @@_error }
+      \flag_clear:N \l_@@_error_flag
       \cs_set_eq:NN \@@_tmp:w #1
       \@@_convert_gmap_internal:N \@@_encode_utf_xvi_char:n
-      \@@_if_flag_error:nne { @@_error } { utf16-encode } { }
+      \@@_if_flag_error:Nne \l_@@_error_flag { utf16-encode } { }
     }
   \cs_new:Npn \@@_encode_utf_xvi_char:n #1
     {
@@ -2131,7 +2131,7 @@
       \else:
         \if_int_compare:w #1 < "10000 \exp_stop_f:
           \if_int_compare:w #1 < "E000 \exp_stop_f:
-            \flag_raise:n { @@_error }
+            \flag_raise:N \l_@@_error_flag
             \@@_tmp:w { \c_@@_replacement_char_int }
           \else:
             \@@_tmp:w {#1}
@@ -2162,9 +2162,9 @@
 %   an unexpected trail surrogate, and a string containing an odd number
 %   of bytes.
 %    \begin{macrocode}
-  \flag_clear_new:n { @@_missing }
-  \flag_clear_new:n { @@_extra }
-  \flag_clear_new:n { @@_end }
+  \flag_clear_new:N \l_@@_missing_flag
+  \flag_clear_new:N \l_@@_extra_flag
+  \flag_clear_new:N \l_@@_end_flag
   \msg_new:nnnn { str } { utf16-encode }
     { Unicode~string~cannot~be~expressed~in~UTF-16:~surrogate. }
     {
@@ -2177,9 +2177,9 @@
       Invalid~UTF-16~string:
       \exp_last_unbraced:Nf \use_none:n
         {
-          \@@_if_flag_times:nT { @@_missing }  { ,~missing~trail~surrogate }
-          \@@_if_flag_times:nT { @@_extra }    { ,~extra~trail~surrogate }
-          \@@_if_flag_times:nT { @@_end }      { ,~odd~number~of~bytes }
+          \@@_if_flag_times:NT \l_@@_missing_flag  { ,~missing~trail~surrogate }
+          \@@_if_flag_times:NT \l_@@_extra_flag    { ,~extra~trail~surrogate }
+          \@@_if_flag_times:NT \l_@@_end_flag      { ,~odd~number~of~bytes }
         }
       .
     }
@@ -2196,17 +2196,17 @@
         }
       Lead~surrogates~are~pairs~of~bytes~in~the~range~[0xD800,~0xDBFF],~
       and~trail~surrogates~are~in~the~range~[0xDC00,~0xDFFF].
-      \flag_if_raised:nT { @@_missing }
+      \flag_if_raised:NT \l_@@_missing_flag
         {
           \\\\
           A~lead~surrogate~was~not~followed~by~a~trail~surrogate.
         }
-      \flag_if_raised:nT { @@_extra }
+      \flag_if_raised:NT \l_@@_extra_flag
         {
           \\\\
           LaTeX~came~across~a~trail~surrogate~when~it~was~not~expected.
         }
-      \flag_if_raised:nT { @@_end }
+      \flag_if_raised:NT \l_@@_end_flag
         {
           \\\\
           The~string~contained~an~odd~number~of~bytes.~This~is~invalid:~
@@ -2260,10 +2260,10 @@
     }
   \cs_new_protected:Npn \@@_decode_utf_xvi:Nw #1#2 \s_@@_stop
     {
-      \flag_clear:n { @@_error }
-      \flag_clear:n { @@_missing }
-      \flag_clear:n { @@_extra }
-      \flag_clear:n { @@_end }
+      \flag_clear:N \l_@@_error_flag
+      \flag_clear:N \l_@@_missing_flag
+      \flag_clear:N \l_@@_extra_flag
+      \flag_clear:N \l_@@_end_flag
       \cs_set:Npn \@@_tmp:w ##1 ##2 { ` ## #1 }
       \__kernel_tl_gset:Nx \g_@@_result_tl
         {
@@ -2271,7 +2271,7 @@
             #2 \q_@@_nil \q_@@_nil
           \prg_break_point:
         }
-      \@@_if_flag_error:nne { @@_error } { utf16-decode } { }
+      \@@_if_flag_error:Nne \l_@@_error_flag { utf16-decode } { }
     }
 %    \end{macrocode}
 % \end{macro}
@@ -2377,8 +2377,8 @@
     { \@@_decode_utf_xvi_error:nNN { extra } #1#2 }
   \cs_new:Npn \@@_decode_utf_xvi_error:nNN #1#2#3
     {
-      \flag_raise:n { @@_error }
-      \flag_raise:n { str_#1 }
+      \flag_raise:N \l_@@_error_flag
+      \flag_raise:c { l_@@_#1_flag }
       #2 #3 \s_@@
       \int_use:N \c_@@_replacement_char_int \s_@@
     }
@@ -2463,29 +2463,29 @@
 %   happens if the encoding was in fact not \textsc{utf-32}, because
 %   most arbitrary strings are not valid in \textsc{utf-32}.
 %    \begin{macrocode}
-  \flag_clear_new:n { @@_overflow }
-  \flag_clear_new:n { @@_end }
+  \flag_clear_new:N \l_@@_overflow_flag
+  \flag_clear_new:N \l_@@_end_flag
   \msg_new:nnnn { str } { utf32-decode }
     {
       Invalid~UTF-32~string:
       \exp_last_unbraced:Nf \use_none:n
         {
-          \@@_if_flag_times:nT { @@_overflow } { ,~code~point~too~large }
-          \@@_if_flag_times:nT { @@_end }      { ,~truncated~string }
+          \@@_if_flag_times:NT \l_@@_overflow_flag { ,~code~point~too~large }
+          \@@_if_flag_times:NT \l_@@_end_flag      { ,~truncated~string }
         }
       .
     }
     {
       In~the~UTF-32~encoding,~every~Unicode~character~
       (in~the~range~[U+0000,~U+10FFFF])~is~encoded~as~4~bytes.
-      \flag_if_raised:nT { @@_overflow }
+      \flag_if_raised:NT \l_@@_overflow_flag
         {
           \\\\
           LaTeX~came~across~a~code~point~larger~than~1114111,~
           the~maximum~code~point~defined~by~Unicode.~
           Perhaps~the~string~was~not~encoded~in~the~UTF-32~encoding?
         }
-      \flag_if_raised:nT { @@_end }
+      \flag_if_raised:NT \l_@@_end_flag
         {
           \\\\
           The~length~of~the~string~is~not~a~multiple~of~4.~
@@ -2549,9 +2549,9 @@
     }
   \cs_new_protected:Npn \@@_decode_utf_xxxii:Nw #1#2 \s_@@_stop
     {
-      \flag_clear:n { @@_overflow }
-      \flag_clear:n { @@_end }
-      \flag_clear:n { @@_error }
+      \flag_clear:N \l_@@_overflow_flag
+      \flag_clear:N \l_@@_end_flag
+      \flag_clear:N \l_@@_error_flag
       \cs_set:Npn \@@_tmp:w ##1 ##2 { ` ## #1 }
       \__kernel_tl_gset:Nx \g_@@_result_tl
         {
@@ -2559,7 +2559,7 @@
             #2 \s_@@_stop \s_@@_stop \s_@@_stop \s_@@_stop
           \prg_break_point:
         }
-      \@@_if_flag_error:nne { @@_error } { utf32-decode } { }
+      \@@_if_flag_error:Nne \l_@@_error_flag { utf32-decode } { }
     }
   \cs_new:Npn \@@_decode_utf_xxxii_loop:NNNN #1#2#3#4
     {
@@ -2568,13 +2568,13 @@
       \fi:
       #1#2#3#4 \s_@@
       \if_int_compare:w \@@_tmp:w #1#4 > \c_zero_int
-        \flag_raise:n { @@_overflow }
-        \flag_raise:n { @@_error }
+        \flag_raise:N \l_@@_overflow_flag
+        \flag_raise:N \l_@@_error_flag
         \int_use:N \c_@@_replacement_char_int
       \else:
         \if_int_compare:w \@@_tmp:w #2#3 > 16 \exp_stop_f:
-          \flag_raise:n { @@_overflow }
-          \flag_raise:n { @@_error }
+          \flag_raise:N \l_@@_overflow_flag
+          \flag_raise:N \l_@@_error_flag
           \int_use:N \c_@@_replacement_char_int
         \else:
           \int_eval:n
@@ -2588,8 +2588,8 @@
     {
       \tl_if_empty:nF {#1}
         {
-          \flag_raise:n { @@_end }
-          \flag_raise:n { @@_error }
+          \flag_raise:N \l_@@_end_flag
+          \flag_raise:N \l_@@_error_flag
           #1 \s_@@
           \int_use:N \c_@@_replacement_char_int \s_@@
         }

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -1522,7 +1522,7 @@
 %   Before doing any actual conversion, first some special case filtering.
 %   Spaces are out here as \LuaTeX{} emulation only makes normal (charcode
 %   $32$ spaces). However, |^^@| is filtered out separately as that can't be
-%   done with macro emulation either, so is flagged up separately. That
+%   done with macro emulation either, so is treated separately. That
 %   done, hand off to the engine-dependent part.
 %    \begin{macrocode}
 \cs_new:Npn \@@_generate_aux:w #1 ; #2 ;

--- a/l3kernel/testfiles/m3flag001.lvt
+++ b/l3kernel/testfiles/m3flag001.lvt
@@ -25,10 +25,10 @@
     {
       \flag_if_exist:nT {A} { \ERROR }
       \flag_new:n {A}
-      \TYPE { \cs_meaning:c { flag~A } }
+      \TYPE { \cs_meaning:N \l_A_flag }
     }
     \flag_if_exist:nF {A} { \ERROR }
-    \TYPE { \cs_meaning:c { flag~A } }
+    \TYPE { \cs_meaning:N \l_A_flag }
     \flag_new:n {A}
     \flag_new:n {B}
   }
@@ -40,9 +40,9 @@
   {
     \flag_if_raised:nTF { C } { T } { F } ~
     \flag_height:n { C } ~
-    \cs_meaning:c { flag~C~0 } ~
-    \cs_meaning:c { flag~C~1 } ~
-    \cs_meaning:c { flag~C~2 } ~ \NEWLINE
+    \cs_meaning:c { l_C_flag 0 } ~
+    \cs_meaning:c { l_C_flag 1 } ~
+    \cs_meaning:c { l_C_flag 2 } ~ \NEWLINE
   }
 \TIMO
 

--- a/l3kernel/testfiles/m3flag001.tlg
+++ b/l3kernel/testfiles/m3flag001.tlg
@@ -4,20 +4,20 @@ Author: Bruno Le Floch
 ============================================================
 TEST 1: flag_new
 ============================================================
-Defining \flag A on line ...
-\long macro:#1;->\exp_after:wN \use_none:n \cs:w flag A #1\cs_end: 
-\long macro:#1;->\exp_after:wN \use_none:n \cs:w flag A #1\cs_end: 
-! LaTeX Error: Control sequence \flag A already defined.
+Defining \l_A_flag on line ...
+\protected\long macro:->l_A_flag
+\protected\long macro:->l_A_flag
+! LaTeX Error: Control sequence \l_A_flag already defined.
 For immediate help type H <return>.
  ...                                              
 l. ...  }
 This is a coding error.
-LaTeX has been asked to create a new control sequence '\flag A' but this name
-has already been used elsewhere.
+LaTeX has been asked to create a new control sequence '\l_A_flag' but this
+name has already been used elsewhere.
 The current meaning is:
-  \long macro:#1;->\exp_after:wN \use_none:n \cs:w flag A #1\cs_end: 
-Defining \flag A on line ...
-Defining \flag B on line ...
+  \protected\long macro:->l_A_flag
+Defining \l_A_flag on line ...
+Defining \l_B_flag on line ...
 ============================================================
 ============================================================
 TEST 2: raise, test, height
@@ -43,20 +43,30 @@ TEST 4: show, log
 <recently read> }
 l. ...  }
 > flag C height=3.
-! LaTeX Error: Variable \flag other undefined.
+! LaTeX Error: Variable \l_other_flag undefined.
 For immediate help type H <return>.
  ...                                              
 l. ...  }
 This is a coding error.
-LaTeX has been asked to show a variable \flag other, but this has not been
+LaTeX has been asked to show a variable \l_other_flag, but this has not been
 defined yet.
 ============================================================
 ============================================================
 TEST 5: undefined
 ============================================================
+! LaTeX Error: The variable \l_other_flag has not been declared on line ....
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+This is a coding error.
+Checking is active, and you have tried do so something like:
+  \tl_set:Nn \l_other_flag { ... }
+without first having:
+  \tl_new:N \l_other_flag
+LaTeX will create the variable and continue.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -64,7 +74,7 @@ made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -72,43 +82,7 @@ made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-|\flag other 0;|
-! Use of \??? doesn't match its definition.
-<argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-|\flag other 0;|
-! Use of \??? doesn't match its definition.
-<argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-|0|
-! Use of \??? doesn't match its definition.
-<argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
-l. ...  }
-If you say, e.g., `\def\a1{...}', then you must always
-put `1' after `\a', since control sequence names are
-made up of letters only. The macro here has not been
-followed by the required stuff, so I'm ignoring it.
-|F|
-! Use of \??? doesn't match its definition.
-<argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
@@ -117,20 +91,56 @@ followed by the required stuff, so I'm ignoring it.
 ||
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
 made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
-|F|
+||
 ! Use of \??? doesn't match its definition.
 <argument> \???  
-                 ! LaTeX Error: Erroneous variable flag other used!
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
 If you say, e.g., `\def\a1{...}', then you must always
 put `1' after `\a', since control sequence names are
 made up of letters only. The macro here has not been
 followed by the required stuff, so I'm ignoring it.
-|F|
+|1|
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
+l. ...  }
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
+|T|
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
+l. ...  }
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
+|T|
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
+l. ...  }
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
+||
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
+l. ...  }
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
+|T|
 ============================================================

--- a/l3kernel/testfiles/m3flag001.tlg
+++ b/l3kernel/testfiles/m3flag001.tlg
@@ -54,16 +54,6 @@ defined yet.
 ============================================================
 TEST 5: undefined
 ============================================================
-! LaTeX Error: The variable \l_other_flag has not been declared on line ....
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Checking is active, and you have tried do so something like:
-  \tl_set:Nn \l_other_flag { ... }
-without first having:
-  \tl_new:N \l_other_flag
-LaTeX will create the variable and continue.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
                  ! LaTeX Error: Erroneous variable \l_other_flag used!

--- a/l3kernel/testfiles/m3flag002.lvt
+++ b/l3kernel/testfiles/m3flag002.lvt
@@ -1,0 +1,102 @@
+%
+% Copyright (C) The LaTeX Project
+%
+
+\documentclass{minimal}
+\input{regression-test}
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation , log-functions }
+\ExplSyntaxOff
+
+\begin{document}
+
+\START
+\AUTHOR{Bruno Le Floch}
+\ExplSyntaxOn
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\OMIT
+\def\foo{foo}
+\TIMO
+
+\TEST { flag_new }
+  {
+    {
+      \flag_if_exist:NT \l_A_flag { \ERROR }
+      \flag_new:N \l_A_flag
+      \TYPE { \cs_meaning:N \l_A_flag }
+    }
+    \flag_if_exist:NF \l_A_flag { \ERROR }
+    \TYPE { \cs_meaning:N \l_A_flag }
+    \flag_new:N \l_A_flag
+    \flag_new:N \l_B_flag
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\OMIT
+\flag_new:N \l_C_flag
+\cs_new:Npn \test:
+  {
+    \flag_if_raised:NTF \l_C_flag { T } { F } ~
+    \flag_height:N \l_C_flag \c_space_tl
+    \cs_meaning:c { l_C_flag 0 } ~
+    \cs_meaning:c { l_C_flag 1 } ~
+    \cs_meaning:c { l_C_flag 2 } ~ \NEWLINE
+  }
+\TIMO
+
+\TEST { raise,~test,~height }
+  {
+    { \TYPE { \prg_replicate:nn {3} { \test: \flag_raise:N \l_C_flag } } }
+    \TYPE { \test: }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\TEST { zero }
+  {
+    \TYPE { \test: \flag_raise:N \l_C_flag \test: }
+    {
+      \prg_replicate:nn {10} { \flag_raise:N \l_C_flag }
+      \flag_clear:N \l_C_flag
+      \TYPE { \test: \prg_replicate:nn {10} { \flag_raise:N \l_C_flag } \test: }
+    }
+    \TYPE { \test: }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\TEST { show,~log }
+  {
+    \flag_raise:N \l_C_flag
+    \flag_ensure_raised:N \l_C_flag
+    \flag_show:N \l_C_flag
+    \flag_clear:N \l_C_flag
+    \flag_ensure_raised:N \l_C_flag
+    \flag_raise:N \l_C_flag
+    \flag_raise:N \l_C_flag
+    \flag_log:N \l_C_flag
+    \flag_log:N \l_other_flag
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\TEST { undefined }
+  {
+    \flag_clear:N \l_other_flag
+    \flag_raise:N \l_other_flag
+    \TYPE { | \flag_raise:N \l_other_flag | }
+    \TYPE { | \flag_ensure_raised:N \l_other_flag | }
+    \TYPE { | \flag_height:N \l_other_flag | }
+    \TYPE { | \flag_if_raised:NTF \l_other_flag {T} {F} | }
+    \TYPE { | \flag_if_raised:NT \l_other_flag {T} | }
+    \TYPE { | \flag_if_raised:NF \l_other_flag {F} | }
+    \TYPE { | \bool_if:nTF { \flag_if_raised_p:N \l_other_flag } {T} {F} | }
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+\TEST { tmpa, tmpb }
+  {
+    \flag_show:N \l_tmpa_flag
+    \flag_show:N \l_tmpb_flag
+  }
+
+\END

--- a/l3kernel/testfiles/m3flag002.tlg
+++ b/l3kernel/testfiles/m3flag002.tlg
@@ -54,116 +54,94 @@ defined yet.
 ============================================================
 TEST 5: undefined
 ============================================================
-! Undefined control sequence.
-<argument> \l_other_flag 
+! LaTeX Error: The variable \l_other_flag has not been declared on line ....
+For immediate help type H <return>.
+ ...                                              
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
-! Undefined control sequence.
-<argument> \l_other_flag 
+This is a coding error.
+Checking is active, and you have tried do so something like:
+  \tl_set:Nn \l_other_flag { ... }
+without first having:
+  \tl_new:N \l_other_flag
+LaTeX will create the variable and continue.
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
-! Undefined control sequence.
-<argument> \l_other_flag 
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
-! Undefined control sequence.
-<argument> \l_other_flag 
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
-! Undefined control sequence.
-<argument> \l_other_flag 
-l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
-! Undefined control sequence.
-<argument> \l_other_flag 
-l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
 ||
-! Undefined control sequence.
-<argument> \l_other_flag 
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
 ||
-! Undefined control sequence.
-<argument> \l_other_flag 
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
-! Undefined control sequence.
-<argument> \l_other_flag 
-l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
 |1|
-! Undefined control sequence.
-<argument> \l_other_flag 
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
 |T|
-! Undefined control sequence.
-<argument> \l_other_flag 
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
 |T|
-! Undefined control sequence.
-<argument> \l_other_flag 
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
 ||
-! Undefined control sequence.
-<argument> \l_other_flag 
+! Use of \??? doesn't match its definition.
+<argument> \???  
+                 ! LaTeX Error: Erroneous variable \l_other_flag used!
 l. ...  }
-The control sequence at the end of the top line
-of your error message was never \def'ed. If you have
-misspelled it (e.g., `\hobx'), type `I' and the correct
-spelling (e.g., `I\hbox'). Otherwise just continue,
-and I'll forget about whatever was undefined.
+If you say, e.g., `\def\a1{...}', then you must always
+put `1' after `\a', since control sequence names are
+made up of letters only. The macro here has not been
+followed by the required stuff, so I'm ignoring it.
 |T|
 ============================================================
 ============================================================

--- a/l3kernel/testfiles/m3flag002.tlg
+++ b/l3kernel/testfiles/m3flag002.tlg
@@ -1,0 +1,178 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Bruno Le Floch
+============================================================
+TEST 1: flag_new
+============================================================
+Defining \l_A_flag on line ...
+\protected\long macro:->l_A_flag
+\protected\long macro:->l_A_flag
+! LaTeX Error: Control sequence \l_A_flag already defined.
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+This is a coding error.
+LaTeX has been asked to create a new control sequence '\l_A_flag' but this
+name has already been used elsewhere.
+The current meaning is:
+  \protected\long macro:->l_A_flag
+Defining \l_A_flag on line ...
+Defining \l_B_flag on line ...
+============================================================
+============================================================
+TEST 2: raise, test, height
+============================================================
+F 0 undefined undefined undefined 
+T 1 \relax undefined undefined 
+T 2 \relax \relax undefined 
+F 0 undefined undefined undefined 
+============================================================
+============================================================
+TEST 3: zero
+============================================================
+F 0 undefined undefined undefined 
+T 1 \relax undefined undefined 
+F 0 undefined undefined undefined 
+T 10 \relax \relax \relax 
+F 0 undefined undefined undefined 
+============================================================
+============================================================
+TEST 4: show, log
+============================================================
+> \l_C_flag height=1.
+<recently read> }
+l. ...  }
+> \l_C_flag height=3.
+! LaTeX Error: Variable \l_other_flag undefined.
+For immediate help type H <return>.
+ ...                                              
+l. ...  }
+This is a coding error.
+LaTeX has been asked to show a variable \l_other_flag, but this has not been
+defined yet.
+============================================================
+============================================================
+TEST 5: undefined
+============================================================
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+||
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+||
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+|1|
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+|T|
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+|T|
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+||
+! Undefined control sequence.
+<argument> \l_other_flag 
+l. ...  }
+The control sequence at the end of the top line
+of your error message was never \def'ed. If you have
+misspelled it (e.g., `\hobx'), type `I' and the correct
+spelling (e.g., `I\hbox'). Otherwise just continue,
+and I'll forget about whatever was undefined.
+|T|
+============================================================
+============================================================
+TEST 6: tmpa,tmpb
+============================================================
+> \l_tmpa_flag height=0.
+<recently read> }
+l. ...  }
+> \l_tmpb_flag height=0.
+<recently read> }
+l. ...  }
+============================================================

--- a/l3kernel/testfiles/m3flag002.tlg
+++ b/l3kernel/testfiles/m3flag002.tlg
@@ -54,16 +54,6 @@ defined yet.
 ============================================================
 TEST 5: undefined
 ============================================================
-! LaTeX Error: The variable \l_other_flag has not been declared on line ....
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Checking is active, and you have tried do so something like:
-  \tl_set:Nn \l_other_flag { ... }
-without first having:
-  \tl_new:N \l_other_flag
-LaTeX will create the variable and continue.
 ! Use of \??? doesn't match its definition.
 <argument> \???  
                  ! LaTeX Error: Erroneous variable \l_other_flag used!

--- a/l3kernel/testfiles/m3fp-traps001.lvt
+++ b/l3kernel/testfiles/m3fp-traps001.lvt
@@ -19,18 +19,18 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \TEST { fp ~ flags }
   {
-    \flag_if_raised:nTF { fp_invalid_operation } { \ERROR } { \FALSE }
-    \exp_args:Ne \use_none:n { \flag_raise:n { fp_invalid_operation } }
-    \flag_if_raised:nTF { fp_invalid_operation } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_invalid_operation }
-    \flag_if_raised:nTF { fp_invalid_operation } { \ERROR } { \FALSE }
+    \flag_if_raised:NTF \l_fp_invalid_operation_flag { \ERROR } { \FALSE }
+    \exp_args:Ne \use_none:n { \flag_raise:N \l_fp_invalid_operation_flag }
+    \flag_if_raised:NTF \l_fp_invalid_operation_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_invalid_operation_flag
+    \flag_if_raised:NTF \l_fp_invalid_operation_flag { \ERROR } { \FALSE }
     {
       \iow_term:e { \fp_to_tl:n { 0 * inf } }
-      \flag_if_raised:nTF { fp_invalid_operation } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_invalid_operation_flag { \TRUE } { \ERROR }
     }
-    \flag_if_raised:nTF { fp_invalid_operation } { \ERROR } { \FALSE }
+    \flag_if_raised:NTF \l_fp_invalid_operation_flag { \ERROR } { \FALSE }
     \iow_term:e { \fp_to_decimal:n { nan } }
-    \flag_if_raised:nTF { fp_invalid_operation } { \TRUE } { \ERROR }
+    \flag_if_raised:NTF \l_fp_invalid_operation_flag { \TRUE } { \ERROR }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -43,125 +43,125 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \TEST { fp_trap:nn ~ invalid ~ operation }
   {
-    \flag_if_raised:nTF { fp_invalid_operation } { \ERROR } { \FALSE }
+    \flag_if_raised:NTF \l_fp_invalid_operation_flag { \ERROR } { \FALSE }
     \iow_term:e { \fp_to_tl:n { 0 * inf } }
-    \flag_if_raised:nTF { fp_invalid_operation } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_invalid_operation }
+    \flag_if_raised:NTF \l_fp_invalid_operation_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_invalid_operation_flag
     {
       \fp_trap:nn { invalid_operation } { error }
       \iow_term:e { \fp_to_tl:n { 0 * inf } }
-      \flag_if_raised:nTF { fp_invalid_operation } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_invalid_operation_flag { \TRUE } { \ERROR }
     }
     {
       \fp_trap:nn { invalid_operation } { flag }
       \iow_term:e { \fp_to_tl:n { 0 * inf } }
-      \flag_if_raised:nTF { fp_invalid_operation } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_invalid_operation_flag { \TRUE } { \ERROR }
     }
     {
       \fp_trap:nn { invalid_operation } { none }
       \iow_term:e { \fp_to_tl:n { 0 * inf } }
-      \flag_if_raised:nTF { fp_invalid_operation } { \ERROR } { \FALSE }
+      \flag_if_raised:NTF \l_fp_invalid_operation_flag { \ERROR } { \FALSE }
     }
     \iow_term:e { \fp_to_tl:n { 0 * inf } }
-    \flag_if_raised:nTF { fp_invalid_operation } { \TRUE } { \ERROR }
+    \flag_if_raised:NTF \l_fp_invalid_operation_flag { \TRUE } { \ERROR }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \TEST { fp_trap:nn ~ division ~ by ~ zero }
   {
-    \flag_if_raised:nTF { fp_division_by_zero } { \ERROR } { \FALSE }
+    \flag_if_raised:NTF \l_fp_division_by_zero_flag { \ERROR } { \FALSE }
     \iow_term:e { \fp_to_tl:n { 1 / 0 } }
-    \flag_if_raised:nTF { fp_division_by_zero } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_division_by_zero }
+    \flag_if_raised:NTF \l_fp_division_by_zero_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_division_by_zero_flag
     {
       \fp_trap:nn { division_by_zero } { error }
       \iow_term:e { \fp_to_tl:n { 1 / 0 } }
-      \flag_if_raised:nTF { fp_division_by_zero } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_division_by_zero_flag { \TRUE } { \ERROR }
     }
     {
       \fp_trap:nn { division_by_zero } { flag }
       \iow_term:e { \fp_to_tl:n { 1 / 0 } }
-      \flag_if_raised:nTF { fp_division_by_zero } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_division_by_zero_flag { \TRUE } { \ERROR }
     }
     {
       \fp_trap:nn { division_by_zero } { none }
       \iow_term:e { \fp_to_tl:n { 1 / 0 } }
-      \flag_if_raised:nTF { fp_division_by_zero } { \ERROR } { \FALSE }
+      \flag_if_raised:NTF \l_fp_division_by_zero_flag { \ERROR } { \FALSE }
     }
     \iow_term:e { \fp_to_tl:n { 1 / 0 } }
-    \flag_if_raised:nTF { fp_division_by_zero } { \TRUE } { \ERROR }
+    \flag_if_raised:NTF \l_fp_division_by_zero_flag { \TRUE } { \ERROR }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \TEST { fp_trap:nn ~ overflow }
   {
     \iow_term:e { \fp_to_tl:n { 1e9999 * 1e9999 } }
-    \flag_if_raised:nTF { fp_overflow } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_overflow }
+    \flag_if_raised:NTF \l_fp_overflow_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_overflow_flag
     {
       \fp_trap:nn { overflow } { none }
       \iow_term:e { \fp_to_tl:n { 1e9999 * 1e9999 } }
-      \flag_if_raised:nTF { fp_overflow } { \ERROR } { \FALSE }
+      \flag_if_raised:NTF \l_fp_overflow_flag { \ERROR } { \FALSE }
     }
     {
       \fp_trap:nn { overflow } { flag }
       \iow_term:e { \fp_to_tl:n { 1e9999 * 1e9999 } }
-      \flag_if_raised:nTF { fp_overflow } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_overflow_flag { \TRUE } { \ERROR }
     }
     {
       \fp_trap:nn { overflow } { error }
       \iow_term:e { \fp_to_tl:n { 1e9999 * 1e9999 } }
-      \flag_if_raised:nTF { fp_overflow } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_overflow_flag { \TRUE } { \ERROR }
     }
-    \flag_clear:n { fp_overflow }
+    \flag_clear:N \l_fp_overflow_flag
     \iow_term:e { \fp_to_tl:n { 1e9999 * 1e9999 } }
-    \flag_if_raised:nTF { fp_overflow } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_overflow }
+    \flag_if_raised:NTF \l_fp_overflow_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_overflow_flag
     \iow_term:e { \fp_to_tl:n { exp(1e5678) } }
-    \flag_if_raised:nTF { fp_overflow } { \TRUE } { \ERROR }
+    \flag_if_raised:NTF \l_fp_overflow_flag { \TRUE } { \ERROR }
     \fp_trap:nn { overflow } { error }
-    \flag_clear:n { fp_overflow }
+    \flag_clear:N \l_fp_overflow_flag
     \iow_term:e { \fp_to_tl:n { 1e9999 * 1e9999 } }
-    \flag_if_raised:nTF { fp_overflow } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_overflow }
+    \flag_if_raised:NTF \l_fp_overflow_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_overflow_flag
     \iow_term:e { \fp_to_tl:n { exp(1e5678) } }
-    \flag_if_raised:nTF { fp_overflow } { \TRUE } { \ERROR }
+    \flag_if_raised:NTF \l_fp_overflow_flag { \TRUE } { \ERROR }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 \TEST { fp_trap:nn ~ underflow }
   {
     \iow_term:e { \fp_to_tl:n { 1e-9999 * 1e-9999 } }
-    \flag_if_raised:nTF { fp_underflow } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_underflow }
+    \flag_if_raised:NTF \l_fp_underflow_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_underflow_flag
     {
       \fp_trap:nn { underflow } { none }
       \iow_term:e { \fp_to_tl:n { 1e-9999 * 1e-9999 } }
-      \flag_if_raised:nTF { fp_underflow } { \ERROR } { \FALSE }
+      \flag_if_raised:NTF \l_fp_underflow_flag { \ERROR } { \FALSE }
     }
     {
       \fp_trap:nn { underflow } { flag }
       \iow_term:e { \fp_to_tl:n { 1e-9999 * 1e-9999 } }
-      \flag_if_raised:nTF { fp_underflow } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_underflow_flag { \TRUE } { \ERROR }
     }
     {
       \fp_trap:nn { underflow } { error }
       \iow_term:e { \fp_to_tl:n { 1e-9999 * 1e-9999 } }
-      \flag_if_raised:nTF { fp_underflow } { \TRUE } { \ERROR }
+      \flag_if_raised:NTF \l_fp_underflow_flag { \TRUE } { \ERROR }
     }
-    \flag_clear:n { fp_underflow }
+    \flag_clear:N \l_fp_underflow_flag
     \iow_term:e { \fp_to_tl:n { 1e-9999 * 1e-9999 } }
-    \flag_if_raised:nTF { fp_underflow } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_underflow }
+    \flag_if_raised:NTF \l_fp_underflow_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_underflow_flag
     \iow_term:e { \fp_to_tl:n { exp(-1e5678) } }
-    \flag_if_raised:nTF { fp_underflow } { \TRUE } { \ERROR }
+    \flag_if_raised:NTF \l_fp_underflow_flag { \TRUE } { \ERROR }
     \fp_trap:nn { underflow } { error }
-    \flag_clear:n { fp_underflow }
+    \flag_clear:N \l_fp_underflow_flag
     \iow_term:e { \fp_to_tl:n { 1e-9999 * 1e-9999 } }
-    \flag_if_raised:nTF { fp_underflow } { \TRUE } { \ERROR }
-    \flag_clear:n { fp_underflow }
+    \flag_if_raised:NTF \l_fp_underflow_flag { \TRUE } { \ERROR }
+    \flag_clear:N \l_fp_underflow_flag
     \iow_term:e { \fp_to_tl:n { exp(-1e5678) } }
-    \flag_if_raised:nTF { fp_underflow } { \TRUE } { \ERROR }
+    \flag_if_raised:NTF \l_fp_underflow_flag { \TRUE } { \ERROR }
   }
 
 \END


### PR DESCRIPTION
Flags are the only variable type that can be modified in an expansion-only context (without using LuaTeX).  They are currently named by an `n`-type string like `fp_overflow` and the present changes allow more LaTeX3 names such as `\l_fp_overflow_flag`.  (In fact, the implementation is such that both the `n`-type flag `fp_overflow` and the `N`-type flag `\l_fp_overflow_flag` have the same value since they use the same underlying csnames.)

There should be a slight speed up from having fewer tokens to move around, but the main motivation is to make flags more similar to other variables.  The goal here is to eventually deprecate `n`-type flag variables.  It is not currently possible to deprecate them since flags are used quite a lot despite the numerous warnings in the documentation that they are almost always a bad idea.