### PR TITLE
Define `\tl_set_from_cs:NN` and `\tl_gset_from_cs:NN`

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -215,6 +215,20 @@
 %   \meta{tl~var}.
 % \end{function}
 %
+% \begin{function}[added = 2024-04-28]
+%   {
+%     \tl_set_from_cs:NN, \tl_set_from_cs:cN, \tl_set_from_cs:Nc, \tl_set_from_cs:cc,
+%     \tl_gset_from_cs:NN, \tl_gset_from_cs:cN, \tl_gset_from_cs:Nc, \tl_gset_from_cs:cc
+%   }
+%   \begin{syntax}
+%     \cs{tl_set_from_cs:NN} \meta{tl var} \meta{control sequence}
+%   \end{syntax}
+%   This function assigns the replacement text of a \meta{control sequence}
+%   to \meta{tl var}. Compared to \cs{cs_replacement_spec:N}, this function
+%   preserves all category codes. This function only works for
+%   \meta{control sequence}s without delimited arguments.
+% \end{function}
+%
 % \section{Token list conditionals}
 %
 % \begin{function}[EXP,pTF, updated = 2019-09-04]
@@ -1717,6 +1731,96 @@
 \cs_generate_variant:Nn \tl_gput_right:No { c }
 \cs_generate_variant:Nn \tl_gput_right:Nn { Nx, cx }
 %    \end{macrocode}
+% \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\@@_from_cs:NNNn}
+% \begin{macro}{\@@_from_cs:NNN}
+% \begin{macro}
+%   {
+%     \tl_set_from_cs:NN, \tl_set_from_cs:cN, \tl_set_from_cs:Nc,
+%     \tl_set_from_cs:cc
+%   }
+% \begin{macro}
+%   {
+%     \tl_gset_from_cs:NN, \tl_gset_from_cs:cN, \tl_gset_from_cs:Nc,
+%     \tl_gset_from_cs:cc
+%   }
+%    \begin{macrocode}
+\cs_new_protected:Nn
+  \@@_from_cs:NNNn
+  {
+    \tl_set:Nn
+      \l_@@_internal_a_tl
+      { #2 }
+    \int_step_inline:nn
+      { #4 }
+      {
+        \exp_args:NNc
+          \tl_put_right:Nn
+          \l_@@_internal_a_tl
+          { @@_from_cs_parameter_ ##1 }
+      }
+    \exp_args:NNV
+      \tl_set:No
+      \l_@@_internal_b_tl
+      \l_@@_internal_a_tl
+    \regex_replace_all:nnN
+      { \cP. }
+      { \0\0 }
+      \l_@@_internal_b_tl
+    \int_step_inline:nn
+      { #4 }
+      {
+        \regex_replace_all:nnN
+          { \c { @@_from_cs_parameter_ ##1 } }
+          { \cP\# ##1 }
+          \l_@@_internal_b_tl
+      }
+    #3
+      #1
+      \l_@@_internal_b_tl
+  }
+\cs_new_protected:Nn
+  \@@_from_cs:NNN
+  {
+    \tl_set:Ne
+      \l_@@_internal_a_tl
+      { \cs_parameter_spec:N #2 }
+    \@@_from_cs:NNNf
+      #1
+      #2
+      #3
+      { \tl_count:N \l_@@_internal_a_tl / 2 }
+  }
+\cs_generate_variant:Nn
+  \@@_from_cs:NNNn
+  { NNNf }
+\cs_new_protected:Nn
+  \tl_set_from_cs:NN
+  {
+    \@@_from_cs:NNN
+      #1
+      #2
+      \tl_set:NV
+  }
+\cs_new_protected:Nn
+  \tl_gset_from_cs:NN
+  {
+    \@@_from_cs:NNN
+      #1
+      #2
+      \tl_gset:NV
+  }
+\cs_generate_variant:Nn
+  \tl_set_from_cs:NN
+  { cN, Nc, cc }
+\cs_generate_variant:Nn
+  \tl_gset_from_cs:NN
+  { cN, Nc, cc }
+%    \end{macrocode}
+% \end{macro}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 %

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -1747,8 +1747,8 @@
 %     \tl_gset_from_cs:cc
 %   }
 %    \begin{macrocode}
-\cs_new_protected:Nn
-  \@@_from_cs:NNNn
+\cs_new_protected:Npn
+  \@@_from_cs:NNNn #1#2#3#4
   {
     \tl_set:Nn
       \l_@@_internal_a_tl
@@ -1781,8 +1781,8 @@
       #1
       \l_@@_internal_b_tl
   }
-\cs_new_protected:Nn
-  \@@_from_cs:NNN
+\cs_new_protected:Npn
+  \@@_from_cs:NNN #1#2#3
   {
     \tl_set:Ne
       \l_@@_internal_a_tl
@@ -1796,16 +1796,16 @@
 \cs_generate_variant:Nn
   \@@_from_cs:NNNn
   { NNNf }
-\cs_new_protected:Nn
-  \tl_set_from_cs:NN
+\cs_new_protected:Npn
+  \tl_set_from_cs:NN #1#2
   {
     \@@_from_cs:NNN
       #1
       #2
       \tl_set:NV
   }
-\cs_new_protected:Nn
-  \tl_gset_from_cs:NN
+\cs_new_protected:Npn
+  \tl_gset_from_cs:NN #1#2
   {
     \@@_from_cs:NNN
       #1


### PR DESCRIPTION
This PR defines functions `\tl_set_from_cs:NN` and `\tl_gset_from_cs:NN` that assign the replacement text of a control sequence to a tl var. Compared to `\cs_replacement_spec:N`, these functions preserve all category codes. These functions only work for control sequences without delimited arguments.

The code has been developed [on TeX StackExchange][1] with contributions from @eg9, @gucci-on-fleek, and @Skillmon. It is currently [used][4] in the Markdown Package for TeX to implement appending to control sequences without the need to maintain copies of their current replacement text in separate tl vars.

Here is a demonstration from TeX StackExchange of how this function can be used:

> ``` tex
> \cs_new:Npn
>   \greet
>   #1#2
>   { Hello,~#1!~How~is~#2~doing? }
> \tl_set_from_cs:NN
>   \l_greet_tl
>   \greet
> \tl_put_right:Nn
>   \l_greet_tl
>   { ~Have~a~great~#3! }
> \cs_generate_from_arg_count:NNnV
>   \greet
>   \cs_set:Npn
>   { 3 }
>   \l_greet_tl
> ```
> 
> Now, I can write `\greet { world } { favorite~species~(humans,~presumably) } { evolutionary~leap }` and receive the following expansion:
> 
> > Hello, world! How is your favorite species (humans, presumably) doing? Have a great evolutionary leap!

 [1]: https://tex.stackexchange.com/q/716362/70941
 [2]: https://github.com/Witiko/markdown/pull/435
 [3]: https://github.com/Witiko/markdown/issues/437
 [4]: https://github.com/Witiko/markdown/pull/438

This PR is currently just a draft meant to kick off a discussion on the following topics:

1. Do we want to include control sequence patching in core expl3?
2. Is l3tl the proper place for these functions?
3. Are there more appropriate names for these functions?

After the discussion, if the answer to the first question is a yes, I will add regression tests and mark this PR as ready for a review. 