### PR TITLE
Update info of prefix "fontspec"

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -97,7 +97,7 @@ fmwao,widows-and-orphans,Frank Mittelbach,https://www.latex-project.org/,https:/
 fnote,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex2e.git,https://github.com/latex3/latex2e/issues,2023-10-17,2023-10-17,
 fnpct,fnpct,Clemens Niederberger,https://github.com/cgnieder/fnpct/,https://github.com/cgnieder/fnpct.git,https://github.com/cgnieder/fnpct/issues,2013-03-16,2020-04-14,
 fontsizes,fontsizes,Julien Rivaud,,,,,2018-06-13,
-fontspec,fontspec,Will Robertson,https://github.com/wspr/fontspec,https://github.com/wspr/fontspec.git,https://github.com/wspr/fontspec/issues,2013-03-16,2013-03-16,
+fontspec,fontspec,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/fontspec.git,https://github.com/latex3/fontspec/issues,2013-03-16,2024-02-15,
 fp,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 fun,functional,Jianrui Lyu,https://github.com/lvjr/functional,https://github.com/lvjr/functional.git,https://github.com/lvjr/functional/issues,2022-04-02,2022-04-02,
 galley,l3galley,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,


### PR DESCRIPTION
`fontspec` is moved from https://github.com/wspr/fontspec to https://github.com/latex3/fontspec  around 2022.