### PR TITLE
Support Oklab and Oklch as interface color models

### DIFF
--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -114,6 +114,14 @@
 %     single six-digit hexadecimal number
 %   \item \texttt{RGB} Red-green-blue color, with three axes, one for each of
 %     the components, values as integers from $0$ to $255$
+%   \item \texttt{oklch} Lightness-chromacity-hue color in the Oklab color space
+%     (\url{https://bottosson.github.io/posts/oklab}), which models human
+%     perception, with three axes, real values in the range $[0,1]$ for
+%     lightness, real values in the range $[0, 0.4]$ for chromacity and real
+%     values in the range $[0, 360]$ for hue.
+%   \item \texttt{oklab} Oklab color, with three axes, real values in the range
+%     $[0,1]$ for lightness and real values in the range $[-0.4, 0.4]$ for the
+%     position on the green/red- and yellow/blue-axes.
 %   \item \texttt{wave} Light wavelength, a real number in the range
 %     $380$ to $780$ (nanometres)
 % \end{itemize}
@@ -1381,6 +1389,75 @@
 %    \begin{macrocode}
 \cs_new:cpn { @@_parse_model_&spot:w } #1 , #2 \s_@@_stop
   { { gray } { #1 } }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP] {
+%     \__color_parse_model_lms:nnn, \__color_parse_model_cbrtlms:nnn,
+%     \__color_parse_model_oklab:nnn, \__color_parse_model_oklab:w
+%   }
+%   The Oklab color space is defined by first transforming the color values to
+%   the responses of the L, M and S cones of a standard human observer, then
+%   taking those responses to the power of $\frac{1}{3}$, and finally applying
+%   one more matrix transformation to obtain the $l$, $a$, and $b$ values.
+%   Here, we just go the other way round.
+%    \begin{macrocode}
+\cs_new:Nn \__color_parse_model_lms:nnn
+  {
+    \__color_parse_model_linearrgb:nnn
+      { \fp_eval:n {  4.0767416621 * #1 - 3.3077115913 * #2 + 0.2309699292 * #3 } }
+      { \fp_eval:n { -1.2684380046 * #1 + 2.6097574011 * #2 - 0.3413193965 * #3 } }
+      { \fp_eval:n { -0.0041960863 * #1 - 0.7034186147 * #2 + 1.7076147010 * #3 } }
+  }
+\cs_new:Nn \__color_parse_model_cbrtlms:nnn
+  {
+    \__color_parse_model_lms:nnn
+      { \fp_eval:n { #1 ^ 3 } }
+      { \fp_eval:n { #2 ^ 3 } }
+      { \fp_eval:n { #3 ^ 3 } }
+  }
+\cs_new:Nn \__color_parse_model_oklab:nnn
+  {
+    \__color_parse_model_cbrtlms:nnn
+      { \fp_eval:n { #1 + 0.3963377774 * #2 + 0.2158037573 * #3 } }
+      { \fp_eval:n { #1 - 0.1055613458 * #2 - 0.0638541728 * #3 } }
+      { \fp_eval:n { #1 - 0.0894841775 * #2 - 1.2914855480 * #3 } }
+  }
+\cs_new:Npn \__color_parse_model_oklab:w #1 , #2 , #3 , #4 \s__color_stop
+  { \__color_parse_model_oklab:nnn { #1 } { #2 } { #3 } }
+%    \end{macrocode}
+% \end{macro}
+% \begin{macro}[EXP]
+%   { \__color_parse_model_linearrgb:nnn, \__color_parse_model_linearrgb_aux:n }
+%   Encode the tristimulus values of the sRGB primaries according to sRGB.
+%    \begin{macrocode}
+\cs_new:Nn \__color_parse_model_linearrgb:nnn
+  {
+    { rgb }
+    {
+      \__color_parse_model_linearrgb_aux:n { #1 } ~
+      \__color_parse_model_linearrgb_aux:n { #2 } ~
+      \__color_parse_model_linearrgb_aux:n { #3 }
+    }
+  }
+\cs_new:Nn \__color_parse_model_linearrgb_aux:n
+  {
+    \fp_compare:nNnTF { #1 } < { 0.0031308 }
+      { \fp_eval:n { 12.92 * max ( 0 , #1 ) } }
+      { \fp_eval:n { 1.055 * min ( 1 , #1 ) ^ (1/2.4) - 0.055 } }
+  }
+%    \end{macrocode}
+% \end{macro}
+% \begin{macro}[EXP] { \__color_parse_model_oklch:w }
+%   Oklch is Oklab in cylinder coordinates.
+%    \begin{macrocode}
+\cs_new:Npn \__color_parse_model_oklch:w #1 , #2 , #3 , #4 \s__color_stop
+  {
+    \__color_parse_model_oklab:nnn
+      { #1 }
+      { \fp_eval:n { #2 * cosd(#3) } }
+      { \fp_eval:n { #2 * sind(#3) } }
+  }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -1392,68 +1392,112 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}[EXP] {
-%     \__color_parse_model_lms:nnn, \__color_parse_model_cbrtlms:nnn,
-%     \__color_parse_model_oklab:nnn, \__color_parse_model_oklab:w
-%   }
-%   The Oklab color space is defined by first transforming the color values to
-%   the responses of the L, M and S cones of a standard human observer, then
-%   taking those responses to the power of $\frac{1}{3}$, and finally applying
-%   one more matrix transformation to obtain the $l$, $a$, and $b$ values.
-%   Here, we just go the other way round.
+% \begin{macro}[EXP]
+%   { \@@_parse_model_linearrgb:nnn, \@@_parse_model_linearrgb_aux:n }
+a
+%   Encode the tristimulus values of the sRGB primaries according to sRGB.
+%   That is, take the actual physical light intensities of the primaries
+%   defined by the default RGB color space sRGB
+%   (\href[https://webstore.iec.ch/en/publication/6168]{IEC 61966-2-1}) and
+%   transform them with the gamma function defined in the same
+%   standard\footnote{For background information see
+%   \url{https://www.w3.org/Graphics/Color/sRGB}.}:
+%   \[ x_{\text{standard}} = \begin{case}
+%   12.92 \cdot x & x<0.0031308 \\
+%   1.055 \cdot \sqrt[2.4]x - 0.055 & x\ge0.0031308
+%   \end{case} \]
+%   Additionally clip values to the range $[0,1]$.
 %    \begin{macrocode}
-\cs_new:Nn \__color_parse_model_lms:nnn
+\cs_new:Nn \@@_parse_model_linearrgb:nnn
   {
-    \__color_parse_model_linearrgb:nnn
-      { \fp_eval:n {  4.0767416621 * #1 - 3.3077115913 * #2 + 0.2309699292 * #3 } }
-      { \fp_eval:n { -1.2684380046 * #1 + 2.6097574011 * #2 - 0.3413193965 * #3 } }
-      { \fp_eval:n { -0.0041960863 * #1 - 0.7034186147 * #2 + 1.7076147010 * #3 } }
+    { rgb }
+    {
+      \@@_parse_model_linearrgb_aux:n { #1 } ~
+      \@@_parse_model_linearrgb_aux:n { #2 } ~
+      \@@_parse_model_linearrgb_aux:n { #3 }
+    }
   }
-\cs_new:Nn \__color_parse_model_cbrtlms:nnn
+\cs_new:Nn \@@_parse_model_linearrgb_aux:n
   {
-    \__color_parse_model_lms:nnn
-      { \fp_eval:n { #1 ^ 3 } }
-      { \fp_eval:n { #2 ^ 3 } }
-      { \fp_eval:n { #3 ^ 3 } }
+    \fp_compare:nNnTF { #1 } < { 0.0031308 }
+      { \fp_eval:n { 12.92 * max ( 0 , #1 ) } }
+      { \fp_eval:n { 1.055 * min ( 1 , #1 ) ^ 0.4166666666666667 - 0.055 } }
   }
-\cs_new:Nn \__color_parse_model_oklab:nnn
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}[EXP] {
+%     \@@_parse_model_lms:nnn, \@@_parse_model_cbrtlms:nnn,
+%     \@@_parse_model_oklab:nnn, \@@_parse_model_oklab:w
+%   }
+%   The \href[https://bottosson.github.io/posts/oklab]{Oklab color space} is
+%   defined by first transforming the color values to the responses of the L, M
+%   and S cones of a standard human observer, then taking those responses to
+%   the power of $\frac{1}{3}$, and finally applying one more matrix
+%   transformation to obtain the $L$, $a$, and $b$ values. Here, we just go the
+%   other way round:
+%
+%   First, transform $L$, $a$ and $b$ into the cube roots of $l$, $m$ and $s$
+%   cone response intensities using the inverse of Oklab's defining matrix
+%   $M_2$:
+%   \[ \begin{array}{c} l' \\ m' \\ s' \end{array}
+%   = \begin{array}{ccc}
+%     1 &   0.3963377774 &   0.2158037573 \\
+%     1 & - 0.1055613458 & - 0.0638541728 \\
+%     1 & - 0.0894841775 & - 1.2914855480
+%   \end{array} \begin{array}{c} L & a & b \end{array} \]
+%    \begin{macrocode}
+\cs_new:Nn \@@_parse_model_oklab:nnn
   {
-    \__color_parse_model_cbrtlms:nnn
+    \exp_args:Neee \@@_parse_model_cbrtlms:nnn
       { \fp_eval:n { #1 + 0.3963377774 * #2 + 0.2158037573 * #3 } }
       { \fp_eval:n { #1 - 0.1055613458 * #2 - 0.0638541728 * #3 } }
       { \fp_eval:n { #1 - 0.0894841775 * #2 - 1.2914855480 * #3 } }
   }
-\cs_new:Npn \__color_parse_model_oklab:w #1 , #2 , #3 , #4 \s__color_stop
-  { \__color_parse_model_oklab:nnn { #1 } { #2 } { #3 } }
 %    \end{macrocode}
-% \end{macro}
-% \begin{macro}[EXP]
-%   { \__color_parse_model_linearrgb:nnn, \__color_parse_model_linearrgb_aux:n }
-%   Encode the tristimulus values of the sRGB primaries according to sRGB.
+%   Next, take those cube roots to the power of $3$:
+%   \[ l = l'^3 \quad m = m'^3 \quad s = s'^3 \]
 %    \begin{macrocode}
-\cs_new:Nn \__color_parse_model_linearrgb:nnn
+\cs_new:Nn \@@_parse_model_cbrtlms:nnn
   {
-    { rgb }
-    {
-      \__color_parse_model_linearrgb_aux:n { #1 } ~
-      \__color_parse_model_linearrgb_aux:n { #2 } ~
-      \__color_parse_model_linearrgb_aux:n { #3 }
-    }
-  }
-\cs_new:Nn \__color_parse_model_linearrgb_aux:n
-  {
-    \fp_compare:nNnTF { #1 } < { 0.0031308 }
-      { \fp_eval:n { 12.92 * max ( 0 , #1 ) } }
-      { \fp_eval:n { 1.055 * min ( 1 , #1 ) ^ (1/2.4) - 0.055 } }
+    \exp_args:Neee \@@_parse_model_lms:nnn
+      { \fp_eval:n { #1 ^ 3 } }
+      { \fp_eval:n { #2 ^ 3 } }
+      { \fp_eval:n { #3 ^ 3 } }
   }
 %    \end{macrocode}
-% \end{macro}
-% \begin{macro}[EXP] { \__color_parse_model_oklch:w }
-%   Oklch is Oklab in cylinder coordinates.
+%
+%   Finally, transform intensities of $l$, $m$ and $s$ cone response to linear
+%   sRGB intensities.
+%   \[ \begin{array}{c} r \\ g \\ b \end{array}
+%   = \begin{array}{ccc}
+%     4.0767416621 & - 3.3077115913 &   0.2309699292 \\
+%    -1.2684380046 &   2.6097574011 & - 0.3413193965 \\
+%    -0.0041960863 & - 0.7034186147 &   1.7076147010
+%   \end{array} \begin{array}{c} l & m & s \end{array} \]
 %    \begin{macrocode}
-\cs_new:Npn \__color_parse_model_oklch:w #1 , #2 , #3 , #4 \s__color_stop
+\cs_new:Nn \@@_parse_model_lms:nnn
   {
-    \__color_parse_model_oklab:nnn
+    \exp_args:Neee \@@_parse_model_linearrgb:nnn
+      { \fp_eval:n {  4.0767416621 * #1 - 3.3077115913 * #2 + 0.2309699292 * #3 } }
+      { \fp_eval:n { -1.2684380046 * #1 + 2.6097574011 * #2 - 0.3413193965 * #3 } }
+      { \fp_eval:n { -0.0041960863 * #1 - 0.7034186147 * #2 + 1.7076147010 * #3 } }
+  }
+%    \end{macrocode}
+%   The actual parse macro with \emph weird signature.
+%    \begin{macrocode}
+\cs_new:Npn \@@_parse_model_oklab:w #1 , #2 , #3 , #4 \s_@@_stop
+  { \@@_parse_model_oklab:nnn { #1 } { #2 } { #3 } }
+%    \end{macrocode}
+% \end{macro}
+% \begin{macro}[EXP] { \@@_parse_model_oklch:w }
+a
+%   Oklch is Oklab in cylinder coordinates with $c$ choosing a color and $h$ a hue:
+%   \[ L = L \quad a = h \cdot \cos(c\degree) \quad b = h \cdor \sin(c\degree) \]
+%    \begin{macrocode}
+\cs_new:Npn \@@_parse_model_oklch:w #1 , #2 , #3 , #4 \s_@@_stop
+  {
+    \exp_args:Nnee \@@_parse_model_oklab:nnn
       { #1 }
       { \fp_eval:n { #2 * cosd(#3) } }
       { \fp_eval:n { #2 * sind(#3) } }

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -1394,18 +1394,17 @@
 %
 % \begin{macro}[EXP]
 %   { \@@_parse_model_linearrgb:nnn, \@@_parse_model_linearrgb_aux:n }
-a
 %   Encode the tristimulus values of the sRGB primaries according to sRGB.
 %   That is, take the actual physical light intensities of the primaries
 %   defined by the default RGB color space sRGB
-%   (\href[https://webstore.iec.ch/en/publication/6168]{IEC 61966-2-1}) and
+%   (\href{https://webstore.iec.ch/en/publication/6168}{IEC 61966-2-1}) and
 %   transform them with the gamma function defined in the same
 %   standard\footnote{For background information see
 %   \url{https://www.w3.org/Graphics/Color/sRGB}.}:
-%   \[ x_{\text{standard}} = \begin{case}
+%   \[ x_{\text{standard}} = \left\{\begin{array}{ll}
 %   12.92 \cdot x & x<0.0031308 \\
-%   1.055 \cdot \sqrt[2.4]x - 0.055 & x\ge0.0031308
-%   \end{case} \]
+%   1.055 \cdot x^{1/2.4} - 0.055 & x\ge0.0031308
+%   \end{array}\right. \]
 %   Additionally clip values to the range $[0,1]$.
 %    \begin{macrocode}
 \cs_new:Nn \@@_parse_model_linearrgb:nnn
@@ -1430,22 +1429,23 @@ a
 %     \@@_parse_model_lms:nnn, \@@_parse_model_cbrtlms:nnn,
 %     \@@_parse_model_oklab:nnn, \@@_parse_model_oklab:w
 %   }
-%   The \href[https://bottosson.github.io/posts/oklab]{Oklab color space} is
-%   defined by first transforming the color values to the responses of the L, M
-%   and S cones of a standard human observer, then taking those responses to
-%   the power of $\frac{1}{3}$, and finally applying one more matrix
-%   transformation to obtain the $L$, $a$, and $b$ values. Here, we just go the
-%   other way round:
+%   The \href{https://bottosson.github.io/posts/oklab}{Oklab color space} is
+%   defined by first transforming the physical light intensity to the
+%   biophysical responses of the L, M and S cones in a typical human eye, then
+%   taking those responses to the power of $\frac{1}{3}$ (which approximately
+%   fits human lightness perception), and finally applying one more matrix
+%   transformation $M_2$ to obtain handy $L$, $a$, and $b$ values. Here, we
+%   just go the other way round:
 %
 %   First, transform $L$, $a$ and $b$ into the cube roots of $l$, $m$ and $s$
 %   cone response intensities using the inverse of Oklab's defining matrix
 %   $M_2$:
-%   \[ \begin{array}{c} l' \\ m' \\ s' \end{array}
-%   = \begin{array}{ccc}
+%   \[ \left(\begin{array}{c} l' \\ m' \\ s' \end{array}\right)
+%   = \left(\begin{array}{ccc}
 %     1 &   0.3963377774 &   0.2158037573 \\
 %     1 & - 0.1055613458 & - 0.0638541728 \\
 %     1 & - 0.0894841775 & - 1.2914855480
-%   \end{array} \begin{array}{c} L & a & b \end{array} \]
+%   \end{array}\right) \left(\begin{array}{c} L \\ a \\ b \end{array}\right) \]
 %    \begin{macrocode}
 \cs_new:Nn \@@_parse_model_oklab:nnn
   {
@@ -1455,8 +1455,8 @@ a
       { \fp_eval:n { #1 - 0.0894841775 * #2 - 1.2914855480 * #3 } }
   }
 %    \end{macrocode}
-%   Next, take those cube roots to the power of $3$:
-%   \[ l = l'^3 \quad m = m'^3 \quad s = s'^3 \]
+%   Next, take those cube roots to the power of $3$ to obtain the actual cone responses:
+%   \[ l = l'^3, \quad m = m'^3, \quad s = s'^3 \]
 %    \begin{macrocode}
 \cs_new:Nn \@@_parse_model_cbrtlms:nnn
   {
@@ -1467,14 +1467,14 @@ a
   }
 %    \end{macrocode}
 %
-%   Finally, transform intensities of $l$, $m$ and $s$ cone response to linear
-%   sRGB intensities.
-%   \[ \begin{array}{c} r \\ g \\ b \end{array}
-%   = \begin{array}{ccc}
+%   Finally, transform $l$, $m$ and $s$ cone responses to linear sRGB
+%   intensity.
+%   \[ \left(\begin{array}{c} r \\ g \\ b \end{array}\right)
+%   = \left(\begin{array}{ccc}
 %     4.0767416621 & - 3.3077115913 &   0.2309699292 \\
 %    -1.2684380046 &   2.6097574011 & - 0.3413193965 \\
 %    -0.0041960863 & - 0.7034186147 &   1.7076147010
-%   \end{array} \begin{array}{c} l & m & s \end{array} \]
+%   \end{array}\right) \left(\begin{array}{c} l \\ m \\ s \end{array}\right) \]
 %    \begin{macrocode}
 \cs_new:Nn \@@_parse_model_lms:nnn
   {
@@ -1484,16 +1484,18 @@ a
       { \fp_eval:n { -0.0041960863 * #1 - 0.7034186147 * #2 + 1.7076147010 * #3 } }
   }
 %    \end{macrocode}
-%   The actual parse macro with \emph weird signature.
+%   The actual parse macro with \emph{weird} signature.
 %    \begin{macrocode}
 \cs_new:Npn \@@_parse_model_oklab:w #1 , #2 , #3 , #4 \s_@@_stop
   { \@@_parse_model_oklab:nnn { #1 } { #2 } { #3 } }
 %    \end{macrocode}
 % \end{macro}
 % \begin{macro}[EXP] { \@@_parse_model_oklch:w }
-a
-%   Oklch is Oklab in cylinder coordinates with $c$ choosing a color and $h$ a hue:
-%   \[ L = L \quad a = h \cdot \cos(c\degree) \quad b = h \cdor \sin(c\degree) \]
+%   Oklch is Oklab in cylinder coordinates with lightness
+%   $L\in\left[0,1\right]$, chroma $c$ giving the color intensity in values up
+%   to around $0.35$ and hue $h$ given in degrees (typically given as value
+%   from $0$ to $360$):
+%   \[ L = L, \quad a = h \cdot \cos(c), \quad b = h \cdot \sin(c) \]
 %    \begin{macrocode}
 \cs_new:Npn \@@_parse_model_oklch:w #1 , #2 , #3 , #4 \s_@@_stop
   {

--- a/l3kernel/testfiles/m3color003.lvt
+++ b/l3kernel/testfiles/m3color003.lvt
@@ -1,0 +1,104 @@
+%
+% Copyright (C) The LaTeX Project
+%
+
+\documentclass{minimal}
+
+\input{regression-test}
+
+\ExplSyntaxOn
+\debug_on:n { check-declarations , deprecation , log-functions }
+
+\cs_new:Npn \__color_parse_model_lms:w #1 , #2 , #3 , #4 \s__color_stop
+  { \__color_parse_model_lms:nnn { #1 } { #2 } { #3 } }
+\cs_new:Npn \__color_parse_model_cbrtlms:w #1 , #2 , #3 , #4 \s__color_stop
+  { \__color_parse_model_cbrtlms:nnn { #1 } { #2 } { #3 } }
+\cs_new:Npn \__color_parse_model_linearrgb:w #1 , #2 , #3 , #4 \s__color_stop
+  { \__color_parse_model_linearrgb:nnn { #1 } { #2 } { #3 } }
+
+\START
+
+\AUTHOR{Markus~Kurtz}
+
+\TEST { linearrgb~model }
+  {
+    \color_set:nnn { foo1 } { linearrgb }
+      { 0.0007739938080495357 , 0.07323895587840545 , 0.2140411404822325 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { linearrgb } { 0 , 0.003130799 , 0.00313081 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { linearrgb } { -0.1 , 1.1 , 1 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { linearrgb } { 0.2 , 0.6 , 0.9 }
+    \color_log:n { foo1 }
+  }
+
+\TEST { lms~model }
+  {
+    \color_set:nnn { foo1 } { lms } { 1, 1, 1 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { lms } { .7, .7, .7 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { lms } { 0 , 0 , 0.5 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { lms } { 0.3 , 0.4 , 0.2 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { lms } { 0.7 , 0.7 , 0.5 }
+    \color_log:n { foo1 }
+  }
+
+\TEST { cbrtlms~model }
+  {
+    \color_set:nnn { foo1 } { cbrtlms } { 1, 1, 1 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { cbrtlms } { .7, .7, .7 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { cbrtlms } { 0 , 0 , 0.5 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { cbrtlms } { 0.3 , 0.4 , 0.2 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { cbrtlms } { 0.7 , 0.7 , 0.5 }
+    \color_log:n { foo1 }
+  }
+
+\TEST { oklab~model }
+  {
+    \color_set:nnn { foo1 } { oklab } { 0 , 0 , 0 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklab } { 1 , 0 , 0 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklab } { .7 , 0 , 0 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklab } { 0.37, 0.13, 0.07 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklab } { 0.45, -0.032, -0.31 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklab } { 0.32 , 0 , -0.06 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklab } { 0.7 , -0.1 , 0.2 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklab } { 1.1 , 0 , 0 }
+    \color_log:n { foo1 }
+  }
+
+\TEST { oklch~model }
+  {
+    \color_set:nnn { foo1 } { oklch } { 0 , 0 , 0 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklch } { 1 , 0 , 0 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklch } { .7 , 0 , 0 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklch } { 0.6, 0.4, 0 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklch } { 0.452 , 0.31 , 264.1 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklch } { 0.8 , 0.1, 90 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklch } { 0.1 , 0.03 , 15 }
+    \color_log:n { foo1 }
+    \color_set:nnn { foo1 } { oklch } { 0.6 , 0.2 , 180 }
+    \color_log:n { foo1 }
+  }
+
+\END

--- a/l3kernel/testfiles/m3color003.tlg
+++ b/l3kernel/testfiles/m3color003.tlg
@@ -1,0 +1,115 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Markus Kurtz
+============================================================
+TEST 1: linearrgb model
+============================================================
+Defining \l__color_named_foo1_tl on line ...
+Defining \l__color_named_foo1_prop on line ...
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.01 0.3 0.5
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0 0.04044992308 0.04045003451334598
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0 1 1
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.4845292044817069 0.79773773303126 0.954687171885866
+============================================================
+============================================================
+TEST 2: lms model
+============================================================
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  1 1 1
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.8543058315449401 0.8543058315449401 0.8543058315449401
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.3741786031699747 0 0.9327622252715925
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0 0.7948336840226253 0.2691830197643374
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.8288044270221876 0.8902538737698393 0.633036318401439
+============================================================
+============================================================
+TEST 3: cbrtlms model
+============================================================
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  1 1 1
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.6204994654003908 0.6204994654003908 0.6204994654003908
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.1858683470023627 0 0.4993628053104879
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0 0.3959478675515466 0
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.5772615717173346 0.6780821058614707 0
+============================================================
+============================================================
+TEST 4: oklab model
+============================================================
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0 0 0
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  1 1 1
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.6204994654003908 0.6204994654003908 0.6204994654003908
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.4842738090432652 0.01913857747061253 0.02426429457184269
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.003179872312245272 0.0000259847232831 0.99379117131677
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.1525473096988617 0.1913362061546487 0.3194347438290483
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.5985815757223127 0.6754026826189243 0
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  1 1 1
+============================================================
+============================================================
+TEST 5: oklch model
+============================================================
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0 0 0
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  1 1 1
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.6204994654003908 0.6204994654003908 0.6204994654003908
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  1 0 0.4646834491735871
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.000646966654132396 0.02772663050089872 0.993174110239439
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.8418570616286571 0.734024402153969 0.4387023732211911
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0.03997663126521621 0.003559099498593614 0.006487309387513319
+The color foo1 has the properties:
+>  model  =>  rgb
+>  rgb  =>  0 0.6387818589565522 0.5207007185748967
+============================================================


### PR DESCRIPTION
As wished in https://github.com/latex3/xcolor/issues/26, I wrote a function converting from some LCh color space (name Oklch based on [Oklab](https://bottosson.github.io/posts/oklab)) to the standard RGB color space. That seemed easier to do with l3color, so I did it here.

IMHO it would make much sense to allow mixing colors in Oklab, and thus provide it as a core color model. Though, that seems better suited in a package like xcolor outside the kernel. So, likely I will also port the code to xcolor after all.