### PR TITLE
Fix typos in list of variants

### DIFF
--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -304,19 +304,19 @@
 %     \prop_put_if_not_in:Nnn, \prop_put_if_not_in:NnV, \prop_put_if_not_in:Nnv, \prop_put_if_not_in:Nne,
 %     \prop_put_if_not_in:NVn, \prop_put_if_not_in:NVV, \prop_put_if_not_in:NVv, \prop_put_if_not_in:NVe,
 %     \prop_put_if_not_in:Nvn, \prop_put_if_not_in:NvV, \prop_put_if_not_in:Nvv, \prop_put_if_not_in:Nve,
-%     \prop_put_if_not_in:Nen, \prop_put_if_not_in:NeV, \prop_put_if_not_in:Nev, \prop_put_if_not_in:NeV,
+%     \prop_put_if_not_in:Nen, \prop_put_if_not_in:NeV, \prop_put_if_not_in:Nev, \prop_put_if_not_in:Nee,
 %     \prop_put_if_not_in:cnn, \prop_put_if_not_in:cnV, \prop_put_if_not_in:cnv, \prop_put_if_not_in:cne,
 %     \prop_put_if_not_in:cVn, \prop_put_if_not_in:cVV, \prop_put_if_not_in:cVv, \prop_put_if_not_in:cVe,
 %     \prop_put_if_not_in:cvn, \prop_put_if_not_in:cvV, \prop_put_if_not_in:cvv, \prop_put_if_not_in:cve,
-%     \prop_put_if_not_in:cen, \prop_put_if_not_in:ceV, \prop_put_if_not_in:cev, \prop_put_if_not_in:ceV,
+%     \prop_put_if_not_in:cen, \prop_put_if_not_in:ceV, \prop_put_if_not_in:cev, \prop_put_if_not_in:cee,
 %     \prop_gput_if_not_in:Nnn, \prop_gput_if_not_in:NnV, \prop_gput_if_not_in:Nnv, \prop_gput_if_not_in:Nne,
 %     \prop_gput_if_not_in:NVn, \prop_gput_if_not_in:NVV, \prop_gput_if_not_in:NVv, \prop_gput_if_not_in:NVe,
 %     \prop_gput_if_not_in:Nvn, \prop_gput_if_not_in:NvV, \prop_gput_if_not_in:Nvv, \prop_gput_if_not_in:Nve,
-%     \prop_gput_if_not_in:Nen, \prop_gput_if_not_in:NeV, \prop_gput_if_not_in:Nev, \prop_gput_if_not_in:NeV,
+%     \prop_gput_if_not_in:Nen, \prop_gput_if_not_in:NeV, \prop_gput_if_not_in:Nev, \prop_gput_if_not_in:Nee,
 %     \prop_gput_if_not_in:cnn, \prop_gput_if_not_in:cnV, \prop_gput_if_not_in:cnv, \prop_gput_if_not_in:cne,
 %     \prop_gput_if_not_in:cVn, \prop_gput_if_not_in:cVV, \prop_gput_if_not_in:cVv, \prop_gput_if_not_in:cVe,
 %     \prop_gput_if_not_in:cvn, \prop_gput_if_not_in:cvV, \prop_gput_if_not_in:cvv, \prop_gput_if_not_in:cve,
-%     \prop_gput_if_not_in:cen, \prop_gput_if_not_in:ceV, \prop_gput_if_not_in:cev, \prop_gput_if_not_in:ceV
+%     \prop_gput_if_not_in:cen, \prop_gput_if_not_in:ceV, \prop_gput_if_not_in:cev, \prop_gput_if_not_in:cee
 %   }
 %   \begin{syntax}
 %     \cs{prop_put_if_not_in:Nnn} \meta{property list} \Arg{key} \Arg{value}
@@ -1955,19 +1955,19 @@
 %     \prop_put_if_not_in:Nnn, \prop_put_if_not_in:NnV, \prop_put_if_not_in:Nnv, \prop_put_if_not_in:Nne,
 %     \prop_put_if_not_in:NVn, \prop_put_if_not_in:NVV, \prop_put_if_not_in:NVv, \prop_put_if_not_in:NVe,
 %     \prop_put_if_not_in:Nvn, \prop_put_if_not_in:NvV, \prop_put_if_not_in:Nvv, \prop_put_if_not_in:Nve,
-%     \prop_put_if_not_in:Nen, \prop_put_if_not_in:NeV, \prop_put_if_not_in:Nev, \prop_put_if_not_in:NeV,
+%     \prop_put_if_not_in:Nen, \prop_put_if_not_in:NeV, \prop_put_if_not_in:Nev, \prop_put_if_not_in:Nee,
 %     \prop_put_if_not_in:cnn, \prop_put_if_not_in:cnV, \prop_put_if_not_in:cnv, \prop_put_if_not_in:cne,
 %     \prop_put_if_not_in:cVn, \prop_put_if_not_in:cVV, \prop_put_if_not_in:cVv, \prop_put_if_not_in:cVe,
 %     \prop_put_if_not_in:cvn, \prop_put_if_not_in:cvV, \prop_put_if_not_in:cvv, \prop_put_if_not_in:cve,
-%     \prop_put_if_not_in:cen, \prop_put_if_not_in:ceV, \prop_put_if_not_in:cev, \prop_put_if_not_in:ceV,
+%     \prop_put_if_not_in:cen, \prop_put_if_not_in:ceV, \prop_put_if_not_in:cev, \prop_put_if_not_in:cee,
 %     \prop_gput_if_not_in:Nnn, \prop_gput_if_not_in:NnV, \prop_gput_if_not_in:Nnv, \prop_gput_if_not_in:Nne,
 %     \prop_gput_if_not_in:NVn, \prop_gput_if_not_in:NVV, \prop_gput_if_not_in:NVv, \prop_gput_if_not_in:NVe,
 %     \prop_gput_if_not_in:Nvn, \prop_gput_if_not_in:NvV, \prop_gput_if_not_in:Nvv, \prop_gput_if_not_in:Nve,
-%     \prop_gput_if_not_in:Nen, \prop_gput_if_not_in:NeV, \prop_gput_if_not_in:Nev, \prop_gput_if_not_in:NeV,
+%     \prop_gput_if_not_in:Nen, \prop_gput_if_not_in:NeV, \prop_gput_if_not_in:Nev, \prop_gput_if_not_in:Nee,
 %     \prop_gput_if_not_in:cnn, \prop_gput_if_not_in:cnV, \prop_gput_if_not_in:cnv, \prop_gput_if_not_in:cne,
 %     \prop_gput_if_not_in:cVn, \prop_gput_if_not_in:cVV, \prop_gput_if_not_in:cVv, \prop_gput_if_not_in:cVe,
 %     \prop_gput_if_not_in:cvn, \prop_gput_if_not_in:cvV, \prop_gput_if_not_in:cvv, \prop_gput_if_not_in:cve,
-%     \prop_gput_if_not_in:cen, \prop_gput_if_not_in:ceV, \prop_gput_if_not_in:cev, \prop_gput_if_not_in:ceV
+%     \prop_gput_if_not_in:cen, \prop_gput_if_not_in:ceV, \prop_gput_if_not_in:cev, \prop_gput_if_not_in:cee
 %   }
 % \begin{macro}[tested = m3prop002]
 %   {


### PR DESCRIPTION
The second occurrences of `(N|c)eV` should be `(N|c)ee`. Lists of variants in `\cs_generate_variant:Nn` were correct.

Introduced in eacd32f5 (Round-out vartiant set for \prop_(g)put_if_not_in:Nnn, 2024-05-07).