### PR TITLE
Correct m3clist002 test

### DIFF
--- a/l3kernel/testfiles/m3clist002.lvt
+++ b/l3kernel/testfiles/m3clist002.lvt
@@ -23,8 +23,8 @@
     \cs_if_eq:NNTF \l_a_clist \c_empty_clist { \TRUE } { \ERROR }
     \cs_if_eq:NNTF \g_b_clist \c_empty_clist { \TRUE } { \ERROR }
   }
-  \TYPE { Empty~-\tl_use:N \l_a_clist- }
-  \TYPE { Empty~-\tl_use:N \g_b_clist- }
+  \TYPE { Empty~-\clist_use:Nn \l_a_clist {,} - }
+  \TYPE { Empty~-\clist_use:Nn \g_b_clist {,} - }
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -44,7 +44,7 @@
     \TYPE { \cs_meaning:N \l_undefined_clist }
     \TYPE { \cs_meaning:N \g_undefined_clist }
     \clist_clear:N \l_undefined_clist
-    \clist_clear:N \g_undefined_clist
+    \clist_gclear:N \g_undefined_clist
     \TYPE { \cs_meaning:N \l_undefined_clist }
     \TYPE { \cs_meaning:N \g_undefined_clist }
   }
@@ -464,18 +464,23 @@
   \clist_push:Nn \l_tmpa_clist {b\par}
   {
     \clist_remove_duplicates:N \l_tmpa_clist
-    \TYPE{ \tl_use:N \l_tmpa_clist }
+    \TYPE{ \clist_use:Nn \l_tmpa_clist {,} }
   }
-  \TYPE{ \tl_use:N \l_tmpa_clist }
+  \TYPE{ \clist_use:Nn \l_tmpa_clist {,} }
+  \clist_gset_eq:NN \g_tmpa_clist \l_tmpa_clist
   {
-    \clist_gremove_duplicates:N \l_tmpa_clist
-    \TYPE{ \tl_use:N \l_tmpa_clist }
+    \clist_gremove_duplicates:N \g_tmpa_clist
+    \TYPE{ \clist_use:Nn \g_tmpa_clist {,} }
   }
-  \TYPE{ \tl_use:N \l_tmpa_clist }
+  \TYPE{ \clist_use:Nn \g_tmpa_clist {,} }
   %
   \clist_set:Nn \l_tmpa_clist { a , {a,b,c,d,e,f,g,h} , b , { b ~ } , ~ b }
   \clist_remove_duplicates:N \l_tmpa_clist
-  \TYPE { \clist_count:N \l_tmpa_clist \c_space_tl items:~ [ \tl_use:N \l_tmpa_clist ] }
+  \TYPE
+    {
+      \clist_count:N \l_tmpa_clist \c_space_tl items:~
+      [ \clist_use:Nn \l_tmpa_clist {||} ]
+    }
 }
 
 \TEST{remove_all}{
@@ -488,15 +493,15 @@
   \clist_push:Nn \l_tmpa_clist {b\par}
   {
     \clist_remove_all:Nn \l_tmpa_clist { a\par }
-    \TYPE{ \tl_use:N \l_tmpa_clist }
+    \TYPE{ \clist_use:Nn \l_tmpa_clist {,} }
   }
-  \TYPE{ \tl_use:N \l_tmpa_clist }
+  \TYPE{ \clist_use:Nn \l_tmpa_clist {,} }
   \clist_gset_eq:NN \g_tmpa_clist \l_tmpa_clist
   {
     \clist_gremove_all:Nn \g_tmpa_clist { a\par }
-    \TYPE{ \tl_use:N \g_tmpa_clist }
+    \TYPE{ \clist_use:Nn \g_tmpa_clist {,} }
   }
-  \TYPE{ \tl_use:N \g_tmpa_clist }
+  \TYPE{ \clist_use:Nn \g_tmpa_clist {,} }
 }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3clist002.tlg
+++ b/l3kernel/testfiles/m3clist002.tlg
@@ -41,16 +41,10 @@ Checking is active, and you have tried do so something like:
 without first having:
   \tl_new:N \g_undefined_clist
 LaTeX will create the variable and continue.
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...}
-This is a coding error.
-Local assignment to a global variable '\g_undefined_clist'.
 macro:->
 macro:->
 undefined
-undefined
+macro:->
 ============================================================
 ============================================================
 TEST 3: clear_new
@@ -364,15 +358,9 @@ TEST 28: remove_duplicates
 ============================================================
 b\par ,c\par ,a\par 
 b\par ,c\par ,a\par ,c\par ,b\par ,a\par 
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...}
-This is a coding error.
-Global assignment to a local variable '\l_tmpa_clist'.
 b\par ,c\par ,a\par 
 b\par ,c\par ,a\par 
-4 items: [a,{a,b,c,d,e,f,g,h},b,{b }]
+4 items: [a||a,b,c,d,e,f,g,h||b||b ]
 ============================================================
 ============================================================
 TEST 29: remove_all


### PR DESCRIPTION
- Fix unwanted inconsistent local/global assignments.
- Fix use of `\tl_use:N` on clist variables.