### PR TITLE
Drop empty part "Removals"

### DIFF
--- a/l3kernel/doc/source3body.tex
+++ b/l3kernel/doc/source3body.tex
@@ -607,8 +607,7 @@ used on top of \LaTeXe{} if \tn{outer} tokens are used in the arguments.
 \DocInput{l3color.dtx}
 \DocInput{l3pdf.dtx}
 
-\part{Removals}
-
+% implementation part only
 \ExplSyntaxOn
 \clist_gput_right:Nn \g_docinput_clist { l3deprecation.dtx }
 \clist_gput_right:Nn \g_docinput_clist { l3debug.dtx }

--- a/l3kernel/doc/source3body.tex
+++ b/l3kernel/doc/source3body.tex
@@ -272,7 +272,11 @@ following argument specifiers:
     dependent and their name can change without warning, thus their
     use is \emph{strongly discouraged} in package code: programmers
     should instead use the interfaces documented in
-    \href{interface3.pdf}{interface3.pdf}.
+    \ifinterface
+      this documentation.
+    \else
+      \href{interface3.pdf}{interface3.pdf}.
+    \fi
 \end{description}
 Notice that the argument specifier describes how the argument is
 processed prior to being passed to the underlying function. For example,


### PR DESCRIPTION
The last part in `interface3.pdf` (also the second last part in `source3.pdf`) has been empty since the removal of empty `l3candidates.dtx`.

See 5d5f252e (Remove l3candidates, 2024-01-10).