### PR TITLE
Adapt `l3doc` for `ltcmd` change to handling of newlines

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,6 +9,8 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Changed
 - Expand object names in `\pdf_object_...` functions (issue \#1521)
+- Adapt `l3doc` for `ltcmd` change to handling of newlines
+  (see latex3/latex2e\#1304)
 
 ### Fixed
 - Global assignment to constant in `\cctab_const:Nn` (issue \#1508)

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -2181,6 +2181,8 @@ and all files in that bundle must be distributed together.
       {
         \tl_remove_all:Ne \l_@@_tmpa_tl
           { \iow_char:N \^^M \c_percent_str }
+        \tl_remove_all:Ne \l_@@_tmpa_tl
+          { \token_to_str:N \obeyedline \c_space_tl \c_percent_str }
         \tl_remove_all:Ne \l_@@_tmpa_tl { \tl_to_str:n { ^ ^ A } }
         \tl_remove_all:Ne \l_@@_tmpa_tl { \iow_char:N \^^I }
         \tl_remove_all:Ne \l_@@_tmpa_tl { \iow_char:N \^^M }


### PR DESCRIPTION
This is the change to `l3doc.cls` in latex3/latex2e@9a544750 (Capture newlines as \obeyedline in ltcmd, 2024-03-20).