### PR TITLE
\ExplSyntax... documentation

### DIFF
--- a/l3kernel/l3bootstrap.dtx
+++ b/l3kernel/l3bootstrap.dtx
@@ -69,18 +69,26 @@
 %   \begin{syntax}
 %     \cs{ExplSyntaxOn} \meta{code} \cs{ExplSyntaxOff}
 %   \end{syntax}
-%   The \cs{ExplSyntaxOn} function switches to a category code
-%   regime in which spaces and new lines are ignored, and in which the colon (|:|)
+%   The \cs{ExplSyntaxOn} function modifies the current category code
+%   regime such that spaces and new lines are ignored, the colon (|:|)
 %   and underscore (|_|) are treated as \enquote{letters}, thus allowing
 %   access to the names of code functions and variables. Within this
-%   environment, |~| is used to input a space. The \cs{ExplSyntaxOff}
-%   reverts to the document category code regime.
+%   environment, the tilde (|~|) is used to input a space.
+%   The \cs{ExplSyntaxOff} function undoes the modifications made by
+%   \cs{ExplSyntaxOn} to the current category code regime
+%   and reverts |\endlinechar| to its previous value.
+%
+%   Nesting "\ExplSyntaxOn...\ExplSyntaxOff" constructs is not supported.
 %   \begin{texnote}
 %     Spaces introduced by~|~| behave much in the same way as normal
 %     space characters in the standard category code regime: they are
 %     ignored after a control word or at the start of a line, and
 %     multiple consecutive~|~| are equivalent to a single one.  However,
 %     |~|~is \emph{not} ignored at the end of a line.
+%
+%     For performance reasons, all the changes made to the current category code
+%     regime while running \meta{code} are not handled by \cs{ExplSyntaxOff}
+%     and must be undone explicitly.
 %   \end{texnote}
 % \end{function}
 %


### PR DESCRIPTION
Problems solved:
- Incorrect documentation of `\ExplSyntaxOff`
- cctab cannot be used to implement `\ExplSyntaxOn` as it is