### PR TITLE
Check missing `\endgroup` at the end of `\DocInclude`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -18,6 +18,7 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - `\keys_set_exclude_groups:nnn(nN)` to replace `\keys_set_filter:nnn(nN)`
 - Flags with N-type names, like other variable types
+- Checking missing `\endgroup` at the end of `\DocInclude`
 
 ### Changed
 - Set `l3doc` option `kernel` off as-standard (issue \#1403)

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -3727,10 +3727,22 @@ and all files in that bundle must be distributed together.
 %
 % \begin{macro}{\DocInclude}
 %   More or less exactly the same as \tn{include}, but uses
-%   \tn{DocInput} on a \file{.dtx} file, not \tn{input} on a \file{.tex}
-%   file.
+%   \tn{DocInput} on a \file{.fdd} or \file{.dtx} file (without file
+%   extension), not \tn{input} on a \file{.tex} file.
 %
 %    \begin{macrocode}
+\msg_new:nnn { l3doc } { missing-endgroup }
+  {
+    \str_if_eq:VnTF \@currenvir { document }
+      {
+        There~are~\int_use:N \tex_currentgrouplevel:D
+        \c_space_tl unclosed~groups~in~#1.
+      }
+      {
+        The~\@currenvir \c_space_tl environment~on~line~\@currenvline
+        \c_space_tl doesn't~have~a~matching~\iow_char:N\\end{\@currenvir}.
+      }
+  }
 \NewDocumentCommand \DocInclude { m }
   {
     \relax\clearpage
@@ -3741,6 +3753,13 @@ and all files in that bundle must be distributed together.
     \int_compare:nNnTF \@auxout = \@partaux
       { \@latexerr{\string\include\space cannot~be~nested}\@eha }
       { \@docinclude {#1} }
+    % check missing \endgroup, e.g., missing "\end{macro}" in time
+    \int_compare:nNnF { \tex_currentgrouplevel:D } = { 0 }
+      {
+        \int_compare:nNnT { \tex_interactionmode:D } = { 0 }
+          { \int_set:Nn \tex_interactionmode:D { 1 } }
+        \msg_fatal:nnn { l3doc } { missing-endgroup } { \currentfile }
+      }
   }
 %    \end{macrocode}
 %


### PR DESCRIPTION
This incorporates latex3/latex2e@60a6a368 (Prevent time wasted debugging latex3/latex2e@50f5256, 2021-10-20) by @PhelypeOleinik, with some modification.

Following https://github.com/latex3/latex2e/pull/1270#discussion_r1485597939, I find this is one of l3doc fixes/improvements made only in latex2e, hence not yet incorporated into `l3doc.dtx`.

Questions:
- Does `\DocInput` need a similar check? Currently `\DocInclude` uses `\DocInput` internally.
- Would `\DocInclude`/`\DocInput` be used in groups, so we need to compare the values of `\tex_currentgrouplevel:D` at the beginning and end of command, instead of simply checking if it's zero at the end?
- I noticed `\DocInclude` is not documented, and it seems it's inherited from `ltxdoc.cls`. Is `\DocInclude` an official `l3doc` command, or it's added for backwards compatibility?
- According to the eTeX manual, assignments to `\interactionmode` are always global. Then which int function is preferable in assigning `\tex_interactionmode:D`, `\int_set:Nn` or `\int_gset:Nn`? Currently local set is used in this PR and in several other places in this repo.