### PR TITLE
fix typo in l3file.dtx

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -718,10 +718,8 @@
 %     \cs{file_if_exist_p:n} \Arg{file name}
 %     \cs{file_if_exist:nTF} \Arg{file name} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Expands the argument of the \meta{file name} to give a string, then
-%   searches for this string using the current \TeX{} search
-%   path and the additional paths controlled by
-%   \cs{l_file_search_path_seq}.
+%   Tests if \meta{file name} is found in the path as detailed for
+%   \cs{file_if_exist:nTF}.
 % \end{function}
 %
 % \subsection{Information about files and file contents}

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -718,7 +718,7 @@
 %     \cs{file_if_exist_p:n} \Arg{file name}
 %     \cs{file_if_exist:nTF} \Arg{file name} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Expands the argument of the \cs{file name} to give a string, then
+%   Expands the argument of the \meta{file name} to give a string, then
 %   searches for this string using the current \TeX{} search
 %   path and the additional paths controlled by
 %   \cs{l_file_search_path_seq}.


### PR DESCRIPTION
Changes `\cs{file name}` to `\meta{file name}` in l3file.dtx

#### Edit
Following muzimuzhi's suggestion, the description for `\file_if_exist:n(TF)` has been reworded to more closely match `\file_get_full_name:nN(TF)` and `\file_full_name:n`.