### PR TITLE
Move `specialformats` settings to root config

### DIFF
--- a/build-config.lua
+++ b/build-config.lua
@@ -10,6 +10,19 @@ checksuppfiles  = checksuppfiles  or
     "regression-test.cfg",
     "sRGB_v4_ICC_preference.icc"
   }
+
+specialformats = specialformats or {}
+specialformats.latex =
+  {
+    ["etex-dvips"] = {binary = "etex", format = "latex"},
+    ["etex-dvisvgm"] =
+      {
+        binary = "etex",
+        format = "latex",
+        tokens = "\\ExplSyntaxOn\\sys_load_backend:n{dvisvgm}\\ExplSyntaxOff"
+      }
+  }
+
 tagfiles = tagfiles or {"*.dtx", "README.md", "CHANGELOG.md", "*.ins"}
 unpacksuppfiles = unpacksuppfiles or
   {

--- a/l3experimental/l3draw/build.lua
+++ b/l3experimental/l3draw/build.lua
@@ -12,21 +12,6 @@ maindir = "../.."
 
 typesetfiles = {"l3draw.dtx", "l3draw-code.tex"}
 
--- Set up to allow testing dvips, etc.
-specialformats = specialformats or {}
-specialformats.latex =
-  {
-    luatex = {binary = "luahbtex",format = "lualatex"},
-    ptex  = {binary = "eptex"},
-    uptex = {binary = "euptex"},
-    ["etex-dvips"] = {binary = "etex", format = "latex"},
-    ["etex-dvisvgm"] =
-      {
-        binary = "etex",
-        format = "latex",
-        tokens = "\\PassOptionsToPackage{backend=dvisvgm}{expl3}"
-      }
-  }
 checkengines =
   {"pdftex", "luatex", "xetex", "etex-dvips", "etex-dvisvgm", "uptex"}
 

--- a/l3experimental/l3graphics/build.lua
+++ b/l3experimental/l3graphics/build.lua
@@ -10,21 +10,6 @@ module = "l3graphics"
 -- Location of main directory: use Unix-style path separators
 maindir = "../.."
 
--- Set up to allow testing dvips, etc.
-specialformats = specialformats or {}
-specialformats.latex =
-  {
-    luatex = {binary = "luahbtex",format = "lualatex"},
-    ptex  = {binary = "eptex"},
-    uptex = {binary = "euptex"},
-    ["etex-dvips"] = {binary = "etex", format = "latex"},
-    ["etex-dvisvgm"] =
-      {
-        binary = "etex",
-        format = "latex",
-        tokens = "\\PassOptionsToPackage{backend=dvisvgm}{expl3}"
-      }
-  }
 checkengines =
   {"pdftex", "luatex", "xetex", "etex-dvips", "etex-dvisvgm", "uptex"}
 

--- a/l3experimental/l3opacity/build.lua
+++ b/l3experimental/l3opacity/build.lua
@@ -10,21 +10,6 @@ module = "l3opacity"
 -- Location of main directory: use Unix-style path separators
 maindir = "../.."
 
--- Set up to allow testing dvips, etc.
-specialformats = specialformats or {}
-specialformats.latex =
-  {
-    luatex = {binary = "luahbtex",format = "lualatex"},
-    ptex  = {binary = "eptex"},
-    uptex = {binary = "euptex"},
-    ["etex-dvips"] = {binary = "etex", format = "latex"},
-    ["etex-dvisvgm"] =
-      {
-        binary = "etex",
-        format = "latex",
-        tokens = "\\ExplSyntaxOn\\sys_load_backend:n{dvisvgm}\\ExplSyntaxOff"
-      }
-  }
 checkengines =
   {"pdftex", "luatex", "xetex", "etex-dvips", "etex-dvisvgm", "uptex"}
 

--- a/l3kernel/config-backend.lua
+++ b/l3kernel/config-backend.lua
@@ -1,19 +1,4 @@
 testfiledir  = "testfiles-backend"
 
--- Set up to allow testing dvips, etc.
-specialformats = specialformats or {}
-specialformats.latex =
-  {
-    luatex = {binary = "luahbtex",format = "lualatex"},
-    ptex  = {binary = "eptex"},
-    uptex = {binary = "euptex"},
-    ["etex-dvips"] = {binary = "etex", format = "latex"},
-    ["etex-dvisvgm"] =
-      {
-        binary = "etex",
-        format = "latex",
-        tokens = "\\ExplSyntaxOn\\sys_load_backend:n{dvisvgm}\\ExplSyntaxOff"
-      }
-  }
 checkengines =
   {"pdftex", "luatex", "xetex", "etex-dvips", "etex-dvisvgm", "uptex"}


### PR DESCRIPTION
Test suites which don't check on `etex-dvips` and `etex-dvisvgm` special formats are not influenced.