### PR TITLE
Fix various misspelling

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -75,7 +75,7 @@ jobs:
   # GitHub automatically informs the initiator of any action about the result, but
   # we additionally want to keep the latex-commits mailing list informed about
   # test failures.
-  notifiy:
+  notify:
     name: Send notifications
     runs-on: ubuntu-20.04
     # Run after the `l3build` job in order to be able to react to it's output.

--- a/l3backend/CHANGELOG.md
+++ b/l3backend/CHANGELOG.md
@@ -40,7 +40,7 @@ this project uses date-based 'snapshot' version identifiers.
 ## [2023-11-09]
 
 ### Changed
-- Changed `luaotfload` integration to allow coexistance with (x)color.
+- Changed `luaotfload` integration to allow coexistence with (x)color.
 
 ## [2023-11-04]
 
@@ -225,7 +225,7 @@ this project uses date-based 'snapshot' version identifiers.
   backend)
 
 ### Changed
-- Implementation of color wtih (x)dvipdfmx (requires an up-to-date
+- Implementation of color with (x)dvipdfmx (requires an up-to-date
   backend)
 
 ## [2020-09-24]

--- a/l3backend/l3backend-color.dtx
+++ b/l3backend/l3backend-color.dtx
@@ -920,7 +920,7 @@
 % Here, \texttt{dvipdfmx}/\XeTeX{} we write direct PDF specials for the fill,
 % and only use the stack for the stroke color (see above for comments on why
 % we cannot use multiple stacks with these backends). \LuaTeX{} and \pdfTeX{}
-% have mutiple stacks that can deal with fill and stroke. For \texttt{dvips}
+% have multiple stacks that can deal with fill and stroke. For \texttt{dvips}
 % we have to manage fill and stroke color ourselves. We also handle
 % \texttt{dvisvgm} independently, as there we can create SVG directly.
 %

--- a/l3backend/l3backend-pdf.dtx
+++ b/l3backend/l3backend-pdf.dtx
@@ -376,7 +376,7 @@
 % \begin{macro}{\@@_backend_link_minima:}
 % \begin{macro}{\@@_backend_link_outerbox:n}
 % \begin{macro}{\@@_backend_link_sf_save:, \@@_backend_link_sf_restore:}
-%   Links are crated like annotations but with dedicated code to allow for
+%   Links are created like annotations but with dedicated code to allow for
 %   adjusting the size of the rectangle. In contrast to \pkg{hyperref}, we
 %   grab the link content as a box which can then unbox: this allows the same
 %   interface as for \pdfTeX{}.

--- a/l3experimental/l3draw/l3draw.dtx
+++ b/l3experimental/l3draw/l3draw.dtx
@@ -643,7 +643,7 @@
 %   \begin{syntax}
 %     \cs{draw_path_use:n} \Arg{action(s)}
 %   \end{syntax}
-%   Inserts the current path, carrying out one ore more possible \meta{actions}
+%   Inserts the current path, carrying out one or more possible \meta{actions}
 %   (a comma list):
 %   \begin{itemize}
 %     \item \texttt{stroke} Draws a line along the current path

--- a/l3experimental/xcoffins/xcoffins-test.tex
+++ b/l3experimental/xcoffins/xcoffins-test.tex
@@ -211,7 +211,7 @@ How do you best define/describe the following design?
 \newcoffin \ggg
 
 \sbox \aaa {\small\scshape les vases communicants}
-\sbox \bbb {\scshape comunicating}
+\sbox \bbb {\scshape communicating}
 \sbox \ccc {\fontsize{70pt}{60pt} \bfseries Ve\S els}
 \sbox \ddd {\scshape andr\'e breton}
 \setvcoffin \eee {4.7cm}{\noindent Translated by Mary Ann Caws \&\break
@@ -286,7 +286,7 @@ x\cbox{\usebox \bbb }x
 x\cbox{\usebox \aaa }x
 
 
-After we have aligned a roated box with some other box we need to decide about
+After we have aligned a rotated box with some other box we need to decide about
 the bounding box of the new box. Right now this become the enclosing box and
 we do not maintain information about the inner boxes. So when we rotate that
 new box there seems to be unnecessary space in the enclosing bounding box,

--- a/l3experimental/xgalley/l3galley.dtx
+++ b/l3experimental/xgalley/l3galley.dtx
@@ -1490,7 +1490,7 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_start_paragraph_std:}
-%   After dealign with the common items, the horizontal mode items can be
+%   After dealing with the common items, the horizontal mode items can be
 %   tidied up before sorting out any items which have been set on a
 %   single-paragraph basis.
 %    \begin{macrocode}

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -878,7 +878,7 @@ this project uses date-based 'snapshot' version identifiers.
   improve target placement, solve pdfTeX and makeindex warnings
 
 ### Fixed
-- Evalutate integer constants only once (issue [\#861](https://github.com/latex3/latex3/issues/861))
+- Evaluate integer constants only once (issue [\#861](https://github.com/latex3/latex3/issues/861))
 - Detect `\ior_map_inline:Nn` calls on undefined streams (issue [\#194](https://github.com/latex3/latex3/issues/194))
 
 ### Deprecated

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -1287,7 +1287,7 @@
 % still compatible) version in which the error mentioned above showed
 % up.  If loading as a package, \file{expl3-code.tex} got read and here
 % the \pkg{expl3} syntax is on.  Otherwise it was already loaded in a
-% sligtly older kernel, so we fire the incompatibility error message and
+% slightly older kernel, so we fire the incompatibility error message and
 % abort loading.
 %    \begin{macrocode}
   \ifodd\csname\detokenize{l__kernel_expl_bool}\endcsname

--- a/l3kernel/l3coffins.dtx
+++ b/l3kernel/l3coffins.dtx
@@ -897,7 +897,7 @@
 %   Special coffins: these cannot be set up earlier as they need
 %   \cs{coffin_new:N}. The empty coffin is set as a box as the full
 %   coffin-setting system needs some material which is not yet available.
-%   The empty coffin is creted entirely by hand: not everything is in place
+%   The empty coffin is created entirely by hand: not everything is in place
 %   yet.
 %    \begin{macrocode}
 \coffin_new:N \c_empty_coffin

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -365,7 +365,7 @@ and all files in that bundle must be distributed together.
 %   \begin{syntax}
 %     \cs{tn} \oarg{options} \marg{csname}
 %   \end{syntax}
-%   Analoguous to \cs{cs} but intended for \enquote{traditional} \TeX{}
+%   Analogous to \cs{cs} but intended for \enquote{traditional} \TeX{}
 %   or \LaTeXe{} commands; they are indexed accordingly.  This is in
 %   fact equivalent to \cs{cs} |[module=TeX, replace=false,|
 %   \meta{options}|]| \Arg{csname}.
@@ -4498,7 +4498,7 @@ and all files in that bundle must be distributed together.
 %
 % \begin{macro}{\@@_key_trim_module:n, \@@_key_drop_underscores:}
 %   Helper that removes from \cs{l_@@_index_module_tl} everything after
-%   the first occurence of |#1|.  Helper that removes any leading
+%   the first occurrence of |#1|.  Helper that removes any leading
 %   underscore from \cs{l_@@_index_key_tl}.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_key_trim_module:n #1

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -135,7 +135,7 @@
 %   then used to define variants of the
 %   \meta{original argument specifier} if these are not already
 %   defined; entries which correspond to existing functions are silently
-%   ingored. For each \meta{variant} given, a function is created
+%   ignored. For each \meta{variant} given, a function is created
 %   that expands its arguments as detailed and passes them
 %   to the \meta{parent control sequence}. So for example
 %   \begin{verbatim}

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -3818,7 +3818,7 @@
 %
 %   The function starts by checking that the kernel date is defined, and
 %   if not zero is used to force the error route.  The kernel date is
-%   then compared with the argument requested date (ususally the
+%   then compared with the argument requested date (usually the
 %   packaging date of the dependency).  If the kernel date is less than
 %   the required date, it's an error and the loading should abort.
 %    \begin{macrocode}

--- a/l3kernel/l3fp-parse.dtx
+++ b/l3kernel/l3fp-parse.dtx
@@ -430,7 +430,7 @@
 % second attempt would be to call \cs{@@_parse_operand:Nw} with the
 % \meta{precedence} of the previous operator, but |0>-2+3| is then
 % parsed as |0>-(2+3)|: the addition is performed because it binds more
-% tightly than the comparision which precedes~|-|.  The correct approach
+% tightly than the comparison which precedes~|-|.  The correct approach
 % is for a unary~|-| to perform operations whose precedence is greater
 % than both that of the previous operation, and that of the unary~|-|
 % itself.  The unary~|-| is given a precedence higher than

--- a/l3kernel/l3fparray.dtx
+++ b/l3kernel/l3fparray.dtx
@@ -89,7 +89,7 @@
 %   Assignments are always global.
 % \end{function}
 %
-% \section{Couting entries in floating point arrays}
+% \section{Counting entries in floating point arrays}
 %
 % \begin{function}[EXP, added = 2018-05-05]{\fparray_count:N, \fparray_count:c}
 %   \begin{syntax}

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -186,7 +186,7 @@
 %   encountered that cannot form part of such an expression.  If that
 %   token is \cs{scan_stop:} it is removed, otherwise not.  Spaces do
 %   \emph{not} terminate the expression.  However, spaces terminate
-%   explict integers, and this may terminate the expression: for
+%   explicit integers, and this may terminate the expression: for
 %   instance, \cs{int_eval:w} \verb*|1 + 1 9| (with explicit space
 %   tokens inserted using |~| in a code setting) expands to \texttt{29}
 %   since the digit~\texttt{9} is not part of the expression. Expansion

--- a/l3kernel/l3intarray.dtx
+++ b/l3kernel/l3intarray.dtx
@@ -109,7 +109,7 @@
 %   global.
 % \end{function}
 %
-% \section{Couting entries in integer arrays}
+% \section{Counting entries in integer arrays}
 %
 % \begin{function}[EXP, added = 2018-03-29]{\intarray_count:N, \intarray_count:c}
 %   \begin{syntax}
@@ -277,7 +277,7 @@ end, 'protected', 'global')
 % \end{macro}
 % \end{macro}
 %
-% Before we get to the first command implmented in Lua, we first need some
+% Before we get to the first command implemented in Lua, we first need some
 % definitions. Since \texttt{token.create} only works correctly if \TeX{}
 % has seen the tokens before, we first run a short \TeX{} sequence to ensure
 % that all relevant control sequences are known.

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -585,7 +585,7 @@
 % by creating sub-keys of the choice key. This can be carried out in
 % two ways.
 %
-% In many cases, choices execute similar code which is dependant only
+% In many cases, choices execute similar code which is dependent only
 % on the name of the choice or the position of the choice in the
 % list of all possibilities. Here, the keys can share the same code, and can
 % be rapidly created using the  \texttt{.choices:nn} property.
@@ -876,7 +876,7 @@
 %     \cs{keys_set_exclude_groups:nnnN} \Arg{module} \Arg{groups} \Arg{keyval list} \meta{tl}
 %     \cs{keys_set_exclude_groups:nnnnN} \Arg{module} \Arg{groups} \Arg{keyval list} \meta{root} \meta{tl}
 %   \end{syntax}
-%   Sets keys by excluding those in the specificied \meta{groups}.
+%   Sets keys by excluding those in the specified \meta{groups}.
 %   The \meta{groups} are
 %   given as a comma-separated list. Unknown keys are not assigned to any
 %   group and are thus always set. The key--value pairs for each

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -452,7 +452,7 @@ ltxutils.filedump = filedump
 %
 % \begin{macro}[int]{md5.HEX}
 % Hash a string and return the hash in uppercase hexadecimal format.
-% In some engines, this is build-in. For traditional \LuaTeX{}, the conversion
+% In some engines, this is built-in. For traditional \LuaTeX{}, the conversion
 % to hexadecimal has to be done by us.
 %    \begin{macrocode}
 local md5_HEX = md5.HEX
@@ -664,7 +664,7 @@ end)
 %<@@=lua>
 %    \end{macrocode}
 %
-% The Lua state is not dumped when a forat is written, therefore any Lua
+% The Lua state is not dumped when a format is written, therefore any Lua
 % variables filled doing format building need to be restored in order to
 % be accessible during normal runs.
 %

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -92,7 +92,7 @@
 % will allow to filter out specifically messages from the \texttt{submodule}.
 %
 % Some authors may find the need to include spaces as |~| characters
-% tedious. This can be avoided by locally reseting the cateogry code
+% tedious. This can be avoided by locally resetting the category code
 % of \verb*| |.
 % \begin{verbatim}
 %   \char_set_catcode_space:n { `\ }

--- a/l3kernel/l3names.dtx
+++ b/l3kernel/l3names.dtx
@@ -1540,7 +1540,7 @@ end, 'global')
 % \begin{macro}[no-user-doc]{\tex_filedump:D}
 %   An emulated primitive for getting a hexdump from a (partial) file.
 %   The length has a default of |0|. This is consistent with
-%   \pdfTeX, but it effectivly makes the primitive useless without an
+%   \pdfTeX, but it effectively makes the primitive useless without an
 %   explicit |length|. Therefore we allow the keyword |whole| to be used
 %   instead of a length, indicating that the whole remaining file should
 %   be read.

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -2047,9 +2047,9 @@
 % phase. Compiled regular expressions consist of the following:
 % \begin{itemize}
 %   \item \cs{@@_class:NnnnN} \meta{boolean} \Arg{tests} \Arg{min}
-%     \Arg{more} \meta{lazyness}
+%     \Arg{more} \meta{laziness}
 %   \item \cs{@@_group:nnnN} \Arg{branches} \Arg{min} \Arg{more}
-%     \meta{lazyness}, also \cs{@@_group_no_capture:nnnN} and
+%     \meta{laziness}, also \cs{@@_group_no_capture:nnnN} and
 %     \cs{@@_group_resetting:nnnN} with the same syntax.
 %   \item \cs{@@_branch:n} \Arg{contents}
 %   \item \cs{@@_command_K:}
@@ -2638,7 +2638,7 @@
 % \end{macro}
 % \end{macro}
 %
-% \begin{macro}{\@@_compile_quantifier_lazyness:nnNN}
+% \begin{macro}{\@@_compile_quantifier_laziness:nnNN}
 %   Once the \enquote{main} quantifier (\texttt{?}, \texttt{*},
 %   \texttt{+} or a braced construction) is found, we check whether it
 %   is lazy (followed by a question mark). We then add to the compiled
@@ -2646,7 +2646,7 @@
 %   the start-point of the range, its end-point, and a boolean,
 %   \texttt{true} for lazy and \texttt{false} for greedy operators.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_compile_quantifier_lazyness:nnNN #1#2#3#4
+\cs_new_protected:Npn \@@_compile_quantifier_laziness:nnNN #1#2#3#4
   {
     \@@_two_if_eq:NNNNTF #3 #4 \@@_compile_special:N ?
       {
@@ -2669,15 +2669,15 @@
 %     \@@_compile_quantifier_+:w
 %   }
 %   For each \enquote{basic} quantifier, |?|, |*|, |+|, feed the correct
-%   arguments to \cs{@@_compile_quantifier_lazyness:nnNN}, $-1$ means
+%   arguments to \cs{@@_compile_quantifier_laziness:nnNN}, $-1$ means
 %   that there is no upper bound on the number of repetitions.
 %    \begin{macrocode}
 \cs_new_protected:cpn { @@_compile_quantifier_?:w }
-  { \@@_compile_quantifier_lazyness:nnNN { 0 } { 1 } }
+  { \@@_compile_quantifier_laziness:nnNN { 0 } { 1 } }
 \cs_new_protected:cpn { @@_compile_quantifier_*:w }
-  { \@@_compile_quantifier_lazyness:nnNN { 0 } { -1 } }
+  { \@@_compile_quantifier_laziness:nnNN { 0 } { -1 } }
 \cs_new_protected:cpn { @@_compile_quantifier_+:w }
-  { \@@_compile_quantifier_lazyness:nnNN { 1 } { -1 } }
+  { \@@_compile_quantifier_laziness:nnNN { 1 } { -1 } }
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2711,7 +2711,7 @@
       {
         { \@@_compile_special:N \c_right_brace_str }
           {
-            \exp_args:No \@@_compile_quantifier_lazyness:nnNN
+            \exp_args:No \@@_compile_quantifier_laziness:nnNN
               { \int_use:N \l_@@_internal_a_int } 0
           }
         { \@@_compile_special:N , }
@@ -2731,7 +2731,7 @@
   {
     \@@_two_if_eq:NNNNTF #1 #2 \@@_compile_special:N \c_right_brace_str
       {
-        \exp_args:No \@@_compile_quantifier_lazyness:nnNN
+        \exp_args:No \@@_compile_quantifier_laziness:nnNN
           { \int_use:N \l_@@_internal_a_int } { -1 }
       }
       {
@@ -2753,7 +2753,7 @@
         \else:
           \int_sub:Nn \l_@@_internal_b_int \l_@@_internal_a_int
         \fi:
-        \exp_args:Noo \@@_compile_quantifier_lazyness:nnNN
+        \exp_args:Noo \@@_compile_quantifier_laziness:nnNN
           { \int_use:N \l_@@_internal_a_int }
           { \int_use:N \l_@@_internal_b_int }
       }
@@ -4517,13 +4517,13 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}{\@@_build_transitions_lazyness:NNNNN}
+% \begin{macro}{\@@_build_transitions_laziness:NNNNN}
 %   This function creates a new state, and puts two transitions starting
 %   from the old current state. The order of the transitions is
 %   controlled by |#1|, true for lazy quantifiers, and false for greedy
 %   quantifiers.
 %    \begin{macrocode}
-\cs_new_protected:Npn \@@_build_transitions_lazyness:NNNNN #1#2#3#4#5
+\cs_new_protected:Npn \@@_build_transitions_laziness:NNNNN #1#2#3#4#5
   {
     \@@_build_new_state:
     \@@_toks_put_right:Ne \l_@@_left_state_int
@@ -4545,7 +4545,7 @@
 % \begin{macro}{\@@_class:NnnnN}
 % \begin{macro}[rEXP]{\@@_tests_action_cost:n}
 %   The arguments are: \meta{boolean} \Arg{tests} \Arg{min} \Arg{more}
-%   \meta{lazyness}. First store the tests with a trailing
+%   \meta{laziness}. First store the tests with a trailing
 %   \cs{@@_action_cost:n}, in the true branch of
 %   \cs{@@_break_point:TF} for positive classes, or the false branch
 %   for negative classes. The integer \meta{more} is $0$ for fixed
@@ -4599,18 +4599,18 @@
 %   \cs{@@_class_repeat:n} for the code to match |#1| repetitions,
 %   and add free transitions from the last state to the previous one,
 %   and to a new one. In both cases, the order of transitions is
-%   controlled by the lazyness boolean |#2|.
+%   controlled by the laziness boolean |#2|.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_class_repeat:nN #1#2
   {
     \if_int_compare:w #1 = \c_zero_int
-      \@@_build_transitions_lazyness:NNNNN #2
+      \@@_build_transitions_laziness:NNNNN #2
         \@@_action_free:n       \l_@@_right_state_int
         \@@_tests_action_cost:n \l_@@_left_state_int
     \else:
       \@@_class_repeat:n {#1}
       \int_set_eq:NN \l_@@_internal_a_int \l_@@_left_state_int
-      \@@_build_transitions_lazyness:NNNNN #2
+      \@@_build_transitions_laziness:NNNNN #2
         \@@_action_free:n \l_@@_right_state_int
         \@@_action_free:n \l_@@_internal_a_int
     \fi:
@@ -4634,7 +4634,7 @@
       { \l_@@_max_state_int + #2 - \c_one_int }
     \prg_replicate:nn { #2 }
       {
-        \@@_build_transitions_lazyness:NNNNN #3
+        \@@_build_transitions_laziness:NNNNN #3
           \@@_action_free:n       \l_@@_internal_a_int
           \@@_tests_action_cost:n \l_@@_right_state_int
       }
@@ -4646,7 +4646,7 @@
 %
 % \begin{macro}{\@@_group_aux:nnnnN}
 %   Arguments: \Arg{label} \Arg{contents} \Arg{min} \Arg{more}
-%   \meta{lazyness}. If \meta{min} is $0$, we need to add a state before
+%   \meta{laziness}. If \meta{min} is $0$, we need to add a state before
 %   building the group, so that the thread which skips the group does
 %   not also set the start-point of the submatch. After adding one more
 %   state, the \texttt{left_state} is the left end of the group, from
@@ -4656,7 +4656,7 @@
 %   build the \textsc{nfa} states for the contents |#2| of the group,
 %   and we forget about the two integers. Once this is done, perform the
 %   repetition: either exactly |#3| times, or |#3| or more times, or
-%   between |#3| and $|#3|+|#4|$ times, with lazyness |#5|. The
+%   between |#3| and $|#3|+|#4|$ times, with laziness |#5|. The
 %   \meta{label} |#1| is used for submatch tracking. Each of the three
 %   auxiliaries expects \texttt{left_state} and \texttt{right_state} to
 %   be set properly.
@@ -4884,7 +4884,7 @@
 %
 % \begin{macro}{\@@_group_repeat:nnnN}
 %   We wish to repeat the group between |#2| and $|#2|+|#3|$ times, with
-%   a lazyness controlled by |#4|. We insert submatch tracking up front:
+%   a laziness controlled by |#4|. We insert submatch tracking up front:
 %   in principle, we could avoid recording submatches for the first |#2|
 %   copies of the group, but that forces us to treat specially the case
 %   $|#2|=0$. Repeat that group with submatch tracking $|#2|+|#3|$ times
@@ -8076,7 +8076,7 @@
 %   This is not technically a message, but seems related enough to go
 %   there. The arguments are: |#1| is the minimum number of repetitions;
 %   |#2| is the number of allowed extra repetitions ($-1$ for infinite
-%   number), and |#3| tells us about lazyness.
+%   number), and |#3| tells us about laziness.
 %    \begin{macrocode}
 \cs_new:Npn \@@_msg_repeated:nnN #1#2#3
   {

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1690,7 +1690,7 @@
   }
 %    \end{macrocode}
 %   If the position is ok, \cs{@@_set_item:nNnnNNNN} makes the assignment
-%   and returns \texttt{true} (in the case of conditionnals).  Here |#1|
+%   and returns \texttt{true} (in the case of conditionals).  Here |#1|
 %   is an integer expression (position minus one), it needs to be
 %   evaluated.  The sequence |#5| starts with \cs{s_@@} (even if empty),
 %   which stops the integer expression and is absorbed by it.  The

--- a/l3kernel/l3text-case.dtx
+++ b/l3kernel/l3text-case.dtx
@@ -1919,7 +1919,7 @@
 %    \end{macrocode}
 %   If there was a hit, output the result with the dot-above and move on.
 %   Otherwise, look for one of the three letters that can take a combining
-%   accent: I, J nd I-ogonek. 
+%   accent: I, J, and I-ogonek. 
 %    \begin{macrocode}
 \cs_new:Npn \@@_change_case_lower_lt_auxi:nnnnn #1#2#3#4#5
   {

--- a/l3kernel/l3text.dtx
+++ b/l3kernel/l3text.dtx
@@ -887,7 +887,7 @@
 %   {\c_@@_chardef_group_begin_token, \c_@@_mathchardef_group_begin_token}
 % \begin{variable}
 %   {\c_@@_chardef_group_end_token, \c_@@_mathchardef_group_end_token}
-%   Markers for implict char handling.
+%   Markers for implicit char handling.
 %    \begin{macrocode}
 \tex_global:D \tex_chardef:D \c_@@_chardef_space_token = `\  %
 \tex_global:D \tex_mathchardef:D \c_@@_mathchardef_space_token = `\  %

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -3339,7 +3339,7 @@
 %   }
 % \begin{macro}[EXP]{\@@_use_none_delimit_by_q_act_stop:w}
 %   To help control the expansion, \cs{@@_act:NNNn} should always
-%   be preceeded by \cs{exp:w} and ends by producing \cs{exp_end:}
+%   be preceded by \cs{exp:w} and ends by producing \cs{exp_end:}
 %   once the result has been obtained. This way no internal token of it can be
 %   accidentally end up in the input stream.
 %   Because \cs{s_@@_act_stop} can't appear without braces around it in the

--- a/l3kernel/l3unicode.dtx
+++ b/l3kernel/l3unicode.dtx
@@ -52,7 +52,7 @@
 % This module provides Unicode-specific functions along with loading data
 % from a range of Unicode Consortium files. Most of the code here is
 % internal, but there are a small set of public functions. These work with
-% Unicode \meta{codepoints} and are designed to give useable results with
+% Unicode \meta{codepoints} and are designed to give usable results with
 % both Unicode-aware and $8$-bit engines.
 %
 % \begin{function}[EXP, added = 2022-10-09, updated = 2022-11-09]

--- a/l3kernel/testfiles/m3int001.lvt
+++ b/l3kernel/testfiles/m3int001.lvt
@@ -140,7 +140,7 @@
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% adding and substracting
+% adding and subtracting
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \TEST { adding~and~subtracting }

--- a/l3packages/CHANGELOG.md
+++ b/l3packages/CHANGELOG.md
@@ -133,7 +133,7 @@ this project uses date-based 'snapshot' version identifiers.
 ## [2021-05-07]
 
 ### Fixed
-- Implmentation of `\DeclareRestrictedTemplate`
+- Implementation of `\DeclareRestrictedTemplate`
 - Incorrect use of restricted template in `xfrac`
 
 ## [2021-03-12]

--- a/l3packages/l3keys2e/l3keys2e-demo.tex
+++ b/l3packages/l3keys2e/l3keys2e-demo.tex
@@ -16,7 +16,7 @@
 
 % Load the class with some options.
 % The class itself recognises `option1', leaving `option2' and
-% `option3' as global optons which are not yet used.
+% `option3' as global options which are not yet used.
 \documentclass[option1=check,option2=more stuff,option3=unused]
   {l3keys2e-class}
 

--- a/l3packages/xtemplate/testfiles/xtemplate003.lvt
+++ b/l3packages/xtemplate/testfiles/xtemplate003.lvt
@@ -331,9 +331,9 @@
 % 17
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-\TEST{Testing~instances:~existance~check}{
+\TEST{Testing~instances:~existence~check}{
 
-   \IfInstanceExistTF {test} {nono}                      % instance unknwon, ok
+   \IfInstanceExistTF {test} {nono}                      % instance unknown, ok
         {\typeout{Yes}} {\typeout{No}}
 
    \IfInstanceExistTF {missingobjecttype} {nono}         % objecttype unknown, ok

--- a/l3packages/xtemplate/testfiles/xtemplate003.tlg
+++ b/l3packages/xtemplate/testfiles/xtemplate003.tlg
@@ -302,7 +302,7 @@ The template 'tname3' of object type 'test' has variable mapping:
 l. ...}
 ============================================================
 ============================================================
-TEST 17: Testing instances: existance check
+TEST 17: Testing instances: existence check
 ============================================================
 No
 No

--- a/l3trial/l3bigint/testfiles/m3bigint001.lvt
+++ b/l3trial/l3bigint/testfiles/m3bigint001.lvt
@@ -110,7 +110,7 @@
 %   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-% adding and substracting
+% adding and subtracting
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 \TEST { adding~and~subtracting }

--- a/l3trial/l3doc/examples/testing.dtx
+++ b/l3trial/l3doc/examples/testing.dtx
@@ -82,7 +82,7 @@
 %   \begin{syntax}
 %     \cs{tn} \oarg{options} \marg{csname}
 %   \end{syntax}
-%   Analoguous to \cs{cs} but intended for \enquote{traditional} \TeX{}
+%   Analogous to \cs{cs} but intended for \enquote{traditional} \TeX{}
 %   or \LaTeXe{} commands; they are indexed accordingly.  This is in
 %   fact equivalent to \cs{cs} |[module=TeX, replace=false,|
 %   \meta{options}|]| \Arg{csname}.

--- a/l3trial/l3kernel-extras/l3kernel-extras.dtx
+++ b/l3trial/l3kernel-extras/l3kernel-extras.dtx
@@ -47,7 +47,7 @@
 % \fi
 %
 % \title{^^A
-%   The \pkg{l3kernel-extras} package\\ Add ons to \pkg{l3kernel}^^A
+%   The \pkg{l3kernel-extras} package\\ Add-ons to \pkg{l3kernel}^^A
 % }
 %
 % \author{^^A

--- a/l3trial/l3ldb/l3ldb.dtx
+++ b/l3trial/l3ldb/l3ldb.dtx
@@ -115,7 +115,7 @@
 % stack of tags to represent the current situation so that we can match
 % it with entries in the database.  The desire to keep the size of this
 % stack under control leads us to formulate a number of restrictions
-% wich will allow us to trim the stack as much and as soon as possible.
+% which will allow us to trim the stack as much and as soon as possible.
 % Also there are semantic difficulties which also suggest certain
 % restrictions.
 % \begin{enumerate}

--- a/l3trial/l3ldb/testfiles/m3ldb003.lvt
+++ b/l3trial/l3ldb/testfiles/m3ldb003.lvt
@@ -177,7 +177,7 @@
 % What is different (for now) is that I made ``item'' an environment
 % and a template (again, it is in reality just the original code).
 %
-% It is an environment as the LDB is currenty made up for environemnt
+% It is an environment as the LDB is currently made up for environment
 % type structures and to produce something like \texttt{<item>} in the
 % LDB context one would need to gain control after the command has
 % read its arguments and processed its code and then issue


### PR DESCRIPTION
Found with `codespell -L 'alph,co-ordinate,co-ordinates,filetest,inteval,openin' -S './texmf,*.eps,*.tlg'`.