### PR TITLE
Narrow scope of debug suspending for \cctab_const:Nn

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -18,7 +18,7 @@ this project uses date-based 'snapshot' version identifiers.
   (see latex3/latex2e\#1304)
 
 ### Fixed
-- Global assignment to constant in `\cctab_const:Nn` (issue \#1508)
+- False `debug` error raised by `\cctab_const:Nn` (issue \#1508)
 - Undefined `\__kernel_iwo_open:Nn` used in `\iow_shell_open:Nn`
   (issue \#1515)
 - Naming of register functions in LuaMetaTeX 2.11+ (issue \#1518)

--- a/l3kernel/l3cctab.dtx
+++ b/l3kernel/l3cctab.dtx
@@ -286,13 +286,21 @@
 %    \end{macrocode}
 %   Now the case for other engines. Here, each table is an integer
 %   array.  Following the \LuaTeX{} pattern, a new table starts with
-%   \IniTeX{} codes.  The index base is out-by-one, so we have an
+%   \IniTeX{} codes.  The \cs{debug_suspend:} and \cs{debug_resume:}
+%   functions prevent errors and logging from \texttt{debug} commands
+%   which are either duplicate or false when \cs{@@_new:N} is used
+%   by \cs{cctab_new:N} or \cs{cctab_const:Nn}.
+%   The index base is out-by-one, so we have an
 %   internal function to handle that.  The \IniTeX{} \tn{endlinechar} is
 %   $13$.
 %    \begin{macrocode}
   {
     \cs_new_protected:Npn \@@_new:N #1
-      { \intarray_new:Nn #1 { 257 } }
+      {
+        \debug_suspend:
+        \intarray_new:Nn #1 { 257 }
+        \debug_resume:
+      }
     \cs_new_protected:Npn \@@_gstore:Nnn #1#2#3
       { \intarray_gset:Nnn #1 { #2 + 1 } {#3} }
     \cs_new_protected:Npn \cctab_new:N #1
@@ -796,17 +804,22 @@
 % \subsection{Constant category code tables}
 %
 % \begin{macro}{\cctab_const:Nn,\cctab_const:cn}
-%  Creates a new \meta{cctab~var} then sets it with the current and
-%  user-supplied codes. The \cs{debug_suspend:} and \cs{debug_resume:}
-%  functions prevent \cs{cctab_new:N} and \cs{cctab_gset:Nn} from
-%  raising errors on global assignment to constant.
+%  Creates a new \meta{cctab~var} then sets it with the \IniTeX{} and
+%  user-supplied codes. To avoid false \texttt{debug} errors, we write
+%  out implementation of \cs{cctab_new:N} and \cs{cctab_gset:Nn}
+%  instead of directly using them here. The initialization part in
+%  \cs{cctab_new:N} in non-\LuaTeX{} is omitted as it's covered by
+%  the \IniTeX{} settings.
 %    \begin{macrocode}
 \cs_new_protected:Npn \cctab_const:Nn #1#2
   {
-    \debug_suspend:
-    \cctab_new:N #1
-    \cctab_gset:Nn #1 {#2}
-    \debug_resume:
+    \__kernel_chk_if_free_cs:N #1
+    \@@_new:N #1
+    \group_begin:
+      \cctab_select:N \c_initex_cctab
+      #2 \scan_stop:
+      \@@_gset:n {#1}
+    \group_end:
   }
 \cs_generate_variant:Nn \cctab_const:Nn { c }
 %    \end{macrocode}

--- a/l3kernel/l3cctab.dtx
+++ b/l3kernel/l3cctab.dtx
@@ -294,7 +294,7 @@
     \cs_new_protected:Npn \@@_new:N #1
       { \intarray_new:Nn #1 { 257 } }
     \cs_new_protected:Npn \@@_gstore:Nnn #1#2#3
-      { \intarray_gset:Nnn #1 { \int_eval:n { #2 + 1 } } {#3} }
+      { \intarray_gset:Nnn #1 { #2 + 1 } {#3} }
     \cs_new_protected:Npn \cctab_new:N #1
       {
         \__kernel_chk_if_free_cs:N #1

--- a/l3kernel/testfiles/m3cctab002.tlg
+++ b/l3kernel/testfiles/m3cctab002.tlg
@@ -56,18 +56,6 @@ For immediate help type H <return>.
  ...                                              
 l. ...  }
 This is a coding error.
-Global assignment to a constant variable '\c_new_cctab'.
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Global assignment to a local variable '\l_new_cctab'.
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
 Global assignment to a local variable '\l_new_cctab'.
 ! LaTeX Error: Inconsistent local/global assignment
 For immediate help type H <return>.

--- a/l3kernel/testfiles/m3cctab002.xetex.tlg
+++ b/l3kernel/testfiles/m3cctab002.xetex.tlg
@@ -56,18 +56,6 @@ For immediate help type H <return>.
  ...                                              
 l. ...  }
 This is a coding error.
-Global assignment to a constant variable '\c_new_cctab'.
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
-Global assignment to a local variable '\l_new_cctab'.
-! LaTeX Error: Inconsistent local/global assignment
-For immediate help type H <return>.
- ...                                              
-l. ...  }
-This is a coding error.
 Global assignment to a local variable '\l_new_cctab'.
 ! LaTeX Error: Inconsistent local/global assignment
 For immediate help type H <return>.

--- a/l3kernel/testfiles/m3regex005.tlg
+++ b/l3kernel/testfiles/m3regex005.tlg
@@ -491,7 +491,6 @@ l. ...  }
 ============================================================
 TEST 17: Catcode used by default
 ============================================================
-Defining \g__cctab_1_cctab on line ...
 The token list \l_tmpa_tl contains the tokens:
 >  ^^M (the character ^^M)
 >  ! (the character !)

--- a/l3kernel/testfiles/m3regex005.xetex.tlg
+++ b/l3kernel/testfiles/m3regex005.xetex.tlg
@@ -491,7 +491,6 @@ l. ...  }
 ============================================================
 TEST 17: Catcode used by default
 ============================================================
-Defining \g__cctab_1_cctab on line ...
 The token list \l_tmpa_tl contains the tokens:
 >  ^^M (the character ^^M)
 >  ! (the character !)


### PR DESCRIPTION
The previous merged PR #1509 suspended debugging too much, especially the debugging for `<category code set up>` in `\cctab_const:Nn <category code table> {<category code set up>}` was suspended.

This PR narrows the scope to only suspend `\intarray_new:Nn` used in non-LuaTeX implementation of `\__cctab_new:N`.

This also avoids duplicate inconsistent local/global assignment errors raised by `\cctab_new:N` and unwanted logging written by `\cctab_begin:` in non-LuaTeX engines, see `.tlg` changes.