### PR TITLE
Move docs of l3debug kernel functions to l3kernel-functions

### DIFF
--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -55,71 +55,9 @@
 %
 % \section{\pkg{l3debug} implementation}
 %
-% \begin{function}{\__kernel_chk_var_local:N, \__kernel_chk_var_global:N}
-%   \begin{syntax}
-%     \cs{__kernel_chk_var_local:N} \meta{var}
-%     \cs{__kernel_chk_var_global:N} \meta{var}
-%   \end{syntax}
-%   Applies \cs{__kernel_chk_var_exist:N} \meta{var} as well as
-%   \cs{__kernel_chk_var_scope:NN} \meta{scope} \meta{var}, where
-%   \meta{scope} is |l| or~|g|.
-% \end{function}
-%
-% \begin{function}{\__kernel_chk_var_scope:NN}
-%   \begin{syntax}
-%     \cs{__kernel_chk_var_scope:NN} \meta{scope} \meta{var}
-%   \end{syntax}
-%   Checks the \meta{var} has the correct \meta{scope}, and if not
-%   raises a kernel-level error.  This function is only created if
-%   debugging is enabled.  The \meta{scope} is a single letter |l|, |g|,
-%   |c| denoting local variables, global variables, or constants.  More
-%   precisely, if the variable name starts with a letter and an
-%   underscore (normal \pkg{expl3} convention) the function checks that
-%   this single letter matches the \meta{scope}.  Otherwise the function
-%   cannot know the scope \meta{var} the first time: instead, it defines
-%   |\__debug_chk_/|\meta{var name} to store that information for the
-%   next call.  Thus, if a given \meta{var} is subject to assignments of
-%   different scopes a kernel error will result.
-% \end{function}
-%
-% \begin{function}
-%   {
-%     \__kernel_chk_cs_exist:N,
-%     \__kernel_chk_cs_exist:c,
-%     \__kernel_chk_var_exist:N
-%   }
-%   \begin{syntax}
-%     \cs{__kernel_chk_cs_exist:N} \meta{cs}
-%     \cs{__kernel_chk_var_exist:N} \meta{var}
-%   \end{syntax}
-%   These functions are only created if debugging is enabled.  They
-%   check that their argument is defined according to the criteria for
-%   \cs{cs_if_exist_p:N},
-%   and if not raises a kernel-level error.  Error messages are
-%   different.
-% \end{function}
-%
-% \begin{function}[EXP]{\__kernel_chk_flag_exist:NN}
-%   \begin{syntax}
-%     \cs{__kernel_chk_flag_exist:NN}
-%     \meta{function} \meta{flag}
-%   \end{syntax}
-%   This function is only created if debugging is enabled.  It checks
-%   that the \meta{flag} is defined according to the criterion for
-%   \cs{flag_if_exist_p:N}, and if not raises a kernel-level error and
-%   calls the function with the argument \cs{l_tmpa_flag} to proceed
-%   somehow without producing too many errors.
-% \end{function}
-%
-% \begin{function}{\__kernel_debug_log:e}
-%   \begin{syntax}
-%     \cs{__kernel_debug_log:e} \Arg{message text}
-%   \end{syntax}
-%   If the \texttt{log-functions} option is active, this function writes
-%   the \meta{message text} to the log file using \cs{iow_log:e}.
-%   Otherwise, the \meta{message text} is ignored using \cs{use_none:n}.
-%   This function is only created if debugging is enabled.
-% \end{function}
+% Internal kernel functions that are only defined here are listed in
+% \pkg{l3kernel-functions},
+% see~\ref{sec:l3kernel-functions:l3debug-internals}.
 %
 %    \begin{macrocode}
 %<*package>

--- a/l3kernel/l3kernel-functions.dtx
+++ b/l3kernel/l3kernel-functions.dtx
@@ -55,16 +55,76 @@
 %
 % \section{\pkg{l3kernel-functions}: kernel-reserved functions}
 %
-% \subsection{Internal kernel functions}
+% \subsection{Internal \pkg{l3debug} kernel functions}
+% \label{sec:l3kernel-functions:l3debug-internals}
 %
-% \begin{function}{\__kernel_chk_cs_exist:N, \__kernel_chk_cs_exist:c}
+% These function are only created if debugging is enabled, hence they are
+% actually defined in \pkg{l3debug}.
+%
+% \begin{function}{\__kernel_chk_var_local:N, \__kernel_chk_var_global:N}
+%   \begin{syntax}
+%     \cs{__kernel_chk_var_local:N} \meta{var}
+%     \cs{__kernel_chk_var_global:N} \meta{var}
+%   \end{syntax}
+%   Applies \cs{__kernel_chk_var_exist:N} \meta{var} as well as
+%   \cs{__kernel_chk_var_scope:NN} \meta{scope} \meta{var}, where
+%   \meta{scope} is |l| or~|g|.
+% \end{function}
+%
+% \begin{function}{\__kernel_chk_var_scope:NN}
+%   \begin{syntax}
+%     \cs{__kernel_chk_var_scope:NN} \meta{scope} \meta{var}
+%   \end{syntax}
+%   Checks the \meta{var} has the correct \meta{scope}, and if not
+%   raises a kernel-level error.
+%   The \meta{scope} is a single letter |l|, |g|,
+%   |c| denoting local variables, global variables, or constants.  More
+%   precisely, if the variable name starts with a letter and an
+%   underscore (normal \pkg{expl3} convention) the function checks that
+%   this single letter matches the \meta{scope}.  Otherwise the function
+%   cannot know the scope \meta{var} the first time: instead, it defines
+%   |\__debug_chk_/|\meta{var name} to store that information for the
+%   next call.  Thus, if a given \meta{var} is subject to assignments of
+%   different scopes a kernel error will result.
+% \end{function}
+%
+% \begin{function}
+%   {
+%     \__kernel_chk_cs_exist:N,
+%     \__kernel_chk_cs_exist:c,
+%     \__kernel_chk_var_exist:N
+%   }
 %   \begin{syntax}
 %     \cs{__kernel_chk_cs_exist:N} \meta{cs}
+%     \cs{__kernel_chk_var_exist:N} \meta{var}
 %   \end{syntax}
-%   This function is only created if debugging is enabled.  It checks
-%   that \meta{cs} exists according to the criteria for
-%   \cs{cs_if_exist_p:N}, and if not raises a kernel-level error.
+%   Checks that their argument is defined according to the criteria for
+%   \cs{cs_if_exist_p:N},
+%   and if not raises a kernel-level error.  Error messages are
+%   different.
 % \end{function}
+%
+% \begin{function}[EXP]{\__kernel_chk_flag_exist:NN}
+%   \begin{syntax}
+%     \cs{__kernel_chk_flag_exist:NN}
+%     \meta{function} \meta{flag}
+%   \end{syntax}
+%   Checks that the \meta{flag} is defined according to the criterion for
+%   \cs{flag_if_exist_p:N}, and if not raises a kernel-level error and
+%   calls the function with the argument \cs{l_tmpa_flag} to proceed
+%   somehow without producing too many errors.
+% \end{function}
+%
+% \begin{function}{\__kernel_debug_log:e}
+%   \begin{syntax}
+%     \cs{__kernel_debug_log:e} \Arg{message text}
+%   \end{syntax}
+%   If the \texttt{log-functions} option is active, this function writes
+%   the \meta{message text} to the log file using \cs{iow_log:e}.
+%   Otherwise, the \meta{message text} is ignored using \cs{use_none:n}.
+% \end{function}
+%
+% \subsection{Internal kernel functions}
 %
 % \begin{function}{\__kernel_chk_defined:NT}
 %   \begin{syntax}


### PR DESCRIPTION
This avoids a warning raised when building `source3.pdf`:
```tex
LaTeX Warning: Label `doc/function////kernel/chk/cs/exist:N' multiply defined.
```

Closes #1447.