### PR TITLE
Document \__kernel_iow_open:Nn in l3kernel-functions.dtx

### DIFF
--- a/l3kernel/l3kernel-functions.dtx
+++ b/l3kernel/l3kernel-functions.dtx
@@ -333,7 +333,21 @@
 %   higher-level
 %   functions which have already fully expanded the \meta{file name} and which
 %   need to perform multiple open or close operations. See for example the
-%   implementation of \cs{file_get_full_name:nN},
+%   implementation of \cs{ior_shell_open:Nn}.
+% \end{function}
+%
+% \begin{function}{\__kernel_iow_open:Nn, \__kernel_iow_open:No}
+%   \begin{syntax}
+%     \cs{__kernel_iow_open:Nn} \meta{stream} \Arg{file name}
+%   \end{syntax}
+%   This function has identical syntax to the public version. However,
+%   is does not take precautions against active characters in the
+%   \meta{file name}, and it does not attempt to add a \meta{path} to
+%   the \meta{file name}: it is therefore intended to be used by
+%   higher-level
+%   functions which have already fully expanded the \meta{file name} and which
+%   need to perform multiple open or close operations. See for example the
+%   implementation of \cs{iow_shell_open:Nn}.
 % \end{function}
 %
 % \begin{function}{\__kernel_iow_with:Nnn}


### PR DESCRIPTION
Also update example function which uses `\__kernel_ior_open:Nn`.

See https://github.com/latex3/latex3/pull/1516.

Sorry for a new PR. When I found this missing piece, #1519 was already merged. :)