### PR TITLE
Typeset `\meta` in `\texttt`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,6 +10,9 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - Checking missing `\endgroup` at the end of `\DocInclude`
 
+### Changed
+- `\meta` now typesets in `\texttt`, along with `\Arg`
+
 ### Fixed
 - Inconsistent local/global assignments in `\vcoffin_gset:Nnn` and
   `\vcoffin_gset:Nnw`

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Checking missing `\endgroup` at the end of `\DocInclude`
+
 ### Fixed
 - Inconsistent local/global assignments in `\vcoffin_gset:Nnn` and
   `\vcoffin_gset:Nnw`
@@ -18,7 +21,6 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - `\keys_set_exclude_groups:nnn(nN)` to replace `\keys_set_filter:nnn(nN)`
 - Flags with N-type names, like other variable types
-- Checking missing `\endgroup` at the end of `\DocInclude`
 
 ### Changed
 - Set `l3doc` option `kernel` off as-standard (issue \#1403)

--- a/l3kernel/doc/interface3.tex
+++ b/l3kernel/doc/interface3.tex
@@ -42,12 +42,6 @@ for those people who are interested.
 
 \documentclass[kernel]{l3doc}
 
-% fix for l3doc class
-\ExplSyntaxOn
-\DeclareDocumentCommand \meta { m }
-  { \texttt{ \__codedoc_meta:n {#1} } }
-\ExplSyntaxOff
-
 \newif\ifinterface
 \interfacetrue
 

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1740,7 +1740,7 @@ and all files in that bundle must be distributed together.
 %   A document-level command.
 %    \begin{macrocode}
 \DeclareDocumentCommand \meta { m }
-  { \@@_meta:n {#1} }
+  { \texttt{ \@@_meta:n {#1} } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -1760,10 +1760,11 @@ and all files in that bundle must be distributed together.
   { < \tl_to_str:n {#1} > }
 \pdfstringdefDisableCommands
   {
-    \cs_set_eq:NN \cmd  \@@_pdfstring_cmd:w
-    \cs_set_eq:NN \cs   \@@_pdfstring_cs:w
-    \cs_set_eq:NN \tn   \@@_pdfstring_cs:w
-    \cs_set_eq:NN \meta \@@_pdfstring_meta:w
+    \cs_set_eq:NN \cmd       \@@_pdfstring_cmd:w
+    \cs_set_eq:NN \cs        \@@_pdfstring_cs:w
+    \cs_set_eq:NN \tn        \@@_pdfstring_cs:w
+    \cs_set_eq:NN \meta      \@@_pdfstring_meta:w
+    \cs_set_eq:NN \@@_meta:n \@@_pdfstring_meta:w
   }
 %    \end{macrocode}
 % \end{macro}
@@ -1775,10 +1776,10 @@ and all files in that bundle must be distributed together.
 %   Finally, \cs{Arg} is the same as \cs{marg}.
 %    \begin{macrocode}
 \newcommand\Arg[1]
-  { \texttt{\char`\{} \meta{#1} \texttt{\char`\}} }
+  { \texttt{\char`\{} \@@_meta:n {#1} \texttt{\char`\}} }
 \providecommand\marg[1]{ \Arg{#1} }
-\providecommand\oarg[1]{ \texttt[ \meta{#1} \texttt] }
-\providecommand\parg[1]{ \texttt( \meta{#1} \texttt) }
+\providecommand\oarg[1]{ \texttt[ \@@_meta:n {#1} \texttt] }
+\providecommand\parg[1]{ \texttt( \@@_meta:n {#1} \texttt) }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/testfiles-l3doc/test.lvt
+++ b/l3kernel/testfiles-l3doc/test.lvt
@@ -11,11 +11,20 @@
   This is a test.
 \end{function}
 And \cs{foo} again.
+
+\begin{function}{\baz:n}
+  \begin{syntax}
+    \cs{baz:n} \Arg{arg}
+  \end{syntax}
+  Argument \meta{arg}.
+\end{function}
+
 \begin{macro}{\foo}
     \begin{macrocode}
 test
 \foo \bar
 \bar
+\baz:n
 %    \end{macrocode}
 \cs{bar}
 \end{macro}

--- a/l3kernel/testfiles-l3doc/test.tlg
+++ b/l3kernel/testfiles-l3doc/test.tlg
@@ -12,6 +12,10 @@ LaTeX Font Info:    External font `lmex10' loaded for size
 (Font)              <5> on input line ....
 LaTeX Font Info:    Trying to load font information for U+msa on input line ....
 LaTeX Font Info:    Trying to load font information for U+msb on input line ....
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <10> on input line ....
+LaTeX Font Info:    External font `lmex10' loaded for size
+(Font)              <7> on input line ....
 LaTeX Font Info:    Trying to load font information for T1+lmss on input line ....
 Completed box being shipped out [1]
 \vbox(682.0+0.0)x458.0
@@ -47,7 +51,7 @@ Completed box being shipped out [1]
 .....\pdfcolorstack 0 pop
 ...\glue 25.0
 ...\glue(\lineskip) 0.0
-...\vbox(598.0+0.0)x385.0, glue set 346.20377fil
+...\vbox(598.0+0.0)x385.0, glue set 266.66296fil
 ....\write-{}
 ....\pdfdest name{Doc-Start} xyz
 ....\glue(\topskip) 10.0
@@ -163,11 +167,162 @@ Completed box being shipped out [1]
 .....\penalty 10000
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
-....\penalty -51
-....\glue 7.0 plus 5.0 minus 2.0
+....\glue 12.0 plus 4.0 minus 4.0
+....\glue 0.0
 ....\glue(\parskip) 0.0 plus 3.0
 ....\glue(\parskip) 0.0
-....\glue(\baselineskip) 1.65561
+....\glue(\baselineskip) 0.50627
+....\hbox(9.5493+21.04929)x385.0
+.....\hbox(9.5493+21.04929)x385.0
+......\hbox(0.0+0.0)x0.0
+......\kern 0.0
+......\kern -33.34995
+......\hbox(0.0+30.59859)x418.34995, shifted -9.5493
+.......\kern 33.34995
+.......\hbox(0.0+30.59859)x385.0
+........\hbox(0.0+14.59859)x385.0
+.........\kern 0.0
+.........\kern 0.0
+.........\hbox(9.5493+5.04929)x385.0, shifted 9.5493
+..........\pdfcolorstack 0 push {0 g 0 G}
+..........\hbox(9.5493+5.04929)x385.0
+...........\hbox(9.5493+5.04929)x385.0
+............\mathon
+............\vbox(9.5493+5.04929)x385.0
+.............\glue 0.0
+.............\pdfcolorstack 0 push {1 g 1 G}
+.............\rule(0.80002+0.0)x385.0
+.............\pdfcolorstack 0 pop
+.............\glue 2.79857
+.............\hbox(7.69997+3.30003)x385.0
+..............\glue(\tabskip) 0.0
+..............\hbox(7.69997+3.30003)x385.0
+...............\rule(7.69997+3.30003)x0.0
+...............\rule(6.75+*)x0.0
+...............\vbox(6.75+2.25)x385.0
+................\hbox(6.75+2.25)x385.0, glue set 160.03201fil
+.................\hbox(0.0+0.0)x0.0
+.................\hbox(0.0+0.0)x0.0
+..................\hbox(0.0+0.0)x0.0, shifted -7.79996
+...................\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
+....................\glue 0.0 plus 1.0fil minus 1.0fil
+....................\pdfdest name{HD.4} xyz
+....................\penalty 10000
+....................\kern 1.57533
+.................\T1/lmtt/m/n/9 \
+.................\T1/lmtt/m/n/9 b
+.................\T1/lmtt/m/n/9 a
+.................\T1/lmtt/m/n/9 z
+.................\T1/lmtt/m/n/9 :
+.................\T1/lmtt/m/n/9 n
+.................\write5{\indexentry{baz commands:=\pkg{baz} commands:>baz:n={\verbatim@font !\verb*&!\baz:n&}|hdpindex{usage}}{MMMMI-\thepage }}
+.................\glue 4.72499
+.................\T1/lmtt/m/n/9 {
+.................\kern 0.0
+.................\mathon
+.................\OMS/lmsy/m/n/9 h
+.................\mathoff
+.................\setlanguage1 (hyphenmin 2,3)
+.................\T1/lmtt/m/it/9 a
+.................\T1/lmtt/m/it/9 r
+.................\T1/lmtt/m/it/9 g
+.................\kern 1.04169
+.................\mathon
+.................\OMS/lmsy/m/n/9 i
+.................\mathoff
+.................\setlanguage0 (hyphenmin 2,3)
+.................\T1/lmtt/m/n/9 }
+.................\kern 0.0
+.................\penalty 10000
+.................\glue(\parfillskip) 0.0 plus 1.0fil
+.................\glue(\rightskip) 0.0 plus 1.0fil
+...............\glue 0.0 plus 1.0fill
+..............\glue(\tabskip) 0.0
+............\mathoff
+..........\pdfcolorstack 0 pop
+........\kern -385.0
+........\kern 0.0
+........\vbox(7.5+2.5)x385.0, shifted 28.09859
+.........\hbox(7.5+2.5)x385.0, glue set 310.28735fil
+..........\T1/lmr/m/n/10 A
+..........\T1/lmr/m/n/10 r
+..........\T1/lmr/m/n/10 g
+..........\T1/lmr/m/n/10 u
+..........\T1/lmr/m/n/10 m
+..........\T1/lmr/m/n/10 e
+..........\T1/lmr/m/n/10 n
+..........\kern-0.27779
+..........\T1/lmr/m/n/10 t
+..........\kern 0.0
+..........\glue 3.33333 plus 1.66666 minus 1.11111
+..........\mathon
+..........\OMS/lmsy/m/n/10 h
+..........\mathoff
+..........\setlanguage1 (hyphenmin 2,3)
+..........\T1/lmtt/m/it/10 a
+..........\T1/lmtt/m/it/10 r
+..........\T1/lmtt/m/it/10 g
+..........\kern 1.15742
+..........\mathon
+..........\OMS/lmsy/m/n/10 i
+..........\mathoff
+..........\setlanguage0 (hyphenmin 2,3)
+..........\T1/lmr/m/n/10 .
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0
+.......\kern -385.0
+.......\kern -33.34995
+.......\hbox(0.0+17.12079)x28.34995
+........\pdfcolorstack 0 push {0 g 0 G}
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0, shifted -7.79996
+..........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+...........\pdfdest name{HD.3} xyz
+...........\penalty 10000
+...........\kern 1.57533
+........\hbox(0.0+17.12079)x28.34995
+.........\mathon
+.........\vbox(0.0+17.12079)x28.34995
+..........\glue 0.0
+..........\rule(0.80002+0.0)x28.34995
+..........\glue 2.79857
+..........\hbox(7.69997+3.30003)x28.34995
+...........\glue(\tabskip) 0.0
+...........\hbox(7.69997+3.30003)x28.34995
+............\rule(7.69997+3.30003)x0.0
+............\rule(6.25+*)x0.0
+............\write5{\indexentry{baz commands:=\pkg{baz} commands:>baz:n={\verbatim@font !\verb*&!\baz:n&}|hdpindex{usage}}{MMMMI-\thepage }}
+............\write1{\newlabel{doc/function//baz:n}{{}{\thepage }{}{HD.3}{}}}
+............\T1/lmtt/m/n/9 \
+............\T1/lmtt/m/n/9 b
+............\T1/lmtt/m/n/9 a
+............\T1/lmtt/m/n/9 z
+............\T1/lmtt/m/n/9 :
+............\T1/lmtt/m/n/9 n
+............\glue 0.0 plus 1.0fill
+...........\glue(\tabskip) 0.0
+...........\hbox(7.69997+3.30003)x0.0
+............\rule(0.0+*)x0.0
+............\glue 0.0 plus 1.0fill
+............\kern 0.0
+...........\glue(\tabskip) 0.0
+..........\glue 1.72218
+..........\rule(0.80002+0.0)x28.34995
+..........\glue 0.0
+.........\mathoff
+........\pdfcolorstack 0 pop
+.......\kern 390.0
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty 0
+....\penalty -51
+....\glue 9.0 plus 6.0 minus 3.0
+....\glue(\parskip) 0.0 plus 3.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 1.10004
 ....\hbox(8.39996+3.60004)x385.0, glue set 385.0fil
 .....\hbox(8.39996+3.60004)x0.0
 ......\glue 0.0
@@ -184,7 +339,7 @@ Completed box being shipped out [1]
 ...........\hbox(0.0+0.0)x0.0, shifted -9.22217
 ............\hbox(0.0+0.0)x0.0, glue set - 1.66702fil
 .............\glue 0.0 plus 1.0fil minus 1.0fil
-.............\pdfdest name{HD.3} xyz
+.............\pdfdest name{HD.5} xyz
 .............\penalty 10000
 .............\kern 1.66702
 .........\glue -12.0
@@ -223,7 +378,7 @@ Completed box being shipped out [1]
 .......\hbox(0.0+0.0)x0.0, shifted -7.79996
 ........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\pdfdest name{HD.4} xyz
+.........\pdfdest name{HD.6} xyz
 .........\penalty 10000
 .........\kern 1.57533
 ......\pdfcolorstack 0 push {0.5 g 0.5 G}
@@ -251,7 +406,7 @@ Completed box being shipped out [1]
 .......\hbox(0.0+0.0)x0.0, shifted -7.79996
 ........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\pdfdest name{HD.5} xyz
+.........\pdfdest name{HD.7} xyz
 .........\penalty 10000
 .........\kern 1.57533
 ......\pdfcolorstack 0 push {0.5 g 0.5 G}
@@ -285,7 +440,7 @@ Completed box being shipped out [1]
 .......\hbox(0.0+0.0)x0.0, shifted -7.79996
 ........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\pdfdest name{HD.6} xyz
+.........\pdfdest name{HD.8} xyz
 .........\penalty 10000
 .........\kern 1.57533
 ......\pdfcolorstack 0 push {0.5 g 0.5 G}
@@ -301,6 +456,36 @@ Completed box being shipped out [1]
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
 ....\penalty 0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 4.00302
+....\hbox(6.25+0.74698)x385.0, glue set 349.9696fil
+.....\glue(\leftskip) 6.68045
+.....\hbox(0.0+0.0)x0.0
+.....\hbox(3.28125+0.0)x0.0, glue set - 7.38124fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(0.0+0.0)x0.0
+.......\hbox(0.0+0.0)x0.0, shifted -7.79996
+........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\pdfdest name{HD.9} xyz
+.........\penalty 10000
+.........\kern 1.57533
+......\pdfcolorstack 0 push {0.5 g 0.5 G}
+......\T1/lmss/m/n/5 4
+......\pdfcolorstack 0 pop
+......\glue 4.72499
+......\glue 0.0
+.....\T1/lmtt/m/n/9 \
+.....\T1/lmtt/m/n/9 b
+.....\T1/lmtt/m/n/9 a
+.....\T1/lmtt/m/n/9 z
+.....\T1/lmtt/m/n/9 :
+.....\T1/lmtt/m/n/9 n
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty 0
 ....\penalty -51
 ....\glue 3.0 plus 1.2 minus 1.0
 ....\glue(\parskip) 0.0 plus 3.0
@@ -311,7 +496,7 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.22217
 .......\hbox(0.0+0.0)x0.0, glue set - 1.66702fil
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\pdfdest name{HD.7} xyz
+........\pdfdest name{HD.10} xyz
 ........\penalty 10000
 ........\kern 1.66702
 .....\T1/lmtt/m/n/10 \
@@ -323,7 +508,7 @@ Completed box being shipped out [1]
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
 ....\penalty -51
-....\glue 7.0 plus 2.0 minus 2.0
+....\glue 9.0 plus 3.0 minus 3.0
 ....\penalty 10000
 ....\glue(\parskip) 0.0 plus 3.0
 ....\glue(\parskip) 0.0
@@ -636,8 +821,8 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\mark{{Index}{Index}}
 ....\penalty 10000
-....\hbox(21.0+3.30003)x385.0, glue set 5.0fil
-.....\vbox(21.0+3.30003)x187.5
+....\hbox(43.0+3.30003)x385.0, glue set 5.0fil
+.....\vbox(43.0+3.30003)x187.5
 ......\glue 0.0 plus -2.0
 ......\glue(\splittopskip) 3.704 plus 2.0
 ......\hbox(6.296+0.0)x187.5, glue set 89.96602fil
@@ -692,16 +877,92 @@ Completed box being shipped out [1]
 .......\pdfendlink
 .......\T1/lmr/m/n/9 ,
 .......\glue 3.08331 plus 1.92706 minus 0.8222
-.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.5}
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.7}
 .......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .......\T1/lmr/m/n/9 2
 .......\pdfcolorstack 0 pop
 .......\pdfendlink
 .......\T1/lmr/m/n/9 ,
 .......\glue 3.08331 plus 1.92706 minus 0.8222
-.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.6}
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.8}
 .......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .......\T1/lmr/m/n/9 3
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 1.44997
+......\hbox(6.25+0.0)x187.5, glue set 125.9007fill
+.......\hbox(0.0+0.0)x0.0
+.......\T1/lmss/m/n/9 b
+.......\T1/lmss/m/n/9 a
+.......\T1/lmss/m/n/9 z
+.......\kern 0.0
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\T1/lmr/m/n/9 c
+.......\T1/lmr/m/n/9 o
+.......\T1/lmr/m/n/9 m
+.......\discretionary
+........\T1/lmr/m/n/9 -
+.......\T1/lmr/m/n/9 m
+.......\T1/lmr/m/n/9 a
+.......\T1/lmr/m/n/9 n
+.......\T1/lmr/m/n/9 d
+.......\T1/lmr/m/n/9 s
+.......\T1/lmr/m/n/9 :
+.......\glue 0.0 plus 1.0fill
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\penalty 10000
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 3.30003
+......\hbox(7.69997+3.30003)x187.5, glue set 122.98328fill
+.......\hbox(0.0+0.0)x0.0
+.......\rule(*+*)x0.0
+.......\penalty 10000
+.......\glue 15.0
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 \
+.......\T1/lmtt/m/n/9 b
+.......\T1/lmtt/m/n/9 a
+.......\T1/lmtt/m/n/9 z
+.......\T1/lmtt/m/n/9 :
+.......\T1/lmtt/m/n/9 n
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\leaders 0.0 plus 1.0fill
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 500
+.......\rule(7.69997+3.30003)x0.0
+.......\penalty 10000
+.......\leaders 0.0 plus 1.0fil
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{page.1}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmr/m/it/9 1
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\T1/lmr/m/n/9 ,
+.......\glue 3.08331 plus 1.92706 minus 0.8222
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.9}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\T1/lmr/m/n/9 4
 .......\pdfcolorstack 0 pop
 .......\pdfendlink
 .......\penalty 10000
@@ -712,7 +973,7 @@ Completed box being shipped out [1]
 .....\rule(*+*)x0.0
 .....\pdfcolorstack 0 pop
 .....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\vbox(21.0+3.30003)x187.5
+.....\vbox(43.0+0.0)x187.5, glue set 18.69997fil
 ......\glue 0.0 plus -2.0
 ......\glue(\splittopskip) 3.704 plus 2.0
 ......\hbox(6.296+0.0)x187.5, glue set 90.40352fil
@@ -770,7 +1031,7 @@ Completed box being shipped out [1]
 .......\mathon
 .......\vbox(5.6945+1.9999)x4.625
 ........\hbox(5.6945+0.0)x4.625
-.........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.3}
+.........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.5}
 .........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .........\T1/lmr/m/n/9 1
 .........\pdfcolorstack 0 pop
@@ -781,6 +1042,7 @@ Completed box being shipped out [1]
 .......\penalty 10000
 .......\glue(\parfillskip) -15.0
 .......\glue(\rightskip) 15.0
+......\glue 0.0 plus 1.0fil
 .....\hbox(3.87498+1.75)x0.0, glue set - 5.139fil
 ......\hbox(3.87498+1.75)x5.139
 ......\glue 0.0 plus 1.0fil minus 1.0fil


### PR DESCRIPTION
To avoid setting `\texttt` twice, commands based on `\meta` (e.g., `\Arg`) now use internal `\__codedoc_meta:n`.

This incorporates a patch to `\meta` added to interface3.tex only, made in c1473aab (Standardise "fp expr", etc., in sources, 2021-07-28).