### PR TITLE
Fix inconsistent local/global assignments in l3coffins

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Inconsistent local/global assignments in `\vcoffin_gset:Nnn` and
+  `\vcoffin_gset:Nnw`
+
 ## [2024-01-22]
 
 ### Added

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -128,7 +128,7 @@
 %   environment in a coffin.
 % \end{function}
 %
-% \begin{function}[added = 2011-08-17, updated = 2019-01-21]
+% \begin{function}[added = 2011-08-17, updated = 2023-02-03]
 %   {
 %     \vcoffin_set:Nnn, \vcoffin_set:cnn,
 %     \vcoffin_gset:Nnn, \vcoffin_gset:cnn
@@ -142,7 +142,7 @@
 %   size of the typeset material.
 % \end{function}
 %
-% \begin{function}[added = 2011-09-10, updated = 2019-01-21]
+% \begin{function}[added = 2011-09-10, updated = 2023-02-03]
 %   {
 %     \vcoffin_set:Nnw, \vcoffin_set:cnw, \vcoffin_set_end:,
 %     \vcoffin_gset:Nnw, \vcoffin_gset:cnw, \vcoffin_gset_end:
@@ -702,7 +702,7 @@
 %     \vcoffin_set:Nnn, \vcoffin_set:cnn,
 %     \vcoffin_gset:Nnn, \vcoffin_gset:cnn
 %   }
-%  \begin{macro}{\@@_set_vertical:NnnNN}
+%  \begin{macro}{\@@_set_vertical:NnnNNN}
 %  \begin{macro}{\@@_set_vertical_aux:}
 %   Setting vertical coffins is more complex. First, the material is
 %   typeset with a given width. The default handles and poles are set as
@@ -714,17 +714,17 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \vcoffin_set:Nnn #1#2#3
   {
-    \@@_set_vertical:NnnNN #1 {#2} {#3}
-      \vbox_set:Nn \coffin_reset_poles:N
+    \@@_set_vertical:NnnNNN #1 {#2} {#3}
+      \vbox_set:Nn \coffin_reset_poles:N \@@_set_pole:Nne
   }
 \cs_generate_variant:Nn \vcoffin_set:Nnn { c }
 \cs_new_protected:Npn \vcoffin_gset:Nnn #1#2#3
   {
-    \@@_set_vertical:NnnNN #1 {#2} {#3}
-      \vbox_gset:Nn \coffin_greset_poles:N
+    \@@_set_vertical:NnnNNN #1 {#2} {#3}
+      \vbox_gset:Nn \coffin_greset_poles:N \@@_gset_pole:Nne
   }
 \cs_generate_variant:Nn \vcoffin_gset:Nnn { c }
-\cs_new_protected:Npn \@@_set_vertical:NnnNN #1#2#3#4#5
+\cs_new_protected:Npn \@@_set_vertical:NnnNNN #1#2#3#4#5#6
   {
     \@@_if_exist:NT #1
       {
@@ -736,7 +736,7 @@
           }
         #5 #1
         \vbox_set_top:Nn \l_@@_internal_box { \vbox_unpack:N #1 }
-        \@@_set_pole:Nne #1 { T }
+        #6 #1 { T }
           {
             { 0pt }
             {
@@ -804,25 +804,25 @@
 %
 % \begin{macro}
 %   {\vcoffin_set:Nnw, \vcoffin_set:cnw, \vcoffin_gset:Nnw, \vcoffin_gset:cnw}
-% \begin{macro}{\@@_set_vertical:NnNNNNw}
+% \begin{macro}{\@@_set_vertical:NnNNNNNw}
 % \begin{macro}{\vcoffin_set_end:, \vcoffin_gset_end:}
 %   The same for vertical coffins.
 %    \begin{macrocode}
 \cs_new_protected:Npn \vcoffin_set:Nnw #1#2
   {
-    \@@_set_vertical:NnNNNNw #1 {#2} \vbox_set:Nw
+    \@@_set_vertical:NnNNNNNw #1 {#2} \vbox_set:Nw
       \vcoffin_set_end:
-      \vbox_set_end: \coffin_reset_poles:N
+      \vbox_set_end: \coffin_reset_poles:N \@@_set_pole:Nne
   }
 \cs_generate_variant:Nn \vcoffin_set:Nnw { c }
 \cs_new_protected:Npn \vcoffin_gset:Nnw #1#2
   {
-    \@@_set_vertical:NnNNNNw #1 {#2} \vbox_gset:Nw
+    \@@_set_vertical:NnNNNNNw #1 {#2} \vbox_gset:Nw
       \vcoffin_gset_end:
-      \vbox_gset_end: \coffin_greset_poles:N
+      \vbox_gset_end: \coffin_greset_poles:N \@@_gset_pole:Nne
   }
 \cs_generate_variant:Nn \vcoffin_gset:Nnw { c }
-\cs_new_protected:Npn \@@_set_vertical:NnNNNNw #1#2#3#4#5#6
+\cs_new_protected:Npn \@@_set_vertical:NnNNNNNw #1#2#3#4#5#6#7
   {
     \@@_if_exist:NT #1
       {
@@ -834,7 +834,7 @@
               #5
               #6 #1
               \vbox_set_top:Nn \l_@@_internal_box { \vbox_unpack:N #1 }
-              \@@_set_pole:Nne #1 { T }
+              #7 #1 { T }
                 {
                   { 0pt }
                   {
@@ -989,7 +989,7 @@
 %     \coffin_gset_vertical_pole:Nnn, \coffin_gset_vertical_pole:cnn
 %   }
 % \begin{macro}{\@@_set_vertical_pole:NnnN}
-% \begin{macro}{\@@_set_pole:Nnn, \@@_set_pole:Nne}
+% \begin{macro}{\@@_set_pole:Nnn, \@@_set_pole:Nne, \@@_gset_pole:Nnn, \@@_gset_pole:Nne}
 %   Setting the pole of a coffin at the user/designer level requires a
 %   bit more care. The idea here is to provide a reasonable interface to
 %   the system, then to do the setting with full expansion. The
@@ -1037,6 +1037,12 @@
       {#2} {#3}
   }
 \cs_generate_variant:Nn \@@_set_pole:Nnn { Nne }
+\cs_new_protected:Npn \@@_gset_pole:Nnn #1#2#3
+  {
+    \prop_gput:cnn { coffin ~ \@@_to_value:N #1 ~ poles }
+      {#2} {#3}
+  }
+\cs_generate_variant:Nn \@@_gset_pole:Nnn { Nne }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -715,13 +715,13 @@
 \cs_new_protected:Npn \vcoffin_set:Nnn #1#2#3
   {
     \@@_set_vertical:NnnNNN #1 {#2} {#3}
-      \vbox_set:Nn \coffin_reset_poles:N \@@_set_pole:Nne
+      \vbox_set:Nn \coffin_reset_poles:N \@@_set_pole:Nnn
   }
 \cs_generate_variant:Nn \vcoffin_set:Nnn { c }
 \cs_new_protected:Npn \vcoffin_gset:Nnn #1#2#3
   {
     \@@_set_vertical:NnnNNN #1 {#2} {#3}
-      \vbox_gset:Nn \coffin_greset_poles:N \@@_gset_pole:Nne
+      \vbox_gset:Nn \coffin_greset_poles:N \@@_gset_pole:Nnn
   }
 \cs_generate_variant:Nn \vcoffin_gset:Nnn { c }
 \cs_new_protected:Npn \@@_set_vertical:NnnNNN #1#2#3#4#5#6
@@ -812,14 +812,14 @@
   {
     \@@_set_vertical:NnNNNNNw #1 {#2} \vbox_set:Nw
       \vcoffin_set_end:
-      \vbox_set_end: \coffin_reset_poles:N \@@_set_pole:Nne
+      \vbox_set_end: \coffin_reset_poles:N \@@_set_pole:Nnn
   }
 \cs_generate_variant:Nn \vcoffin_set:Nnw { c }
 \cs_new_protected:Npn \vcoffin_gset:Nnw #1#2
   {
     \@@_set_vertical:NnNNNNNw #1 {#2} \vbox_gset:Nw
       \vcoffin_gset_end:
-      \vbox_gset_end: \coffin_greset_poles:N \@@_gset_pole:Nne
+      \vbox_gset_end: \coffin_greset_poles:N \@@_gset_pole:Nnn
   }
 \cs_generate_variant:Nn \vcoffin_gset:Nnw { c }
 \cs_new_protected:Npn \@@_set_vertical:NnNNNNNw #1#2#3#4#5#6#7
@@ -989,7 +989,7 @@
 %     \coffin_gset_vertical_pole:Nnn, \coffin_gset_vertical_pole:cnn
 %   }
 % \begin{macro}{\@@_set_vertical_pole:NnnN}
-% \begin{macro}{\@@_set_pole:Nnn, \@@_set_pole:Nne, \@@_gset_pole:Nnn, \@@_gset_pole:Nne}
+% \begin{macro}{\@@_set_pole:Nnn, \@@_gset_pole:Nnn}
 %   Setting the pole of a coffin at the user/designer level requires a
 %   bit more care. The idea here is to provide a reasonable interface to
 %   the system, then to do the setting with full expansion. The
@@ -1033,16 +1033,14 @@
   }
 \cs_new_protected:Npn \@@_set_pole:Nnn #1#2#3
   {
-    \prop_put:cnn { coffin ~ \@@_to_value:N #1 ~ poles }
+    \prop_put:cne { coffin ~ \@@_to_value:N #1 ~ poles }
       {#2} {#3}
   }
-\cs_generate_variant:Nn \@@_set_pole:Nnn { Nne }
 \cs_new_protected:Npn \@@_gset_pole:Nnn #1#2#3
   {
-    \prop_gput:cnn { coffin ~ \@@_to_value:N #1 ~ poles }
+    \prop_gput:cne { coffin ~ \@@_to_value:N #1 ~ poles }
       {#2} {#3}
   }
-\cs_generate_variant:Nn \@@_gset_pole:Nnn { Nne }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -2074,7 +2072,7 @@
     \tl_if_in:nnTF {#2} { - }
       { \tl_set:Nn \l_@@_internal_tl { {#2} } }
       { \tl_set:Nn \l_@@_internal_tl { { #1 - #2 } } }
-    \exp_last_unbraced:NNo \@@_set_pole:Nne \l_@@_aligned_coffin
+    \exp_last_unbraced:NNo \@@_set_pole:Nnn \l_@@_aligned_coffin
       { \l_@@_internal_tl }
       {
         { \dim_use:N \l_@@_x_dim } { \dim_use:N \l_@@_y_dim }
@@ -2136,11 +2134,11 @@
   {
     \dim_compare:nNnTF {#2} < {#6}
       {
-        \@@_set_pole:Nne #9 { T }
+        \@@_set_pole:Nnn #9 { T }
           { { 0pt } {#6} { 1000pt } { 0pt } }
       }
       {
-        \@@_set_pole:Nne #9 { T }
+        \@@_set_pole:Nnn #9 { T }
           { { 0pt } {#2} { 1000pt } { 0pt } }
       }
   }
@@ -2148,11 +2146,11 @@
   {
     \dim_compare:nNnTF {#2} < {#6}
       {
-        \@@_set_pole:Nne #9 { B }
+        \@@_set_pole:Nnn #9 { B }
           { { 0pt } {#2}  { 1000pt } { 0pt } }
       }
       {
-        \@@_set_pole:Nne #9 { B }
+        \@@_set_pole:Nnn #9 { B }
           { { 0pt } {#6} { 1000pt } { 0pt } }
       }
   }

--- a/l3kernel/testfiles/m3coffins001.luatex.tlg
+++ b/l3kernel/testfiles/m3coffins001.luatex.tlg
@@ -2755,12 +2755,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -2800,7 +2794,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.94444pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.94444+0.0)x142.26378, direction TLT
 .\hbox(6.94444+0.0)x142.26378, glue set 99.76373fil, direction TLT
@@ -2821,12 +2815,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -2866,7 +2854,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378, direction TLT
 .\hbox(6.83331+1.94444)x142.26378, glue set 105.73596fil, direction TLT
@@ -2925,7 +2913,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378, direction TLT
@@ -2985,7 +2973,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}
 >  test-V  =>  {71.1319pt}{0pt}{0pt}{1000pt}.
 > \box...=

--- a/l3kernel/testfiles/m3coffins001.ptex.tlg
+++ b/l3kernel/testfiles/m3coffins001.ptex.tlg
@@ -3020,12 +3020,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -3066,7 +3060,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.94444pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.94444+0.0)x142.26378
 .\hbox(6.94444+0.0)x142.26378, glue set 99.76373fil
@@ -3082,12 +3076,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -3128,7 +3116,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378
 .\hbox(6.83331+1.94444)x142.26378, glue set 105.73596fil
@@ -3183,7 +3171,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378
@@ -3239,7 +3227,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}
 >  test-V  =>  {71.1319pt}{0pt}{0pt}{1000pt}.
 > \box...=

--- a/l3kernel/testfiles/m3coffins001.tlg
+++ b/l3kernel/testfiles/m3coffins001.tlg
@@ -2742,12 +2742,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -2787,7 +2781,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.94444pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.94444+0.0)x142.26378
 .\hbox(6.94444+0.0)x142.26378, glue set 99.76373fil
@@ -2803,12 +2797,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -2848,7 +2836,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378
 .\hbox(6.83331+1.94444)x142.26378, glue set 105.73596fil
@@ -2902,7 +2890,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378
@@ -2957,7 +2945,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}
 >  test-V  =>  {71.1319pt}{0pt}{0pt}{1000pt}.
 > \box...=

--- a/l3kernel/testfiles/m3coffins001.uptex.tlg
+++ b/l3kernel/testfiles/m3coffins001.uptex.tlg
@@ -3020,12 +3020,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -3066,7 +3060,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.94444pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.94444+0.0)x142.26378
 .\hbox(6.94444+0.0)x142.26378, glue set 99.76373fil
@@ -3082,12 +3076,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -3128,7 +3116,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378
 .\hbox(6.83331+1.94444)x142.26378, glue set 105.73596fil
@@ -3183,7 +3171,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378
@@ -3239,7 +3227,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}
 >  test-V  =>  {71.1319pt}{0pt}{0pt}{1000pt}.
 > \box...=

--- a/l3kernel/testfiles/m3coffins001.xetex.tlg
+++ b/l3kernel/testfiles/m3coffins001.xetex.tlg
@@ -2742,12 +2742,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -2787,7 +2781,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.94444pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.94444+0.0)x142.26378
 .\hbox(6.94444+0.0)x142.26378, glue set 99.76373fil
@@ -2803,12 +2797,6 @@ Poles of coffin \g_tmpa_coffin:
 ! OK.
 <argument> \g_tmpa_coffin 
 l. ...  }
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Local assignment to a global variable '\coffin 24 poles'.
 Size of coffin \l_tmpa_coffin:
 > ht = 6.94444pt
 > dp = 0.0pt
@@ -2848,7 +2836,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}.
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378
 .\hbox(6.83331+1.94444)x142.26378, glue set 105.73596fil
@@ -2902,7 +2890,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}.
 > \box...=
 \vbox(6.83331+1.94444)x142.26378
@@ -2957,7 +2945,7 @@ Poles of coffin \g_tmpa_coffin:
 >  t  =>  {0pt}{6.83331pt}{1000pt}{0pt}
 >  B  =>  {0pt}{0pt}{1000pt}{0pt}
 >  H  =>  {0pt}{0pt}{1000pt}{0pt}
->  T  =>  {0pt}{0pt}{1000pt}{0pt}
+>  T  =>  {0pt}{0.0pt}{1000pt}{0pt}
 >  test-H  =>  {0pt}{3.41666pt}{1000pt}{0pt}
 >  test-V  =>  {71.1319pt}{0pt}{0pt}{1000pt}.
 > \box...=


### PR DESCRIPTION
This PR fixes local assignments (`\prop_put:cnn`) to global variables in `\vcoffin_gset:Nnn` and `\vcoffin_gset:Nnw`.