### PR TITLE
Doc typo, \meta -> \Arg

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -429,7 +429,7 @@
 %
 % \begin{function}[added = 2019-03-23]{\ior_get_term:nN, \ior_str_get_term:nN}
 %   \begin{syntax}
-%     \cs{ior_get_term:nN} \meta{prompt} \meta{token list variable}
+%     \cs{ior_get_term:nN} \Arg{prompt} \meta{token list variable}
 %   \end{syntax}
 %   Function that reads one or more lines (until an equal number of left
 %   and right braces are found) from the terminal and stores


### PR DESCRIPTION
- Before: `\ior_get_term:nN <prompt> <token list variable>`
- After: `\ior_get_term:nN {<prompt>} <token list variable>`, added braces around `<prompt>`.