### PR TITLE
\if:w documentation

### DIFF
--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1251,14 +1251,13 @@
 %
 % \begin{function}[EXP]{\if:w, \if_charcode:w, \if_catcode:w}
 %   \begin{syntax}
-%     "\if:w" <token(s)> <true code> "\else:" <false code> "\fi:" \\
-%     "\if_catcode:w" <token(s_> <true code> "\else:" <false code> "\fi:"
+%     "\if:w" <token_1> <token_2> <true code> "\else:" <false code> "\fi:" \\
+%     "\if_catcode:w" <token_1> <token_2> <true code> "\else:" <false code> "\fi:"
 %   \end{syntax}
-%   These conditionals expand \meta{token(s)} until two
+%   These conditionals expand their following tokens until two
 %   unexpandable tokens \meta{token_1} and \meta{tokens_2} are left;
-%   any further tokens become part of the \meta{true code}.
-%   If you wish to prevent this expansion,
-%   prefix the token in question with "\exp_not:N". "\if_catcode:w"
+%   any further tokens up to the next "\else" are the \meta{true code}.
+%   With "\exp_not:N", you can prevent the expansion of a token. "\if_catcode:w"
 %   tests if the category codes of the two tokens are the same whereas
 %   "\if:w" tests if the character codes are
 %   identical. "\if_charcode:w" is an alternative name for "\if:w".

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1251,18 +1251,23 @@
 %
 % \begin{function}[EXP]{\if:w, \if_charcode:w, \if_catcode:w}
 %   \begin{syntax}
-%     "\if:w" <token_1> <token_2> <true code> "\else:" <false code> "\fi:" \\
-%     "\if_catcode:w" <token_1> <token_2> <true code> "\else:" <false code> "\fi:"
+%     "\if:w" <token(s)> <true code> "\else:" <false code> "\fi:" \\
+%     "\if_catcode:w" <token(s)> <true code> "\else:" <false code> "\fi:"
 %   \end{syntax}
-%   These conditionals expand their following tokens until two
-%   unexpandable tokens \meta{token_1} and \meta{token_2} are left;
-%   any further tokens up to the next "\else" are the \meta{true code}.
-%   With "\exp_not:N", you can prevent the expansion of a token.
+%   "\if_charcode:w" is an alternative name for "\if:w".
+%   These conditionals expand \meta{token(s)} until two
+%   unexpandable tokens \meta{token_1} and \meta{token_2} are found;
+%   any further tokens up to the next unbalanced "\else:" are the true branch,
+%   ending with \meta{true code}. It is executed if the condition is fulfilled,
+%   otherwise \meta{false code} is executed.
+%   You can omit "\else:" when just in front of "\fi:" and
+%   you can nest "\if...\else:...\fi:" constructs inside the true branch or the
+%   \meta{false code}.
+%   With "\exp_not:N", you can prevent the expansion of a token. 
 %
 %   "\if_catcode:w"
-%   tests if the category codes of the two tokens are the same whereas
-%   "\if:w" tests if the character codes are
-%   identical. "\if_charcode:w" is an alternative name for "\if:w".
+%   tests if \meta{token_1} and \meta{token_2} have the same category code whereas
+%   "\if:w" and \cs{if_charcode:w} test if they have the same character code.
 %   \begin{texnote}
 %     \cs{if:w} and \cs{if_charcode:w} are both the \TeX{} primitive \tn{if}.
 %     \cs{if_catcode:w} is the \TeX{} primitive \tn{ifcat}.

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1255,9 +1255,11 @@
 %     "\if_catcode:w" <token_1> <token_2> <true code> "\else:" <false code> "\fi:"
 %   \end{syntax}
 %   These conditionals expand their following tokens until two
-%   unexpandable tokens \meta{token_1} and \meta{tokens_2} are left;
+%   unexpandable tokens \meta{token_1} and \meta{token_2} are left;
 %   any further tokens up to the next "\else" are the \meta{true code}.
-%   With "\exp_not:N", you can prevent the expansion of a token. "\if_catcode:w"
+%   With "\exp_not:N", you can prevent the expansion of a token.
+%
+%   "\if_catcode:w"
 %   tests if the category codes of the two tokens are the same whereas
 %   "\if:w" tests if the character codes are
 %   identical. "\if_charcode:w" is an alternative name for "\if:w".


### PR DESCRIPTION
Problems solved:
- `<token_1>` and `<token_2>` notations used only once
- `<true code>` not well defined
- typo
- legal construct not covered:
```
\def\x{xYES\else: NO\fi:}
\def\y{yNO\else: YES\fi:}
\if:w x\x
\if:w x\y
```