### PR TITLE
Typo, `\cs{char_set_active_eq:NN}` -> `:nN`

### DIFF
--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -119,7 +119,7 @@
 %   Sets the behaviour of the \meta{char} which has character
 %   code as given by the \meta{integer expression} in situations
 %   where it is active (category code $13$) to be equivalent to that of the
-%   \meta{function} at the time \cs{char_set_active_eq:NN}
+%   \meta{function} at the time \cs{char_set_active_eq:nN}
 %   is used. The category code of the \meta{char} is
 %   \emph{unchanged} by this process. The \meta{function} may itself
 %   be an active character.


### PR DESCRIPTION
This PR corrects a typo introduced in fe2ec419 (Extend docs for \char_set_active_eq:NN (see #1437), 2024-02-09).