### PR TITLE
Remove an unnecessary parenthese in `l3doc.dtx`

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1655,7 +1655,7 @@ and all files in that bundle must be distributed together.
 %
 % \begin{macro}{\l@section, \l@subsection}
 %   Customise the table of contents (as we have so many sections).
-%   Different design and/or structure is called for).
+%   Different design and/or structure is called for.
 %    \begin{macrocode}
 \@addtoreset{section}{part}
 \cs_gset:Npn \l@section #1#2


### PR DESCRIPTION
Remove an unnecessary parenthese in `l3doc.dtx`.