### PR TITLE
Generate standalone package (`l3doc.sty`) from l3doc.dtx

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -48,6 +48,7 @@ and all files in that bundle must be distributed together.
 \postamble
 \endpostamble
 \generate{\file{l3doc.cls}{\from{l3doc.dtx}{class,cfg}}}
+\generate{\file{l3doc.sty}{\from{l3doc.dtx}{package,cfg}}}
 %\generate{\file{l3doc.ist}{\from{l3doc.dtx}{docist}}}
 \ifx\fmtname\nameofplainTeX
   \expandafter\endbatchfile
@@ -71,9 +72,20 @@ and all files in that bundle must be distributed together.
 % This isn't included in the typeset documentation because it's a bit
 % ugly:
 %<*class>
-\ProvidesExplClass{l3doc}{2024-02-20}{}
+\ProvidesExplClass
+%</class>
+%<*package>
+\ProvidesExplPackage
+%</package>
+%<*class|package>
+  {l3doc}{2024-02-20}{}
+%</class|package>
+%<*class>
   {L3 Experimental documentation class}
 %</class>
+%<*package>
+  {L3 Experimental documentation package}
+%</package>
 % \fi
 %
 % \title{The \cls{l3doc} class -- experimental\thanks{%
@@ -639,7 +651,7 @@ and all files in that bundle must be distributed together.
 % \section{\pkg{l3doc} implementation}
 %
 %    \begin{macrocode}
-%<*class>
+%<*class|package>
 %    \end{macrocode}
 %
 %    \begin{macrocode}
@@ -1451,7 +1463,7 @@ and all files in that bundle must be distributed together.
         \bool_gset_true:N \g_@@_typeset_documentation_bool
         \bool_gset_true:N \g_@@_typeset_implementation_bool
       } ,
-    onlydoc .code:n = 
+    onlydoc .code:n =
       {
         \bool_gset_true:N \g_@@_typeset_documentation_bool
         \bool_gset_false:N \g_@@_typeset_implementation_bool
@@ -1501,8 +1513,15 @@ and all files in that bundle must be distributed together.
 % \subsection{Class and package loading}
 %
 %    \begin{macrocode}
+%</class|package>
+%<*class>
 \LoadClass{article}
+%</class>
+%<*class|package>
 \RequirePackage{doc}
+%    \end{macrocode}
+%
+%    \begin{macrocode}
 \RequirePackage
   {
     array,
@@ -1616,7 +1635,15 @@ and all files in that bundle must be distributed together.
 % \end{macro}
 % \end{macro}
 %
+%    \begin{macrocode}
+%</class|package>
+%    \end{macrocode}
+%
 % \subsection{Design}
+%
+%    \begin{macrocode}
+%<*class>
+%    \end{macrocode}
 %
 % Increase the text width slightly so that width the standard fonts
 % 72~columns of code may appear in a \env{macrocode} environment.
@@ -1679,7 +1706,15 @@ and all files in that bundle must be distributed together.
 %    \end{macrocode}
 % \end{macro}
 %
+%    \begin{macrocode}
+%</class>
+%    \end{macrocode}
+%
 % \subsection{Text markup}
+%
+%    \begin{macrocode}
+%<*class|package>
+%    \end{macrocode}
 %
 % Make "|" and |"| be \enquote{short verb} characters, but not in the
 % document preamble, where an active character may interfere with
@@ -2429,7 +2464,7 @@ and all files in that bundle must be distributed together.
       } ,
     added .code:n = { \@@_date_set_past:Nn \l_@@_date_added_tl {#1} },
     updated .code:n = { \@@_date_set_past:Nn \l_@@_date_updated_tl {#1} } ,
-    deprecated .bool_set:N = \l_@@_macro_deprecated_bool , 
+    deprecated .bool_set:N = \l_@@_macro_deprecated_bool ,
     no-user-doc .bool_set:N = \l_@@_macro_nodoc_bool ,
     tested .code:n = { } ,
     label .code:n =
@@ -2880,7 +2915,7 @@ and all files in that bundle must be distributed together.
         \msg_warning:nnnn { l3doc } { deprecated-option }
           { aux } { function/macro }
       } ,
-    deprecated .bool_set:N = \l_@@_macro_deprecated_bool , 
+    deprecated .bool_set:N = \l_@@_macro_deprecated_bool ,
     internal .value_forbidden:n = true ,
     internal .code:n =
       { \bool_set_true:N \l_@@_macro_internal_bool } ,
@@ -3440,7 +3475,7 @@ and all files in that bundle must be distributed together.
 %   For describing package options: retained for consistency, but updated for
 %   \pkg{doc}~v3.
 %    \begin{macrocode}
-\NewDocElement[idxtype = option, idxgroup = options]{Option}{optionenv}  
+\NewDocElement[idxtype = option, idxgroup = options]{Option}{optionenv}
 %    \end{macrocode}
 % \end{macro}
 %
@@ -3553,13 +3588,13 @@ and all files in that bundle must be distributed together.
 % The environments \env{function} and \env{variable} are boxes
 % and so looses footnotes. The following implements support.
 % It relies currently on an internal from hyperref to get the correct targets.
-% 
+%
 %    \begin{macrocode}
 \providecommand\Hy@footnote@currentHref{}
 \prop_new:N\g_@@_fnmark_prop
-\cs_new_protected:Npn \@@_fn_store: 
-  { 
-    \prop_gput:Nee\g_@@_fnmark_prop 
+\cs_new_protected:Npn \@@_fn_store:
+  {
+    \prop_gput:Nee\g_@@_fnmark_prop
       {fn\int_use:N\c@footnote}{{\Hy@footnote@currentHref}{\int_use:N\c@footnote}}
   }
 \cs_new_protected:Npn \@@_fn_restore:n  #1
@@ -3568,18 +3603,18 @@ and all files in that bundle must be distributed together.
     \tl_gset:Ne\Hy@footnote@currentHref
       {\exp_last_unbraced:NV\use_i:nn \l_@@_tmpa_tl }
     \setcounter{footnote}{\exp_last_unbraced:NV\use_ii:nn \l_@@_tmpa_tl}
-  }  
+  }
 
 \cs_generate_variant:Nn \hook_gput_next_code:nn {ne}
 \cs_new_protected:Npn \@@_fn_footnote:nn #1 #2
   {
     \footnotemark
-    \@@_fn_store: 
+    \@@_fn_store:
     \hook_gput_next_code:ne {env/#1/after}
       {\exp_not:N\@@_fn_restore:n{\int_use:N\c@footnote}{\exp_not:n{\footnotetext{#2}}}}}
 
 \AddToHook{env/function/begin}{\def\footnote{\@@_fn_footnote:nn{function}}}
-\AddToHook{env/variable/begin}{\def\footnote{\@@_fn_footnote:nn{variable}}} 
+\AddToHook{env/variable/begin}{\def\footnote{\@@_fn_footnote:nn{variable}}}
 %    \end{macrocode}
 %
 % \subsection{Documenting templates}
@@ -3678,7 +3713,7 @@ and all files in that bundle must be distributed together.
 %    We also need to support doc V3 \cs{MaybeStop} if it is around
 %    (which may not be the case).
 %    \begin{macrocode}
-\cs_if_exist:NT \MaybeStop  
+\cs_if_exist:NT \MaybeStop
   { \RenewCommandCopy \MaybeStop \StopEventually }
 %    \end{macrocode}
 %
@@ -4678,7 +4713,7 @@ and all files in that bundle must be distributed together.
 %
 %
 %    \begin{macrocode}
-%</class>
+%</class|package>
 %    \end{macrocode}
 %
 % \subsection{Internal macros for \LaTeX3 sources}


### PR DESCRIPTION
When creating a document class, my intention is to utilize the class itself for setting up custom styles while employing commands pertinent to documenting implementation, such as \begin{macrocode}. Currently, I am using doc.sty to fulfill this requirement; however, the package only offers basic documentation functionality, lacking some useful utilities like \begin{macro} and \begin{variable}. Therefore, I have adjusted the DocStrip instructions to enable DocTeX to generate a standalone package (.sty).

I am unsure if this modification is appropriate, so I have only made minimal changes to the file. If deemed suitable, I am prepared to continue updating the corresponding documentation related to this modification.

Minimal working example:
```tex
% \iffalse
\documentclass{article}
\usepackage{l3doc}
\begin{document}
	\DocInput{\jobname.dtx}
\end{document}
% \fi
%
% \section{Implementation}
% \begin{variable}{\l_demo_tl}
%    \begin{macrocode}
\tl_new:N \l_demo_tl
%    \end{macrocode}
% \end{variable}
```