### PR TITLE
Expand object names in backend layer

### DIFF
--- a/l3backend/CHANGELOG.md
+++ b/l3backend/CHANGELOG.md
@@ -6,6 +6,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Expand object names in `\pdf_object_...` functions (issue \#1521)
+
 ## [2024-03-14]
 
 ### Removed

--- a/l3backend/l3backend-pdf.dtx
+++ b/l3backend/l3backend-pdf.dtx
@@ -127,11 +127,11 @@
   {
     \int_gincr:N \g_@@_backend_object_int
     \int_const:cn
-      { c_@@_object_ \tl_to_str:n {#1} _int }
+      { c_@@_object_ #1 _int }
       { \g_@@_backend_object_int }
   }
 \cs_new:Npn \@@_backend_object_ref:n #1
-  { { pdf.obj \int_use:c { c_@@_object_ \tl_to_str:n {#1} _int } } }
+  { { pdf.obj \int_use:c { c_@@_object_ #1 _int } } }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -973,7 +973,7 @@
 %</pdftex>
       reserveobjnum ~
     \int_const:cn
-      { c_@@_object_ \tl_to_str:n {#1} _int }
+      { c_@@_object_ #1 _int }
 %<*luatex>
         { \tex_pdffeedback:D lastobj }
 %</luatex>
@@ -982,7 +982,7 @@
 %</pdftex>
   }
 \cs_new:Npn \@@_backend_object_ref:n #1
-  { \int_use:c { c_@@_object_ \tl_to_str:n {#1} _int } ~ 0 ~ R }
+  { \int_use:c { c_@@_object_ #1 _int } ~ 0 ~ R }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -1003,7 +1003,7 @@
 %</pdftex>
       useobjnum ~
         \int_use:c
-          { c_@@_object_ \tl_to_str:n {#1} _int }
+          { c_@@_object_ #1 _int }
     \@@_backend_object_write:nn {#2} {#3}
   }
 \cs_new:Npn \@@_backend_object_write:nn #1#2
@@ -1252,11 +1252,11 @@
   {
     \int_gincr:N \g_@@_backend_object_int
     \int_const:cn
-      { c_@@_object_ \tl_to_str:n {#1} _int }
+      { c_@@_object_ #1 _int }
       { \g_@@_backend_object_int }
   }
 \cs_new:Npn \@@_backend_object_ref:n #1
-  { @pdf.obj \int_use:c { c_@@_object_ \tl_to_str:n {#1} _int } }
+  { @pdf.obj \int_use:c { c_@@_object_ #1 _int } }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3pdf.dtx
+++ b/l3kernel/l3pdf.dtx
@@ -341,7 +341,7 @@
 \cs_new:Npn \pdf_object_ref:n #1 { \@@_backend_object_ref:n {#1} }
 \cs_new_protected:Npn \pdf_object_unnamed_write:nn #1#2
   {
-    \exp_args:Ne \@@_backend_object_now:nn {#1} {#2}
+    \@@_backend_object_now:nn {#1} {#2}
     \bool_gset_true:N \g_@@_init_bool
   }
 \cs_generate_variant:Nn \pdf_object_unnamed_write:nn { ne , nx }

--- a/l3kernel/l3pdf.dtx
+++ b/l3kernel/l3pdf.dtx
@@ -338,7 +338,8 @@
     \bool_gset_true:N \g_@@_init_bool
   }
 \cs_generate_variant:Nn \pdf_object_write:nnn { nne , nnx }
-\cs_new:Npn \pdf_object_ref:n #1 { \@@_backend_object_ref:n {#1} }
+\cs_new:Npn \pdf_object_ref:n #1
+  { \exp_args:Ne \@@_backend_object_ref:n {#1} }
 \cs_new_protected:Npn \pdf_object_unnamed_write:nn #1#2
   {
     \@@_backend_object_now:nn {#1} {#2}

--- a/l3kernel/l3pdf.dtx
+++ b/l3kernel/l3pdf.dtx
@@ -330,16 +330,15 @@
 %    \begin{macrocode}
 \cs_new_protected:Npn \pdf_object_new:n #1
   {
-    \exp_args:Ne \@@_backend_object_new:n {#1}
+    \@@_backend_object_new:n {#1}
   }
 \cs_new_protected:Npn \pdf_object_write:nnn #1#2#3
   {
-    \exp_args:Ne \@@_backend_object_write:nnn {#1} {#2} {#3}
+    \@@_backend_object_write:nnn {#1} {#2} {#3}
     \bool_gset_true:N \g_@@_init_bool
   }
 \cs_generate_variant:Nn \pdf_object_write:nnn { nne , nnx }
-\cs_new:Npn \pdf_object_ref:n #1
-  { \exp_args:Ne \@@_backend_object_ref:n {#1} }
+\cs_new:Npn \pdf_object_ref:n #1 { \@@_backend_object_ref:n {#1} }
 \cs_new_protected:Npn \pdf_object_unnamed_write:nn #1#2
   {
     \@@_backend_object_now:nn {#1} {#2}
@@ -364,7 +363,7 @@
 % \begin{macro}{\pdf_pageobject_ref:n}
 %    \begin{macrocode}
 \cs_new:Npn \pdf_pageobject_ref:n #1
-  { \exp_args:Ne \@@_backend_pageobject_ref:n {#1} }
+  { \@@_backend_pageobject_ref:n {#1} }
 %    \end{macrocode}
 % \end{macro}
 %


### PR DESCRIPTION
Addresses comments I made in bcfbc26b (Expand object names (closes #1521), 2024-03-26). Refactoring is done in the last commit.

When refactoring, I found `\pdf_object_if_exist:n(TF)` is the only kernel function which makes direct use of int `\c__pdf_object_<object>_int` otherwise hidden in `l3backend-pdf.dtx`.
https://github.com/latex3/latex3/blob/a32300d602908dc6115f9d709c686db841593cd7/l3kernel/l3pdf.dtx#L349-L354