### PR TITLE
Fix tagging for tex files

### DIFF
--- a/l3kernel/build.lua
+++ b/l3kernel/build.lua
@@ -57,6 +57,10 @@ function update_tag_extra(file,content,tagname,tagdate)
     content = string.gsub(content,
       "\n\\def\\ExplFileDate{" .. iso .. "}%%\n",
       "\n\\def\\ExplFileDate{" .. tagname .. "}%%\n")
+  elseif string.match(file,"%.tex$") then
+    content = string.gsub(content,
+      "\n\\date{Released " .. iso .. "}\n",
+      "\n\\date{Released " .. tagname .. "}\n")
   end
   return(content)
 end

--- a/l3kernel/doc/interface3.tex
+++ b/l3kernel/doc/interface3.tex
@@ -58,7 +58,7 @@ for those people who are interested.
          {latex-team@latex-project.org}%
    }%
 }
-\date{Released 2023-12-08}
+\date{Released 2024-02-13}
 
 \pagenumbering{roman}
 \maketitle

--- a/l3kernel/doc/l3styleguide.tex
+++ b/l3kernel/doc/l3styleguide.tex
@@ -32,7 +32,7 @@ The released version of this bundle is available from CTAN.
         {latex-team@latex-project.org}%
     }%
 }
-\date{Released 2023-12-08}
+\date{Released 2024-02-13}
 
 \begin{document}
 

--- a/l3kernel/doc/l3syntax-changes.tex
+++ b/l3kernel/doc/l3syntax-changes.tex
@@ -32,7 +32,7 @@ The released version of this bundle is available from CTAN.
         {latex-team@latex-project.org}%
     }%
 }
-\date{Released 2023-12-08}
+\date{Released 2024-02-13}
 
 \newcommand{\TF}{\textit{(TF)}}
 

--- a/l3kernel/doc/l3term-glossary.tex
+++ b/l3kernel/doc/l3term-glossary.tex
@@ -32,7 +32,7 @@ The released version of this bundle is available from CTAN.
         {latex-team@latex-project.org}%
     }%
 }
-\date{Released 2023-12-08}
+\date{Released 2024-02-13}
 
 \newcommand{\TF}{\textit{(TF)}}
 

--- a/l3kernel/doc/source3.tex
+++ b/l3kernel/doc/source3.tex
@@ -57,7 +57,7 @@ for those people who are interested.
          {latex-team@latex-project.org}%
    }%
 }
-\date{Released 2023-12-08}
+\date{Released 2024-02-13}
 
 \pagenumbering{roman}
 \maketitle


### PR DESCRIPTION
This fixes a regression introduced in ecccd76a (Avoid code duplicate in tagging routine, 2023-12-11) that made tex files in `./l3kernel/doc` not tagged.

The original logic was
```lua
  if string.match(file,"%.dtx$") or string.match(file,"%.tex$") then
    return string.gsub(content,
      "\n(%%*%s*)\\date{Released " .. iso .. "}\n",
      "\n%1\\date{Released " .. tagname .. "}\n")
  elseif string.match(file, "%.md$") then
    -- ...
  end
```