### PR TITLE
Declare `\l_graphics_search_ext_seq` in l3backend in non-LaTeX

### DIFF
--- a/l3backend/CHANGELOG.md
+++ b/l3backend/CHANGELOG.md
@@ -6,6 +6,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fix
+- Setting `\l_graphics_search_ext_seq` before declaration if loaded in
+  formats other than LaTeX
+
 ## [2024-02-20]
 
 ### Fixed

--- a/l3backend/l3backend-graphics.dtx
+++ b/l3backend/l3backend-graphics.dtx
@@ -61,20 +61,28 @@
 %    \end{macrocode}
 %
 % \begin{macro}{\@@_backend_loaded:n}
+% \begin{variable}[no-user-doc]{\l_graphics_search_ext_seq}
 %   To deal with file load ordering. Plain users are on their own.
+%   In \LaTeX{} format, setting \cs{l_graphics_search_ext_seq} is
+%   postponed until after loading \pkg{l3graphics}. In other formats
+%   it is set immediately, so we declare it right now.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_backend_loaded:n #1
+\cs_if_exist:NTF \hook_gput_code:nnn
   {
-    \cs_if_exist:NTF \hook_gput_code:nnn
+    \cs_new_protected:Npn \@@_backend_loaded:n #1
       {
         \hook_gput_code:nnn
           { package / l3graphics / after }
           { backend }
           {#1}
       }
-      {#1}
+  }
+  {
+    \cs_new_eq:NN \@@_backend_loaded:n \use:n
+    \seq_new:N \l_graphics_search_ext_seq
   }
 %    \end{macrocode}
+% \end{variable}
 % \end{macro}
 %
 % \subsection{\texttt{dvips} backend}

--- a/l3backend/l3backend-graphics.dtx
+++ b/l3backend/l3backend-graphics.dtx
@@ -60,7 +60,7 @@
 %<@@=graphics>
 %    \end{macrocode}
 %
-% \begin{macro}{\@@_backend_loaded:n}
+% \begin{macro}[no-user-doc]{\@@_backend_loaded:n}
 % \begin{variable}[no-user-doc]{\l_graphics_search_ext_seq}
 %   To deal with file load ordering. Plain users are on their own.
 %   In \LaTeX{} format, setting \cs{l_graphics_search_ext_seq} is

--- a/l3experimental/CHANGELOG.md
+++ b/l3experimental/CHANGELOG.md
@@ -10,6 +10,10 @@ this project uses date-based 'snapshot' version identifiers.
 ### Added
 - `\draw_path_replace_bb:`
 
+### Changed
+- Skip declaration of `\l_graphics_search_ext_seq` if `l3graphics` is loaded
+  in formats other than LaTeX
+
 ## [2024-02-20]
 
 ### Fixed

--- a/l3experimental/l3graphics/l3graphics.dtx
+++ b/l3experimental/l3graphics/l3graphics.dtx
@@ -474,9 +474,13 @@
 % \end{variable}
 %
 % \begin{variable}{\l_graphics_search_ext_seq}
-%   Used to specify fall-back extensions: actually set on a per-backend basis.
+%   Used to specify fall-back extensions: actually set on a per-backend
+%   basis. First we check if it's already declared (in backend driver),
+%   which happens when the generic \pkg{expl3} loader is used in formats
+%   other than \LaTeX{}.
 %    \begin{macrocode}
-\seq_new:N \l_graphics_search_ext_seq
+\seq_if_exist:NF \l_graphics_search_ext_seq
+  { \seq_new:N \l_graphics_search_ext_seq }
 %    \end{macrocode}
 % \end{variable}
 %

--- a/l3kernel/l3debug.dtx
+++ b/l3kernel/l3debug.dtx
@@ -787,6 +787,7 @@
       \prop_set_eq:NN
       \prop_set_from_keyval:Nn
       \seq_set_eq:NN
+      \seq_set_from_clist:Nn
       \skip_zero:N
       \skip_set:Nn
       \skip_set_eq:NN


### PR DESCRIPTION
This seq was declared in `l3graphics` but is set in a per-backend basis. Since backend driver is always loaded, even without `l3graphics`, declaring it in `l3backend-graphics` avoids a setting-before-declaration issue.