### PR TITLE
Implement \__kernel_iow_open:Nn

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -1687,16 +1687,21 @@
   {
     \__kernel_tl_set:Nx \l_@@_file_name_tl
       { \__kernel_file_name_sanitize:n {#2} }
+    \__kernel_iow_open:No #1 \l_@@_file_name_tl
+  }
+\cs_generate_variant:Nn \iow_open:Nn { NV , c , cV }
+\cs_new_protected:Npn \__kernel_iow_open:Nn #1#2
+  {
     \iow_close:N #1
     \seq_gpop:NNTF \g_@@_streams_seq \l_@@_stream_tl
-      { \@@_open_stream:NV #1 \l_@@_file_name_tl }
+      { \@@_open_stream:Nn #1 {#2} }
       {
         \@@_new:N #1
         \__kernel_tl_set:Nx \l_@@_stream_tl { \int_eval:n {#1} }
-        \@@_open_stream:NV #1 \l_@@_file_name_tl
+        \@@_open_stream:Nn #1 {#2}
       }
   }
-\cs_generate_variant:Nn \iow_open:Nn { NV , c , cV }
+\cs_generate_variant:Nn \__kernel_iow_open:Nn { No }
 \cs_new_protected:Npn \@@_open_stream:Nn #1#2
   {
     \tex_global:D \tex_chardef:D #1 = \l_@@_stream_tl \scan_stop:


### PR DESCRIPTION
This function was missed when `\iow_shell_open:Nn` was added in 8c2338d. I based the implementation on `\__kernel_ior_open:Nn`.

This closes #1515.