### PR TITLE
Expand a msg arg [ci skip]

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -3759,7 +3759,7 @@ and all files in that bundle must be distributed together.
       {
         \int_compare:nNnT { \tex_interactionmode:D } = { 0 }
           { \int_gset:Nn \tex_interactionmode:D { 1 } }
-        \msg_fatal:nnn { l3doc } { missing-endgroup } { \currentfile }
+        \msg_fatal:nne { l3doc } { missing-endgroup } { \currentfile }
       }
   }
 %    \end{macrocode}


### PR DESCRIPTION
This PR fixes a problem pointed out by @blefloch in https://github.com/latex3/latex3/pull/1448#discussion_r1485972439.

Relevant logic is not covered by any tests so skipping ci is not more dangerous.