### PR TITLE
Typeset `TF` of internal conditionals in current color

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Typeset `TF` of internal conditionals in current color (issue \#730)
+
 ## [2024-02-20]
 
 ### Changed

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -2130,7 +2130,6 @@ and all files in that bundle must be distributed together.
         \itshape TF
         \makebox[0pt][r]
           {
-            \cs_if_exist:NT \Codedoc@explTF { \color{red} }
             \underline { \phantom{\itshape TF} \kern-0.1em }
           }
       }

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -2127,7 +2127,6 @@ and all files in that bundle must be distributed together.
       { \hyperlink { explTF } }
       { \mbox }
       {
-        \color{black}
         \itshape TF
         \makebox[0pt][r]
           {
@@ -3206,18 +3205,22 @@ and all files in that bundle must be distributed together.
         \tl_set:Nn \l_@@_tmpa_tl {#1}
         \tl_replace_all:NnV \l_@@_tmpa_tl
           { ~ } \c_catcode_other_space_tl
-        \@@_macroname_prefix:o \l_@@_tmpa_tl
-        \@@_macroname_suffix:N #2
+        \@@_print_macroname_aux:on
+          \l_@@_tmpa_tl { \bool_if:NT #2 { \@@_typeset_TF: } }
       }
   }
-\cs_new_protected:Npn \@@_macroname_prefix:n #1
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\@@_print_macroname_aux:nn}
+%  |#1| is prefix, |#2| is optional |TF| suffix.
+%    \begin{macrocode}
+\cs_new_protected:Npn \@@_print_macroname_aux:nn #1#2
   {
     \@@_if_macro_internal:nTF {#1}
-      { \@@_typeset_aux:n {#1} } {#1}
+      { \@@_typeset_aux:n { #1 #2 } } { #1 #2 }
   }
-\cs_generate_variant:Nn \@@_macroname_prefix:n { o }
-\cs_new_protected:Npn \@@_macroname_suffix:N #1
-  { \bool_if:NTF #1 { \@@_typeset_TF: } { } }
+\cs_generate_variant:Nn \@@_print_macroname_aux:nn { o }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/testfiles-l3doc/github-1398.tlg
+++ b/l3kernel/testfiles-l3doc/github-1398.tlg
@@ -114,7 +114,6 @@ Completed box being shipped out [1]
 ............\T1/lmtt/m/n/9 N
 ............\T1/lmtt/m/n/9 N
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -127,7 +126,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -254,7 +252,6 @@ Completed box being shipped out [1]
 ............\T1/lmtt/m/n/9 N
 ............\T1/lmtt/m/n/9 N
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -267,7 +264,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -293,7 +289,6 @@ Completed box being shipped out [1]
 ............\T1/lmtt/m/n/9 c
 ............\T1/lmtt/m/n/9 N
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -306,7 +301,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -445,7 +439,6 @@ Completed box being shipped out [1]
 ............\T1/lmtt/m/n/9 N
 ............\T1/lmtt/m/n/9 N
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -458,7 +451,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -496,7 +488,6 @@ Completed box being shipped out [1]
 ............\T1/lmr/m/n/9 )
 ............\kern 0.0
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -509,7 +500,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -586,7 +576,6 @@ Completed box being shipped out [1]
 ............\T1/lmtt/m/n/9 N
 ............\T1/lmtt/m/n/9 N
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -599,7 +588,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -678,7 +666,6 @@ Completed box being shipped out [1]
 ............\T1/lmtt/m/n/9 N
 ............\T1/lmtt/m/n/9 N
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -691,7 +678,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -717,7 +703,6 @@ Completed box being shipped out [1]
 ............\T1/lmtt/m/n/9 c
 ............\T1/lmtt/m/n/9 N
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -730,7 +715,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -809,7 +793,6 @@ Completed box being shipped out [1]
 ............\T1/lmtt/m/n/9 N
 ............\T1/lmtt/m/n/9 N
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -822,7 +805,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0
@@ -860,7 +842,6 @@ Completed box being shipped out [1]
 ............\T1/lmr/m/n/9 )
 ............\kern 0.0
 ............\hbox(5.39143+1.9999)x9.44998
-.............\pdfcolorstack 0 push {0 g 0 G}
 .............\T1/lmtt/m/it/9 T
 .............\T1/lmtt/m/it/9 F
 .............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
@@ -873,7 +854,6 @@ Completed box being shipped out [1]
 ...............\kern1.19994
 ...............\rule(0.39998+0.0)x*
 ..............\mathoff
-............\pdfcolorstack 0 pop
 ............\glue 0.0 plus 1.0fill
 ...........\glue(\tabskip) 0.0
 ...........\hbox(7.69997+3.30003)x0.0

--- a/l3kernel/testfiles-l3doc/test.lvt
+++ b/l3kernel/testfiles-l3doc/test.lvt
@@ -6,6 +6,10 @@
 \documentclass{l3doc}
 \CodelineIndex
 \begin{document}
+\ExplSyntaxOn
+\tl_gset:Nn \g__codedoc_module_name_tl {foo}
+\ExplSyntaxOff
+
 \START
 \begin{function}{\foo}
   This is a test.
@@ -19,6 +23,10 @@ And \cs{foo} again.
   Argument \meta{arg}.
 \end{function}
 
+\begin{function}[TF]{\foo_if:n}
+  doc
+\end{function}
+
 \begin{macro}{\foo}
     \begin{macrocode}
 test
@@ -28,6 +36,17 @@ test
 %    \end{macrocode}
 \cs{bar}
 \end{macro}
+
+% #730, https://github.com/latex3/latex3/issues/730
+\begin{macro}[TF]{\foo_if:n, \__foo_if:n}
+    \begin{macrocode}
+\prg_new_conditional:Nnn \foo_if:n { p , T , F , TF }
+  { \prg_return_true: }
+\prg_new_conditional:Nnn \__foo_if:n { p , T , F , TF }
+  { \prg_return_true: }
+%    \end{macrocode}
+\end{macro}
+
 \PrintIndex
 \showoutput
 \clearpage

--- a/l3kernel/testfiles-l3doc/test.tlg
+++ b/l3kernel/testfiles-l3doc/test.tlg
@@ -51,7 +51,7 @@ Completed box being shipped out [1]
 .....\pdfcolorstack 0 pop
 ...\glue 25.0
 ...\glue(\lineskip) 0.0
-...\vbox(598.0+0.0)x385.0, glue set 266.66296fil
+...\vbox(598.0+0.0)x385.0, glue set 85.06158fil
 ....\write-{}
 ....\pdfdest name{Doc-Start} xyz
 ....\glue(\topskip) 10.0
@@ -318,11 +318,108 @@ Completed box being shipped out [1]
 .....\glue(\parfillskip) 0.0 plus 1.0fil
 .....\glue(\rightskip) 0.0
 ....\penalty 0
+....\glue 12.0 plus 4.0 minus 4.0
+....\glue 0.0
+....\glue(\parskip) 0.0 plus 3.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 9.5
+....\hbox(0.0+17.12079)x385.0
+.....\hbox(0.0+17.12079)x385.0
+......\hbox(0.0+0.0)x0.0
+......\kern 0.0
+......\kern -56.9749
+......\hbox(0.0+17.12079)x441.9749
+.......\kern 56.9749
+.......\hbox(0.0+12.88875)x385.0
+........\hbox(0.0+0.0)x0.0
+.........\kern 0.0
+.........\kern 0.0
+.........\hbox(0.0+0.0)x0.0
+..........\pdfcolorstack 0 push {0 g 0 G}
+..........\pdfcolorstack 0 pop
+........\kern 0.0
+........\kern 0.0
+........\vbox(6.88875+0.0)x385.0, shifted 12.88875
+.........\hbox(6.88875+0.0)x385.0, glue set 369.72221fil
+..........\T1/lmr/m/n/10 d
+..........\T1/lmr/m/n/10 o
+..........\kern0.27779
+..........\T1/lmr/m/n/10 c
+..........\penalty 10000
+..........\glue(\parfillskip) 0.0 plus 1.0fil
+..........\glue(\rightskip) 0.0
+.......\kern -385.0
+.......\kern -56.9749
+.......\hbox(0.0+17.12079)x51.9749
+........\pdfcolorstack 0 push {0 g 0 G}
+........\hbox(0.0+0.0)x0.0
+.........\hbox(0.0+0.0)x0.0, shifted -7.79996
+..........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+...........\pdfdest name{HD.5} xyz
+...........\penalty 10000
+...........\kern 1.57533
+........\hbox(0.0+17.12079)x51.9749
+.........\mathon
+.........\vbox(0.0+17.12079)x51.9749
+..........\glue 0.0
+..........\pdfcolorstack 0 push {0 g 0 G}
+..........\rule(0.80002+0.0)x51.9749
+..........\pdfcolorstack 0 pop
+..........\glue 2.79857
+..........\hbox(7.69997+3.30003)x51.9749
+...........\glue(\tabskip) 0.0
+...........\hbox(7.69997+3.30003)x51.9749
+............\rule(7.69997+3.30003)x0.0
+............\rule(6.25+*)x0.0
+............\write5{\indexentry{foo commands:=\pkg{foo} commands:>foo_if:nTF={\verbatim@font !\verb*&!\foo&!\_!\verb*&if:nTF&}|hdpindex{usage}}{MMMMI-\thepage }}
+............\write1{\newlabel{doc/function//foo/if:nTF}{{}{\thepage }{}{HD.5}{}}}
+............\T1/lmtt/m/n/9 \
+............\T1/lmtt/m/n/9 f
+............\T1/lmtt/m/n/9 o
+............\T1/lmtt/m/n/9 o
+............\T1/lmtt/m/n/9 _
+............\T1/lmtt/m/n/9 i
+............\T1/lmtt/m/n/9 f
+............\T1/lmtt/m/n/9 :
+............\T1/lmtt/m/n/9 n
+............\hbox(5.39143+1.9999)x9.44998
+.............\T1/lmtt/m/it/9 T
+.............\T1/lmtt/m/it/9 F
+.............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
+..............\glue 0.0 plus 1.0fil minus 1.0fil
+..............\mathon
+..............\vbox(5.39143+1.9999)x8.50493
+...............\hbox(5.39143+0.0)x8.50493
+................\hbox(5.39143+0.0)x9.44998
+................\kern -0.94505
+...............\kern1.19994
+...............\rule(0.39998+0.0)x*
+..............\mathoff
+............\glue 0.0 plus 1.0fill
+...........\glue(\tabskip) 0.0
+...........\hbox(7.69997+3.30003)x0.0
+............\rule(0.0+*)x0.0
+............\glue 0.0 plus 1.0fill
+............\kern 0.0
+...........\glue(\tabskip) 0.0
+..........\glue 1.72218
+..........\pdfcolorstack 0 push {0 g 0 G}
+..........\rule(0.80002+0.0)x51.9749
+..........\pdfcolorstack 0 pop
+..........\glue 0.0
+.........\mathoff
+........\pdfcolorstack 0 pop
+.......\kern 390.0
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty 0
 ....\penalty -51
 ....\glue 9.0 plus 6.0 minus 3.0
 ....\glue(\parskip) 0.0 plus 3.0
 ....\glue(\parskip) 0.0
-....\glue(\baselineskip) 1.10004
+....\glue(\baselineskip) 3.60004
 ....\hbox(8.39996+3.60004)x385.0, glue set 385.0fil
 .....\hbox(8.39996+3.60004)x0.0
 ......\glue 0.0
@@ -339,7 +436,7 @@ Completed box being shipped out [1]
 ...........\hbox(0.0+0.0)x0.0, shifted -9.22217
 ............\hbox(0.0+0.0)x0.0, glue set - 1.66702fil
 .............\glue 0.0 plus 1.0fil minus 1.0fil
-.............\pdfdest name{HD.5} xyz
+.............\pdfdest name{HD.6} xyz
 .............\penalty 10000
 .............\kern 1.66702
 .........\glue -12.0
@@ -378,7 +475,7 @@ Completed box being shipped out [1]
 .......\hbox(0.0+0.0)x0.0, shifted -7.79996
 ........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\pdfdest name{HD.6} xyz
+.........\pdfdest name{HD.7} xyz
 .........\penalty 10000
 .........\kern 1.57533
 ......\pdfcolorstack 0 push {0.5 g 0.5 G}
@@ -406,7 +503,7 @@ Completed box being shipped out [1]
 .......\hbox(0.0+0.0)x0.0, shifted -7.79996
 ........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\pdfdest name{HD.7} xyz
+.........\pdfdest name{HD.8} xyz
 .........\penalty 10000
 .........\kern 1.57533
 ......\pdfcolorstack 0 push {0.5 g 0.5 G}
@@ -440,7 +537,7 @@ Completed box being shipped out [1]
 .......\hbox(0.0+0.0)x0.0, shifted -7.79996
 ........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\pdfdest name{HD.8} xyz
+.........\pdfdest name{HD.9} xyz
 .........\penalty 10000
 .........\kern 1.57533
 ......\pdfcolorstack 0 push {0.5 g 0.5 G}
@@ -468,7 +565,7 @@ Completed box being shipped out [1]
 .......\hbox(0.0+0.0)x0.0, shifted -7.79996
 ........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
 .........\glue 0.0 plus 1.0fil minus 1.0fil
-.........\pdfdest name{HD.9} xyz
+.........\pdfdest name{HD.10} xyz
 .........\penalty 10000
 .........\kern 1.57533
 ......\pdfcolorstack 0 push {0.5 g 0.5 G}
@@ -496,7 +593,7 @@ Completed box being shipped out [1]
 ......\hbox(0.0+0.0)x0.0, shifted -9.22217
 .......\hbox(0.0+0.0)x0.0, glue set - 1.66702fil
 ........\glue 0.0 plus 1.0fil minus 1.0fil
-........\pdfdest name{HD.10} xyz
+........\pdfdest name{HD.11} xyz
 ........\penalty 10000
 ........\kern 1.66702
 .....\T1/lmtt/m/n/10 \
@@ -582,6 +679,530 @@ Completed box being shipped out [1]
 .....\T1/lmr/m/it/8 e
 .....\glue 3.07224 plus 1.31667 minus 0.87778
 .....\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.1}
+.....\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.....\T1/lmr/m/it/8 1
+.....\pdfcolorstack 0 pop
+.....\pdfendlink
+.....\T1/lmr/m/it/8 .
+.....\kern 0.0
+.....\T1/lmr/m/n/8 )
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty -51
+....\glue 9.0 plus 6.0 minus 3.0
+....\glue(\parskip) 0.0 plus 3.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 1.60004
+....\hbox(8.39996+3.60004)x385.0, glue set 385.0fil
+.....\hbox(8.39996+3.60004)x0.0
+......\glue 0.0
+......\glue 0.0
+......\glue -5.0
+......\hbox(8.39996+3.60004)x0.0
+.......\pdfcolorstack 0 push {0 g 0 G}
+.......\hbox(8.39996+3.60004)x0.0
+........\glue 0.0 plus 1.0fil minus 1.0fil
+........\vbox(8.39996+3.60004)x0.0, glue set - 12.0fil
+.........\hbox(8.39996+3.60004)x0.0
+..........\rule(8.39996+3.60004)x0.0
+..........\hbox(0.0+0.0)x0.0
+...........\hbox(0.0+0.0)x0.0, shifted -9.22217
+............\hbox(0.0+0.0)x0.0, glue set - 1.66702fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\pdfdest name{HD.12} xyz
+.............\penalty 10000
+.............\kern 1.66702
+.........\glue -12.0
+.........\hbox(8.39996+3.60004)x0.0
+..........\hbox(8.39996+3.60004)x0.0, glue set - 56.69989fil
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+...........\rule(8.39996+3.60004)x0.0
+...........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.5}
+...........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+...........\T1/lmtt/m/n/9 \
+...........\T1/lmtt/m/n/9 f
+...........\T1/lmtt/m/n/9 o
+...........\T1/lmtt/m/n/9 o
+...........\T1/lmtt/m/n/9 _
+...........\T1/lmtt/m/n/9 i
+...........\T1/lmtt/m/n/9 f
+...........\T1/lmtt/m/n/9 :
+...........\T1/lmtt/m/n/9 n
+...........\hbox(5.39143+1.9999)x9.44998
+............\T1/lmtt/m/it/9 T
+............\T1/lmtt/m/it/9 F
+............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\mathon
+.............\vbox(5.39143+1.9999)x8.50493
+..............\hbox(5.39143+0.0)x8.50493
+...............\hbox(5.39143+0.0)x9.44998
+...............\kern -0.94505
+..............\kern1.19994
+..............\rule(0.39998+0.0)x*
+.............\mathoff
+...........\pdfcolorstack 0 pop
+...........\pdfendlink
+...........\glue 4.72499
+.........\hbox(8.39996+3.60004)x0.0
+..........\hbox(8.39996+3.60004)x0.0, glue set - 66.14987fil
+...........\glue 0.0 plus 1.0fil minus 1.0fil
+...........\rule(8.39996+3.60004)x0.0
+...........\pdfcolorstack 0 push {0.5 g 0.5 G}
+...........\T1/lmtt/m/n/9 \
+...........\T1/lmtt/m/n/9 _
+...........\T1/lmtt/m/n/9 _
+...........\T1/lmtt/m/n/9 f
+...........\T1/lmtt/m/n/9 o
+...........\T1/lmtt/m/n/9 o
+...........\T1/lmtt/m/n/9 _
+...........\T1/lmtt/m/n/9 i
+...........\T1/lmtt/m/n/9 f
+...........\T1/lmtt/m/n/9 :
+...........\T1/lmtt/m/n/9 n
+...........\hbox(5.39143+1.9999)x9.44998
+............\T1/lmtt/m/it/9 T
+............\T1/lmtt/m/it/9 F
+............\hbox(5.39143+1.9999)x0.0, glue set - 8.50493fil
+.............\glue 0.0 plus 1.0fil minus 1.0fil
+.............\mathon
+.............\vbox(5.39143+1.9999)x8.50493
+..............\hbox(5.39143+0.0)x8.50493
+...............\hbox(5.39143+0.0)x9.44998
+...............\kern -0.94505
+..............\kern1.19994
+..............\rule(0.39998+0.0)x*
+.............\mathoff
+...........\pdfcolorstack 0 pop
+...........\glue 4.72499
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\pdfcolorstack 0 pop
+......\glue 5.0
+.....\penalty 0
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty 10000
+....\glue 3.0 plus 4.2 minus 1.0
+....\penalty 0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 1.14996
+....\hbox(6.25+2.0)x385.0, glue set 127.89503fil
+.....\glue(\leftskip) 6.68045
+.....\hbox(0.0+0.0)x0.0
+.....\hbox(3.28125+0.0)x0.0, glue set - 7.38124fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(0.0+0.0)x0.0
+.......\hbox(0.0+0.0)x0.0, shifted -7.79996
+........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\pdfdest name{HD.13} xyz
+.........\penalty 10000
+.........\kern 1.57533
+......\pdfcolorstack 0 push {0.5 g 0.5 G}
+......\T1/lmss/m/n/5 5
+......\pdfcolorstack 0 pop
+......\glue 4.72499
+......\glue 0.0
+.....\T1/lmtt/m/n/9 \
+.....\T1/lmtt/m/n/9 p
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 g
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 e
+.....\T1/lmtt/m/n/9 w
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 c
+.....\T1/lmtt/m/n/9 o
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 d
+.....\T1/lmtt/m/n/9 i
+.....\T1/lmtt/m/n/9 t
+.....\T1/lmtt/m/n/9 i
+.....\T1/lmtt/m/n/9 o
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 a
+.....\T1/lmtt/m/n/9 l
+.....\T1/lmtt/m/n/9 :
+.....\T1/lmtt/m/n/9 N
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 n
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 \
+.....\T1/lmtt/m/n/9 f
+.....\T1/lmtt/m/n/9 o
+.....\T1/lmtt/m/n/9 o
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 i
+.....\T1/lmtt/m/n/9 f
+.....\T1/lmtt/m/n/9 :
+.....\T1/lmtt/m/n/9 n
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 {
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 p
+.....\penalty 10000
+.....\glue 4.72499
+.....\kern 0.0
+.....\T1/lmtt/m/n/9 ,
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 T
+.....\penalty 10000
+.....\glue 4.72499
+.....\kern 0.0
+.....\T1/lmtt/m/n/9 ,
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 F
+.....\penalty 10000
+.....\glue 4.72499
+.....\kern 0.0
+.....\T1/lmtt/m/n/9 ,
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 T
+.....\T1/lmtt/m/n/9 F
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 }
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty 0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 2.75
+....\hbox(6.25+2.0)x385.0, glue set 269.64476fil
+.....\glue(\leftskip) 6.68045
+.....\hbox(0.0+0.0)x0.0
+.....\hbox(3.28125+0.0)x0.0, glue set - 7.38124fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(0.0+0.0)x0.0
+.......\hbox(0.0+0.0)x0.0, shifted -7.79996
+........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\pdfdest name{HD.14} xyz
+.........\penalty 10000
+.........\kern 1.57533
+......\pdfcolorstack 0 push {0.5 g 0.5 G}
+......\T1/lmss/m/n/5 6
+......\pdfcolorstack 0 pop
+......\glue 4.72499
+......\glue 0.0
+.....\penalty 10000
+.....\glue 4.72499
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 {
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 \
+.....\T1/lmtt/m/n/9 p
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 g
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 e
+.....\T1/lmtt/m/n/9 t
+.....\T1/lmtt/m/n/9 u
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 t
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 u
+.....\T1/lmtt/m/n/9 e
+.....\T1/lmtt/m/n/9 :
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 }
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty 0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 2.75
+....\hbox(6.25+2.0)x385.0, glue set 118.44505fil
+.....\glue(\leftskip) 6.68045
+.....\hbox(0.0+0.0)x0.0
+.....\hbox(3.28125+0.0)x0.0, glue set - 7.38124fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(0.0+0.0)x0.0
+.......\hbox(0.0+0.0)x0.0, shifted -7.79996
+........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\pdfdest name{HD.15} xyz
+.........\penalty 10000
+.........\kern 1.57533
+......\pdfcolorstack 0 push {0.5 g 0.5 G}
+......\T1/lmss/m/n/5 7
+......\pdfcolorstack 0 pop
+......\glue 4.72499
+......\glue 0.0
+.....\T1/lmtt/m/n/9 \
+.....\T1/lmtt/m/n/9 p
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 g
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 e
+.....\T1/lmtt/m/n/9 w
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 c
+.....\T1/lmtt/m/n/9 o
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 d
+.....\T1/lmtt/m/n/9 i
+.....\T1/lmtt/m/n/9 t
+.....\T1/lmtt/m/n/9 i
+.....\T1/lmtt/m/n/9 o
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 a
+.....\T1/lmtt/m/n/9 l
+.....\T1/lmtt/m/n/9 :
+.....\T1/lmtt/m/n/9 N
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 n
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 \
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 f
+.....\T1/lmtt/m/n/9 o
+.....\T1/lmtt/m/n/9 o
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 i
+.....\T1/lmtt/m/n/9 f
+.....\T1/lmtt/m/n/9 :
+.....\T1/lmtt/m/n/9 n
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 {
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 p
+.....\penalty 10000
+.....\glue 4.72499
+.....\kern 0.0
+.....\T1/lmtt/m/n/9 ,
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 T
+.....\penalty 10000
+.....\glue 4.72499
+.....\kern 0.0
+.....\T1/lmtt/m/n/9 ,
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 F
+.....\penalty 10000
+.....\glue 4.72499
+.....\kern 0.0
+.....\T1/lmtt/m/n/9 ,
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 T
+.....\T1/lmtt/m/n/9 F
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 }
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty 0
+....\glue(\parskip) 0.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 2.75
+....\hbox(6.25+2.0)x385.0, glue set 269.64476fil
+.....\glue(\leftskip) 6.68045
+.....\hbox(0.0+0.0)x0.0
+.....\hbox(3.28125+0.0)x0.0, glue set - 7.38124fil
+......\glue 0.0 plus 1.0fil minus 1.0fil
+......\hbox(0.0+0.0)x0.0
+.......\hbox(0.0+0.0)x0.0, shifted -7.79996
+........\hbox(0.0+0.0)x0.0, glue set - 1.57533fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\pdfdest name{HD.16} xyz
+.........\penalty 10000
+.........\kern 1.57533
+......\pdfcolorstack 0 push {0.5 g 0.5 G}
+......\T1/lmss/m/n/5 8
+......\pdfcolorstack 0 pop
+......\glue 4.72499
+......\glue 0.0
+.....\penalty 10000
+.....\glue 4.72499
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 {
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 \
+.....\T1/lmtt/m/n/9 p
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 g
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 e
+.....\T1/lmtt/m/n/9 t
+.....\T1/lmtt/m/n/9 u
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 n
+.....\T1/lmtt/m/n/9 _
+.....\T1/lmtt/m/n/9 t
+.....\T1/lmtt/m/n/9 r
+.....\T1/lmtt/m/n/9 u
+.....\T1/lmtt/m/n/9 e
+.....\T1/lmtt/m/n/9 :
+.....\penalty 10000
+.....\glue 4.72499
+.....\T1/lmtt/m/n/9 }
+.....\penalty 10000
+.....\glue(\parfillskip) 0.0 plus 1.0fil
+.....\glue(\rightskip) 0.0
+....\penalty 0
+....\penalty -51
+....\glue 3.0 plus 1.2 minus 1.0
+....\glue -3.0 plus -1.2 minus -1.0
+....\glue 3.0 plus 1.2 minus 1.0
+....\glue -5.0 plus -1.2 minus -1.0
+....\penalty -51
+....\glue 2.0
+....\glue 3.0 plus 1.2 minus 1.0
+....\glue -3.0 plus -1.2 minus -1.0
+....\glue 9.0 plus 3.0 minus 3.0
+....\penalty 10000
+....\glue(\parskip) 0.0 plus 3.0
+....\glue(\parskip) 0.0
+....\glue(\baselineskip) 1.5
+....\hbox(6.0+2.0)x385.0, glue set 21.5618fil
+.....\T1/lmr/m/n/8 (
+.....\T1/lmr/m/it/8 E
+.....\T1/lmr/m/it/8 n
+.....\T1/lmr/m/it/8 d
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmr/m/it/8 o
+.....\T1/lmr/m/it/8 f
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmr/m/it/8 d
+.....\T1/lmr/m/it/8 e
+.....\T1/lmr/m/it/8 ^^\ (ligature fi)
+.....\T1/lmr/m/it/8 n
+.....\T1/lmr/m/it/8 i
+.....\T1/lmr/m/it/8 t
+.....\T1/lmr/m/it/8 i
+.....\T1/lmr/m/it/8 o
+.....\T1/lmr/m/it/8 n
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmr/m/it/8 f
+.....\T1/lmr/m/it/8 o
+.....\T1/lmr/m/it/8 r
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmtt/m/it/8 \
+.....\T1/lmtt/m/it/8 f
+.....\T1/lmtt/m/it/8 o
+.....\T1/lmtt/m/it/8 o
+.....\penalty 10000
+.....\glue 0.0
+.....\T1/lmtt/m/it/8 _
+.....\discretionary
+......\T1/lmtt/m/it/8 -
+.....\penalty 10000
+.....\glue 0.0
+.....\T1/lmtt/m/it/8 i
+.....\T1/lmtt/m/it/8 f
+.....\T1/lmtt/m/it/8 :
+.....\T1/lmtt/m/it/8 n
+.....\T1/lmtt/m/it/8 T
+.....\T1/lmtt/m/it/8 F
+.....\kern 1.46326
+.....\glue 3.07224 plus 1.31534 minus 0.87865
+.....\T1/lmr/m/it/8 a
+.....\T1/lmr/m/it/8 n
+.....\T1/lmr/m/it/8 d
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmtt/m/it/8 \
+.....\penalty 10000
+.....\glue 0.0
+.....\T1/lmtt/m/it/8 _
+.....\discretionary
+......\T1/lmtt/m/it/8 -
+.....\penalty 10000
+.....\glue 0.0
+.....\penalty 10000
+.....\glue 0.0
+.....\T1/lmtt/m/it/8 _
+.....\discretionary
+......\T1/lmtt/m/it/8 -
+.....\penalty 10000
+.....\glue 0.0
+.....\T1/lmtt/m/it/8 f
+.....\T1/lmtt/m/it/8 o
+.....\T1/lmtt/m/it/8 o
+.....\penalty 10000
+.....\glue 0.0
+.....\T1/lmtt/m/it/8 _
+.....\discretionary
+......\T1/lmtt/m/it/8 -
+.....\penalty 10000
+.....\glue 0.0
+.....\T1/lmtt/m/it/8 i
+.....\T1/lmtt/m/it/8 f
+.....\T1/lmtt/m/it/8 :
+.....\T1/lmtt/m/it/8 n
+.....\T1/lmtt/m/it/8 T
+.....\T1/lmtt/m/it/8 F
+.....\T1/lmr/m/it/8 .
+.....\glue 3.95001 plus 3.95 minus 0.29259
+.....\T1/lmr/m/it/8 T
+.....\T1/lmr/m/it/8 h
+.....\T1/lmr/m/it/8 i
+.....\T1/lmr/m/it/8 s
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmr/m/it/8 f
+.....\T1/lmr/m/it/8 u
+.....\T1/lmr/m/it/8 n
+.....\T1/lmr/m/it/8 c
+.....\T1/lmr/m/it/8 t
+.....\T1/lmr/m/it/8 i
+.....\T1/lmr/m/it/8 o
+.....\T1/lmr/m/it/8 n
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmr/m/it/8 i
+.....\T1/lmr/m/it/8 s
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmr/m/it/8 d
+.....\T1/lmr/m/it/8 o
+.....\kern-0.43889
+.....\T1/lmr/m/it/8 c
+.....\T1/lmr/m/it/8 u
+.....\T1/lmr/m/it/8 m
+.....\T1/lmr/m/it/8 e
+.....\T1/lmr/m/it/8 n
+.....\T1/lmr/m/it/8 t
+.....\T1/lmr/m/it/8 e
+.....\kern-0.43889
+.....\T1/lmr/m/it/8 d
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmr/m/it/8 o
+.....\T1/lmr/m/it/8 n
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\T1/lmr/m/it/8 p
+.....\kern-0.43889
+.....\T1/lmr/m/it/8 a
+.....\T1/lmr/m/it/8 g
+.....\T1/lmr/m/it/8 e
+.....\glue 3.07224 plus 1.31667 minus 0.87778
+.....\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.5}
 .....\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .....\T1/lmr/m/it/8 1
 .....\pdfcolorstack 0 pop
@@ -821,8 +1442,8 @@ Completed box being shipped out [1]
 ....\penalty 10000
 ....\mark{{Index}{Index}}
 ....\penalty 10000
-....\hbox(43.0+3.30003)x385.0, glue set 5.0fil
-.....\vbox(43.0+3.30003)x187.5
+....\hbox(97.0+3.30003)x385.0, glue set 5.0fil
+.....\vbox(97.0+3.30003)x187.5
 ......\glue 0.0 plus -2.0
 ......\glue(\splittopskip) 3.704 plus 2.0
 ......\hbox(6.296+0.0)x187.5, glue set 89.96602fil
@@ -877,14 +1498,14 @@ Completed box being shipped out [1]
 .......\pdfendlink
 .......\T1/lmr/m/n/9 ,
 .......\glue 3.08331 plus 1.92706 minus 0.8222
-.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.7}
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.8}
 .......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .......\T1/lmr/m/n/9 2
 .......\pdfcolorstack 0 pop
 .......\pdfendlink
 .......\T1/lmr/m/n/9 ,
 .......\glue 3.08331 plus 1.92706 minus 0.8222
-.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.8}
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.9}
 .......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .......\T1/lmr/m/n/9 3
 .......\pdfcolorstack 0 pop
@@ -960,7 +1581,7 @@ Completed box being shipped out [1]
 .......\pdfendlink
 .......\T1/lmr/m/n/9 ,
 .......\glue 3.08331 plus 1.92706 minus 0.8222
-.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.9}
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.10}
 .......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .......\T1/lmr/m/n/9 4
 .......\pdfcolorstack 0 pop
@@ -968,14 +1589,11 @@ Completed box being shipped out [1]
 .......\penalty 10000
 .......\glue(\parfillskip) -15.0
 .......\glue(\rightskip) 15.0
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\pdfcolorstack 0 push {0 g 0 G}
-.....\rule(*+*)x0.0
-.....\pdfcolorstack 0 pop
-.....\glue 0.0 plus 1.0fil minus 1.0fil
-.....\vbox(43.0+0.0)x187.5, glue set 18.69997fil
-......\glue 0.0 plus -2.0
-......\glue(\splittopskip) 3.704 plus 2.0
+......\glue 10.0 plus 2.0 minus 3.0
+......\glue 0.0
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 1.40396
 ......\hbox(6.296+0.0)x187.5, glue set 90.40352fil
 .......\hbox(0.0+0.0)x0.0
 .......\hbox(0.0+0.0)x0.0
@@ -1031,7 +1649,7 @@ Completed box being shipped out [1]
 .......\mathon
 .......\vbox(5.6945+1.9999)x4.625
 ........\hbox(5.6945+0.0)x4.625
-.........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.5}
+.........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.6}
 .........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
 .........\T1/lmr/m/n/9 1
 .........\pdfcolorstack 0 pop
@@ -1042,7 +1660,569 @@ Completed box being shipped out [1]
 .......\penalty 10000
 .......\glue(\parfillskip) -15.0
 .......\glue(\rightskip) 15.0
-......\glue 0.0 plus 1.0fil
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 1.44997
+......\hbox(6.25+0.0)x187.5, glue set 126.81032fill
+.......\hbox(0.0+0.0)x0.0
+.......\T1/lmss/m/n/9 f
+.......\T1/lmss/m/n/9 o
+.......\kern0.25694
+.......\T1/lmss/m/n/9 o
+.......\kern 0.0
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\T1/lmr/m/n/9 c
+.......\T1/lmr/m/n/9 o
+.......\T1/lmr/m/n/9 m
+.......\discretionary
+........\T1/lmr/m/n/9 -
+.......\T1/lmr/m/n/9 m
+.......\T1/lmr/m/n/9 a
+.......\T1/lmr/m/n/9 n
+.......\T1/lmr/m/n/9 d
+.......\T1/lmr/m/n/9 s
+.......\T1/lmr/m/n/9 :
+.......\glue 0.0 plus 1.0fill
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\penalty 10000
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 3.30003
+......\hbox(7.69997+3.30003)x187.5, glue set 119.18346fill
+.......\hbox(0.0+0.0)x0.0
+.......\rule(*+*)x0.0
+.......\penalty 10000
+.......\glue 15.0
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 \
+.......\T1/lmtt/m/n/9 f
+.......\T1/lmtt/m/n/9 o
+.......\T1/lmtt/m/n/9 o
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 i
+.......\T1/lmtt/m/n/9 f
+.......\T1/lmtt/m/n/9 :
+.......\T1/lmtt/m/n/9 n
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\leaders 0.0 plus 1.0fill
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 500
+.......\rule(7.69997+3.30003)x0.0
+.......\penalty 10000
+.......\leaders 0.0 plus 1.0fil
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.13}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmr/m/n/9 5
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\pdfcolorstack 0 push {0 g 0 G}
+.....\rule(*+*)x0.0
+.....\pdfcolorstack 0 pop
+.....\glue 0.0 plus 1.0fil minus 1.0fil
+.....\vbox(97.0+3.30003)x187.5
+......\glue 0.0 plus -2.0
+......\glue(\splittopskip) 2.30003 plus 2.0
+......\hbox(7.69997+3.30003)x187.5, glue set 99.35832fill
+.......\hbox(0.0+0.0)x0.0
+.......\rule(*+*)x0.0
+.......\penalty 10000
+.......\glue 15.0
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 \
+.......\T1/lmtt/m/n/9 f
+.......\T1/lmtt/m/n/9 o
+.......\T1/lmtt/m/n/9 o
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 i
+.......\T1/lmtt/m/n/9 f
+.......\T1/lmtt/m/n/9 :
+.......\T1/lmtt/m/n/9 n
+.......\T1/lmtt/m/n/9 T
+.......\T1/lmtt/m/n/9 F
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\leaders 0.0 plus 1.0fill
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 500
+.......\rule(7.69997+3.30003)x0.0
+.......\penalty 10000
+.......\leaders 0.0 plus 1.0fil
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{page.1}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmr/m/it/9 1
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\T1/lmr/m/n/9 ,
+.......\glue 3.08331 plus 1.92706 minus 0.8222
+.......\mathon
+.......\vbox(5.6945+1.9999)x4.625
+........\hbox(5.6945+0.0)x4.625
+.........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.12}
+.........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.........\T1/lmr/m/n/9 5
+.........\pdfcolorstack 0 pop
+.........\pdfendlink
+........\kern1.19994
+........\rule(0.39998+0.0)x*
+.......\mathoff
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 1.44997
+......\hbox(6.25+0.0)x187.5, glue set 92.61246fill
+.......\hbox(0.0+0.0)x0.0
+.......\T1/lmss/m/n/9 f
+.......\T1/lmss/m/n/9 o
+.......\kern0.25694
+.......\T1/lmss/m/n/9 o
+.......\kern 0.0
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\T1/lmr/m/n/9 i
+.......\discretionary replacing 2
+........\T1/lmr/m/n/9 n
+........\T1/lmr/m/n/9 -
+.......\T1/lmr/m/n/9 n
+.......\kern-0.25694
+.......\T1/lmr/m/n/9 t
+.......\T1/lmr/m/n/9 e
+.......\T1/lmr/m/n/9 r
+.......\discretionary
+........\T1/lmr/m/n/9 -
+.......\T1/lmr/m/n/9 n
+.......\T1/lmr/m/n/9 a
+.......\T1/lmr/m/n/9 l
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\T1/lmr/m/n/9 c
+.......\T1/lmr/m/n/9 o
+.......\T1/lmr/m/n/9 m
+.......\discretionary
+........\T1/lmr/m/n/9 -
+.......\T1/lmr/m/n/9 m
+.......\T1/lmr/m/n/9 a
+.......\T1/lmr/m/n/9 n
+.......\T1/lmr/m/n/9 d
+.......\T1/lmr/m/n/9 s
+.......\T1/lmr/m/n/9 :
+.......\glue 0.0 plus 1.0fill
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\penalty 10000
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 3.30003
+......\hbox(7.69997+3.30003)x187.5, glue set 109.73347fill
+.......\hbox(0.0+0.0)x0.0
+.......\rule(*+*)x0.0
+.......\penalty 10000
+.......\glue 15.0
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 \
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\penalty 10000
+.......\glue 0.0
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 f
+.......\T1/lmtt/m/n/9 o
+.......\T1/lmtt/m/n/9 o
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 i
+.......\T1/lmtt/m/n/9 f
+.......\T1/lmtt/m/n/9 :
+.......\T1/lmtt/m/n/9 n
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\leaders 0.0 plus 1.0fill
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 500
+.......\rule(7.69997+3.30003)x0.0
+.......\penalty 10000
+.......\leaders 0.0 plus 1.0fil
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.15}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmr/m/n/9 7
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 0.0
+......\hbox(7.69997+3.30003)x187.5, glue set 100.2835fill
+.......\hbox(0.0+0.0)x0.0
+.......\rule(*+*)x0.0
+.......\penalty 10000
+.......\glue 15.0
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 \
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\penalty 10000
+.......\glue 0.0
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 f
+.......\T1/lmtt/m/n/9 o
+.......\T1/lmtt/m/n/9 o
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 i
+.......\T1/lmtt/m/n/9 f
+.......\T1/lmtt/m/n/9 :
+.......\T1/lmtt/m/n/9 n
+.......\T1/lmtt/m/n/9 T
+.......\T1/lmtt/m/n/9 F
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\leaders 0.0 plus 1.0fill
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 500
+.......\rule(7.69997+3.30003)x0.0
+.......\penalty 10000
+.......\leaders 0.0 plus 1.0fil
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\mathon
+.......\vbox(5.6945+1.9999)x4.625
+........\hbox(5.6945+0.0)x4.625
+.........\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.12}
+.........\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.........\T1/lmr/m/n/9 5
+.........\pdfcolorstack 0 pop
+.........\pdfendlink
+........\kern1.19994
+........\rule(0.39998+0.0)x*
+.......\mathoff
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\glue 10.0 plus 2.0 minus 3.0
+......\glue 0.0
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 1.40396
+......\hbox(6.296+0.0)x187.5, glue set 90.114fil
+.......\hbox(0.0+0.0)x0.0
+.......\hbox(0.0+0.0)x0.0
+........\hbox(0.0+0.0)x0.0, shifted -11.0
+.........\kern -2.84526
+.........\write6{\protect \BOOKMARK [1][-]{HD.P.1}{\376\377\000P}{index1.0}% 4}
+.........\pdfdest name{HD.P.1} xyz
+.........\penalty 10000
+.........\kern 2.84526
+.......\glue 0.0 plus 1.0fil
+.......\T1/lmr/bx/n/9 P
+.......\glue 0.0 plus 1.0fil
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\penalty 10000
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 4.8
+......\hbox(6.2+1.75)x187.5, glue set 126.72217fill
+.......\hbox(0.0+0.0)x0.0
+.......\T1/lmss/m/n/9 p
+.......\kern-0.25694
+.......\T1/lmss/m/n/9 r
+.......\T1/lmss/m/n/9 g
+.......\kern 0.11604
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\T1/lmr/m/n/9 c
+.......\T1/lmr/m/n/9 o
+.......\T1/lmr/m/n/9 m
+.......\discretionary
+........\T1/lmr/m/n/9 -
+.......\T1/lmr/m/n/9 m
+.......\T1/lmr/m/n/9 a
+.......\T1/lmr/m/n/9 n
+.......\T1/lmr/m/n/9 d
+.......\T1/lmr/m/n/9 s
+.......\T1/lmr/m/n/9 :
+.......\glue 0.0 plus 1.0fill
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\penalty 10000
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 1.55003
+......\hbox(7.69997+3.30003)x187.5, glue set 38.03078fill
+.......\hbox(0.0+0.0)x0.0
+.......\rule(*+*)x0.0
+.......\penalty 10000
+.......\glue 15.0
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 \
+.......\T1/lmtt/m/n/9 p
+.......\T1/lmtt/m/n/9 r
+.......\T1/lmtt/m/n/9 g
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 n
+.......\T1/lmtt/m/n/9 e
+.......\T1/lmtt/m/n/9 w
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 c
+.......\T1/lmtt/m/n/9 o
+.......\T1/lmtt/m/n/9 n
+.......\T1/lmtt/m/n/9 d
+.......\T1/lmtt/m/n/9 i
+.......\T1/lmtt/m/n/9 t
+.......\T1/lmtt/m/n/9 i
+.......\T1/lmtt/m/n/9 o
+.......\T1/lmtt/m/n/9 n
+.......\T1/lmtt/m/n/9 a
+.......\T1/lmtt/m/n/9 l
+.......\T1/lmtt/m/n/9 :
+.......\T1/lmtt/m/n/9 N
+.......\T1/lmtt/m/n/9 n
+.......\T1/lmtt/m/n/9 n
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\leaders 0.0 plus 1.0fill
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 500
+.......\rule(7.69997+3.30003)x0.0
+.......\penalty 10000
+.......\leaders 0.0 plus 1.0fil
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.13}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmr/m/n/9 5
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\T1/lmr/m/n/9 ,
+.......\glue 3.08331 plus 1.92706 minus 0.8222
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.15}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\T1/lmr/m/n/9 7
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
+......\glue(\parskip) 0.0 plus 1.0
+......\glue(\parskip) 0.0
+......\glue(\baselineskip) 0.0
+......\hbox(7.69997+3.30003)x187.5, glue set 71.10571fill
+.......\hbox(0.0+0.0)x0.0
+.......\rule(*+*)x0.0
+.......\penalty 10000
+.......\glue 15.0
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 \
+.......\T1/lmtt/m/n/9 p
+.......\T1/lmtt/m/n/9 r
+.......\T1/lmtt/m/n/9 g
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 r
+.......\T1/lmtt/m/n/9 e
+.......\T1/lmtt/m/n/9 t
+.......\T1/lmtt/m/n/9 u
+.......\T1/lmtt/m/n/9 r
+.......\T1/lmtt/m/n/9 n
+.......\penalty 10000
+.......\glue 0.0
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 _
+.......\discretionary
+........\T1/lmtt/m/n/9 -
+.......\penalty 10000
+.......\glue 0.0
+.......\hbox(0.0+0.0)x0.0
+.......\setlanguage1 (hyphenmin 2,3)
+.......\T1/lmtt/m/n/9 t
+.......\T1/lmtt/m/n/9 r
+.......\T1/lmtt/m/n/9 u
+.......\T1/lmtt/m/n/9 e
+.......\T1/lmtt/m/n/9 :
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\leaders 0.0 plus 1.0fill
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 500
+.......\rule(7.69997+3.30003)x0.0
+.......\penalty 10000
+.......\leaders 0.0 plus 1.0fil
+........\hbox(0.97223+0.0)x5.54999, glue set 1.49025fil
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.........\T1/lmr/m/n/9 .
+.........\glue 0.0 plus 1.0fil minus 1.0fil
+.......\penalty 10000
+.......\glue 3.08331 plus 1.54166 minus 1.02777
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.14}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\setlanguage0 (hyphenmin 2,3)
+.......\T1/lmr/m/n/9 6
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\T1/lmr/m/n/9 ,
+.......\glue 3.08331 plus 1.92706 minus 0.8222
+.......\pdfstartlink(*+*)x* attr{/Border[0 0 0]/H/I/C[1 0 0]} action goto name{HD.16}
+.......\pdfcolorstack 0 push {1 0 0 rg 1 0 0 RG}
+.......\T1/lmr/m/n/9 8
+.......\pdfcolorstack 0 pop
+.......\pdfendlink
+.......\penalty 10000
+.......\glue(\parfillskip) -15.0
+.......\glue(\rightskip) 15.0
 .....\hbox(3.87498+1.75)x0.0, glue set - 5.139fil
 ......\hbox(3.87498+1.75)x5.139
 ......\glue 0.0 plus 1.0fil minus 1.0fil


### PR DESCRIPTION
Fixes #730

Before
<img width="741" alt="image" src="https://github.com/latex3/latex3/assets/6376638/e50f5aba-1bab-4691-b243-4713d05535fa">

After
<img width="720" alt="image" src="https://github.com/latex3/latex3/assets/6376638/8d178384-9054-4669-93b7-7085e807d459">

Currently the color of `TF` of public conditionals is also changed. Is this change welcome?