### PR TITLE
Fix softpath markers with the same meaning

### DIFF
--- a/l3experimental/CHANGELOG.md
+++ b/l3experimental/CHANGELOG.md
@@ -17,6 +17,7 @@ this project uses date-based 'snapshot' version identifiers.
 - Interaction between drawing rotation and shift (issue \#1483)
 - Shifting not applied to `\draw_path_rectangle:n` (issue \#1486)
 - Out of boundary lines drawn by `\draw_path_grid:nnn` (issue \#1489)
+- Two softpath markers with the same meaning in l3draw (issue \#1492)
 
 ## [2024-02-20]
 

--- a/l3experimental/l3draw/l3draw-softpath.dtx
+++ b/l3experimental/l3draw/l3draw-softpath.dtx
@@ -260,12 +260,14 @@
   { \@@_backend_lineto:nn {#1} {#2} }
 \cs_new_protected:Npn \@@_softpath_moveto_op:nn #1#2
   { \@@_backend_moveto:nn {#1} {#2} }
-\cs_new_protected:Npn \@@_softpath_roundpoint_op:nn #1#2 { }
+\cs_new_protected:Npn \@@_softpath_roundpoint_op:nn #1#2
+  { \@@_softpath_roundpoint_op:nn }
 \cs_new_protected:Npn \@@_softpath_rectangle_opi:nn #1#2 
   { \@@_softpath_rectangle_opi:nnNnn {#1} {#2} }
 \cs_new_protected:Npn \@@_softpath_rectangle_opi:nnNnn #1#2#3#4#5
   { \@@_backend_rectangle:nnnn {#1} {#2} {#4} {#5} }
-  \cs_new_protected:Npn \@@_softpath_rectangle_opii:nn #1#2 { }
+\cs_new_protected:Npn \@@_softpath_rectangle_opii:nn #1#2
+  { \@@_softpath_rectangle_opii:nn }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3experimental/l3draw/l3draw-softpath.dtx
+++ b/l3experimental/l3draw/l3draw-softpath.dtx
@@ -163,6 +163,7 @@
 %    \end{macrocode}
 % \end{variable}
 %
+% \begin{macro}{\@@_softpath_closepath:}
 % \begin{macro}{\@@_softpath_curveto:nnnnnn}
 % \begin{macro}
 %   {
@@ -223,6 +224,7 @@
   }
 \cs_generate_variant:Nn \@@_softpath_roundpoint:nn { VV }
 %    \end{macrocode}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 % \end{macro}

--- a/l3experimental/l3draw/testfiles/m3draw003.etex-dvips.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw003.etex-dvips.tlg
@@ -721,6 +721,44 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
+\hbox(85.75827+0.0)x85.75827
+.\hbox(85.75827+0.0)x85.75827
+..\glue -56.70552
+..\hbox(0.0+0.0)x0.0, shifted 56.70552
+...\special{ps::[begin]}
+...\special{ps::@beginspecial}
+...\special{ps::0.39851 setlinewidth}
+...\special{color push gray 0}
+...\special{ps:SDict begin /color.sc {} def end}
+...\special{ps::0 setlinecap}
+...\special{ps::0 setlinejoin}
+...\special{ps::10 setmiterlimit}
+...\special{ps::[] 0 setdash}
+...\hbox(0.0+0.0)x0.0
+....\special{ps::28.34647 28.34647 56.69293 56.69293 moveto dup 0 rlineto exch 0 exch rlineto neg 0 rlineto closepath}
+....\special{ps::139.73978 141.7323 moveto}
+....\special{ps::115.37837 141.7323 lineto}
+....\special{ps::114.27794 141.7323 113.38585 140.84023 113.38585 139.73978 curveto}
+....\special{ps::113.38585 115.37837 lineto}
+....\special{ps::113.38585 114.27794 114.27794 113.38585 115.37837 113.38585 curveto}
+....\special{ps::139.73978 113.38585 lineto}
+....\special{ps::140.84023 113.38585 141.7323 114.27794 141.7323 115.37837 curveto}
+....\special{ps::141.7323 139.73978 lineto}
+....\special{ps::141.7323 140.84023 140.84023 141.7323 139.73978 141.7323 curveto}
+....\special{ps::closepath}
+....\special{ps::113.38585 113.38585 moveto}
+....\special{ps::gsave}
+....\special{ps::color.sc}
+....\special{ps::stroke}
+....\special{ps::grestore}
+....\special{ps::newpath}
+...\special{ps::@endspecial}
+...\special{ps::[end]}
+...\special{color pop}
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
 \hbox(28.85275+0.0)x28.85275
 .\hbox(28.85275+0.0)x28.85275
 ..\glue -56.70552

--- a/l3experimental/l3draw/testfiles/m3draw003.etex-dvisvgm.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw003.etex-dvisvgm.tlg
@@ -684,6 +684,34 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
+\hbox(85.75827+0.0)x85.75827
+.\hbox(85.75827+0.0)x85.75827
+..\glue -56.70552
+..\hbox(0.0+0.0)x0.0, shifted 56.70552
+...\special{dvisvgm:raw <g>{?nl}}
+...\special{dvisvgm:raw <g transform="translate({?x},{?y}) scale(1,-1)">{?nl}}
+...\special{dvisvgm:raw <g stroke-width="0.4">{?nl}}
+...\special{color push gray 0}
+...\special{dvisvgm:raw <g fill-rule="nonzero">{?nl}}
+...\special{dvisvgm:raw <g stroke-linecap="butt">{?nl}}
+...\special{dvisvgm:raw <g stroke-linejoin="miter">{?nl}}
+...\special{dvisvgm:raw <g stroke-miterlimit="10">{?nl}}
+...\special{dvisvgm:raw <g stroke-dasharray="none" stroke-offset="0">{?nl}}
+...\hbox(0.0+0.0)x0.0
+....\special{dvisvgm:raw <path d="M 56.90552 56.90552h 28.45276 v 28.45276 h -28.45276 Z M 140.2638 142.2638 L 115.81104 142.2638 C 114.70647 142.2638 113.81104 141.36836 113.81104 140.2638 L 113.81104 115.81104 C 113.81104 114.70647 114.70647 113.81104 115.81104 113.81104 L 140.2638 113.81104 C 141.36836 113.81104 142.2638 114.70647 142.2638 115.81104 L 142.2638 140.2638 C 142.2638 141.36836 141.36836 142.2638 140.2638 142.2638 Z M 113.81104 113.81104" style="fill:none"/>{?nl}}
+...\special{dvisvgm:raw </g>{?nl}}
+...\special{dvisvgm:raw </g>{?nl}}
+...\special{dvisvgm:raw </g>{?nl}}
+...\special{dvisvgm:raw </g>{?nl}}
+...\special{dvisvgm:raw </g>{?nl}}
+...\special{dvisvgm:raw </g>{?nl}}
+...\special{dvisvgm:raw </g>{?nl}}
+...\special{dvisvgm:raw </g>{?nl}}
+...\special{color pop}
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
 \hbox(28.85275+0.0)x28.85275
 .\hbox(28.85275+0.0)x28.85275
 ..\glue -56.70552

--- a/l3experimental/l3draw/testfiles/m3draw003.lvt
+++ b/l3experimental/l3draw/testfiles/m3draw003.lvt
@@ -191,6 +191,16 @@
       }
     \test:n
       {
+        \draw_path_rectangle:nn
+          { \draw_point_vec:nn { 2 } { 2 } }
+          { \draw_point_vec:nn { 1 } { 1 } }
+        \draw_path_corner_arc:nn { 2pt } { 2pt }
+        \draw_path_rectangle:nn
+          { \draw_point_vec:nn { 4 } { 4 } }
+          { \draw_point_vec:nn { 1 } { 1 } }
+      }
+    \test:n
+      {
         \draw_path_rectangle_corners:nn
           { \draw_point_vec:nn { 2 } { 2 } }
           { \draw_point_vec:nn { 3 } { 3 } }

--- a/l3experimental/l3draw/testfiles/m3draw003.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw003.tlg
@@ -560,6 +560,37 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
+\hbox(85.75827+0.0)x85.75827
+.\hbox(85.75827+0.0)x85.75827
+..\glue -56.70552
+..\hbox(0.0+0.0)x0.0, shifted 56.70552
+...\pdfsave
+...\pdfliteral{0.39851 w}
+...\pdfcolorstack 0 push {0 g 0 G}
+...\pdfliteral{0 J}
+...\pdfliteral{0 j}
+...\pdfliteral{10 M}
+...\pdfliteral{[] 0 d}
+...\hbox(0.0+0.0)x0.0
+....\pdfliteral{56.69293 56.69293 28.34647 28.34647 re}
+....\pdfliteral{139.73978 141.7323 m}
+....\pdfliteral{115.37837 141.7323 l}
+....\pdfliteral{114.27794 141.7323 113.38585 140.84023 113.38585 139.73978 c}
+....\pdfliteral{113.38585 115.37837 l}
+....\pdfliteral{113.38585 114.27794 114.27794 113.38585 115.37837 113.38585 c}
+....\pdfliteral{139.73978 113.38585 l}
+....\pdfliteral{140.84023 113.38585 141.7323 114.27794 141.7323 115.37837 c}
+....\pdfliteral{141.7323 139.73978 l}
+....\pdfliteral{141.7323 140.84023 140.84023 141.7323 139.73978 141.7323 c}
+....\pdfliteral{h}
+....\pdfliteral{113.38585 113.38585 m}
+....\pdfliteral{S}
+...\pdfrestore
+...\pdfcolorstack 0 pop
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
 \hbox(28.85275+0.0)x28.85275
 .\hbox(28.85275+0.0)x28.85275
 ..\glue -56.70552

--- a/l3experimental/l3draw/testfiles/m3draw003.uptex.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw003.uptex.tlg
@@ -721,6 +721,44 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
+\hbox(85.75827+0.0)x85.75827
+.\hbox(85.75827+0.0)x85.75827
+..\glue -56.70552
+..\hbox(0.0+0.0)x0.0, shifted 56.70552
+...\special{ps::[begin]}
+...\special{ps::@beginspecial}
+...\special{ps::0.39851 setlinewidth}
+...\special{color push gray 0}
+...\special{ps:SDict begin /color.sc {} def end}
+...\special{ps::0 setlinecap}
+...\special{ps::0 setlinejoin}
+...\special{ps::10 setmiterlimit}
+...\special{ps::[] 0 setdash}
+...\hbox(0.0+0.0)x0.0
+....\special{ps::28.34647 28.34647 56.69293 56.69293 moveto dup 0 rlineto exch 0 exch rlineto neg 0 rlineto closepath}
+....\special{ps::139.73978 141.7323 moveto}
+....\special{ps::115.37837 141.7323 lineto}
+....\special{ps::114.27794 141.7323 113.38585 140.84023 113.38585 139.73978 curveto}
+....\special{ps::113.38585 115.37837 lineto}
+....\special{ps::113.38585 114.27794 114.27794 113.38585 115.37837 113.38585 curveto}
+....\special{ps::139.73978 113.38585 lineto}
+....\special{ps::140.84023 113.38585 141.7323 114.27794 141.7323 115.37837 curveto}
+....\special{ps::141.7323 139.73978 lineto}
+....\special{ps::141.7323 140.84023 140.84023 141.7323 139.73978 141.7323 curveto}
+....\special{ps::closepath}
+....\special{ps::113.38585 113.38585 moveto}
+....\special{ps::gsave}
+....\special{ps::color.sc}
+....\special{ps::stroke}
+....\special{ps::grestore}
+....\special{ps::newpath}
+...\special{ps::@endspecial}
+...\special{ps::[end]}
+...\special{color pop}
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
 \hbox(28.85275+0.0)x28.85275
 .\hbox(28.85275+0.0)x28.85275
 ..\glue -56.70552

--- a/l3experimental/l3draw/testfiles/m3draw003.xetex.tlg
+++ b/l3experimental/l3draw/testfiles/m3draw003.xetex.tlg
@@ -560,6 +560,37 @@ l. ...  }
 <argument> \l_tmpa_box 
 l. ...  }
 > \box...=
+\hbox(85.75827+0.0)x85.75827
+.\hbox(85.75827+0.0)x85.75827
+..\glue -56.70552
+..\hbox(0.0+0.0)x0.0, shifted 56.70552
+...\special{x:gsave}
+...\special{pdf:literal 0.39851 w}
+...\special{pdf:bc [0]}
+...\special{pdf:literal 0 J}
+...\special{pdf:literal 0 j}
+...\special{pdf:literal 10 M}
+...\special{pdf:literal [] 0 d}
+...\hbox(0.0+0.0)x0.0
+....\special{pdf:literal 56.69293 56.69293 28.34647 28.34647 re}
+....\special{pdf:literal 139.73978 141.7323 m}
+....\special{pdf:literal 115.37837 141.7323 l}
+....\special{pdf:literal 114.27794 141.7323 113.38585 140.84023 113.38585 139.73978 c}
+....\special{pdf:literal 113.38585 115.37837 l}
+....\special{pdf:literal 113.38585 114.27794 114.27794 113.38585 115.37837 113.38585 c}
+....\special{pdf:literal 139.73978 113.38585 l}
+....\special{pdf:literal 140.84023 113.38585 141.7323 114.27794 141.7323 115.37837 c}
+....\special{pdf:literal 141.7323 139.73978 l}
+....\special{pdf:literal 141.7323 140.84023 140.84023 141.7323 139.73978 141.7323 c}
+....\special{pdf:literal h}
+....\special{pdf:literal 113.38585 113.38585 m}
+....\special{pdf:literal S}
+...\special{x:grestore}
+...\special{pdf:ec}
+! OK.
+<argument> \l_tmpa_box 
+l. ...  }
+> \box...=
 \hbox(28.85275+0.0)x28.85275
 .\hbox(28.85275+0.0)x28.85275
 ..\glue -56.70552


### PR DESCRIPTION
Fixes #1492.

The Changelog entry may be improved, and might conflict with #1490.

Theoretically only one of the two markers needs to be patched quark-like, but I changed both of them.