### PR TITLE
Tag indented \ProvidesExpl... lines

### DIFF
--- a/build-config.lua
+++ b/build-config.lua
@@ -59,8 +59,8 @@ function update_tag(file,content,tagname,tagdate)
   end
   if string.match(file,"%.dtx$") then
     content = string.gsub(content,
-      "\n\\ProvidesExpl" .. "(%w+ *{[^}]+} *){" .. iso .. "}",
-      "\n\\ProvidesExpl%1{" .. tagname .. "}")
+      "\n( *)\\ProvidesExpl" .. "(%w+ *{[^}]+} *){" .. iso .. "}",
+      "\n%1\\ProvidesExpl%2{" .. tagname .. "}")
     return string.gsub(content,
       "\n%% \\date{Released " .. iso .. "}\n",
       "\n%% \\date{Released " .. tagname .. "}\n")

--- a/l3packages/xtemplate/xtemplate.dtx
+++ b/l3packages/xtemplate/xtemplate.dtx
@@ -5,7 +5,7 @@
 % Copyright (C) 1999 Frank Mittelbach, Chris Rowley, David Carlisle
 %           (C) 2004-2010 Frank Mittelbach, The LaTeX Project
 %           (C) 2011-2024 The LaTeX Project
-%\
+%
 % It may be distributed and/or modified under the conditions of the
 % LaTeX Project Public License (LPPL), either version 1.3c of this
 % license or (at your option) any later version.  The latest version
@@ -695,8 +695,8 @@
 %
 % \begin{macro}{\DeclareRestrictedTemplate}
 % \begin{macro}{\DeclareObjectType}
-%   If the new kernel code is not loaded, make a couple of compatibility
-%   additions. Otherwise, hand over to the frozen version. 
+%   If the new kernel code is not loaded, hand over to the frozen version.
+%   Otherwise, make a couple of compatibility additions.
 %    \begin{macrocode}
 \@ifundefined{NewTemplateType}
   {%
@@ -707,9 +707,9 @@
     \ProvidesExplPackage{xtemplate}{2024-02-20}{}
       {L3 Experimental prototype document functions}
     \long\protected\def\DeclareRestrictedTemplate#1#2#3#4{%
-        \DeclareTemplateCopy{#1}{#3}{#2}%
-        \EditTemplateDefaults{#1}{#3}{#4}%
-      }%
+      \DeclareTemplateCopy{#1}{#3}{#2}%
+      \EditTemplateDefaults{#1}{#3}{#4}%
+    }%
   }
 \ExplSyntaxOn
 \cs_new_protected:Npn \DeclareObjectType #1#2

--- a/l3packages/xtemplate/xtemplate.dtx
+++ b/l3packages/xtemplate/xtemplate.dtx
@@ -704,7 +704,7 @@
     \endinput
   }
   {%
-    \ProvidesExplPackage{xtemplate}{2023-10-10}{}
+    \ProvidesExplPackage{xtemplate}{2024-02-20}{}
       {L3 Experimental prototype document functions}
     \long\protected\def\DeclareRestrictedTemplate#1#2#3#4{%
         \DeclareTemplateCopy{#1}{#3}{#2}%


### PR DESCRIPTION
The updated date (2024-02-20) in `xtemplate.dtx` is the same as those in other `l3packages` packages.

```
$ rg --no-heading '^\s*\\ProvidesExpl' -g 'l3packages/**/*.dtx' -g '!examples'
l3packages/xparse/xparse.dtx:1082:\ProvidesExplPackage{xparse}{2024-02-20}{}
l3packages/xtemplate/xtemplate.dtx:707:    \ProvidesExplPackage{xtemplate}{2024-02-20}{}
l3packages/l3keys2e/l3keys2e.dtx:157:\ProvidesExplPackage{l3keys2e}{2024-02-20}{}
l3packages/xfp/xfp.dtx:174:\ProvidesExplPackage{xfp}{2024-02-20}{}
```