### PR TITLE
Drop outdated docs

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -809,7 +809,6 @@
 %   Sets the \meta{tl var} to the result of applying
 %   \cs{file_size:n} to the \meta{file}. If the file is not found,
 %   the \meta{tl var} will be set to \cs{q_no_value}.
-%   This is not available in older versions of \XeTeX{}.
 % \end{function}
 %
 % \begin{function}[rEXP, added = 2019-09-03]
@@ -825,7 +824,6 @@
 %   \meta{minute}\meta{second}\meta{offset}, where the latter may be |Z|
 %   (UTC) or \meta{plus-minus}\meta{hours}|'|\meta{minutes}|'|.
 %   When the file is not found, the result of expansion is empty.
-%   This is not available in older versions of \XeTeX{}.
 % \end{function}
 %
 % \begin{function}[noTF, added = 2017-07-09, updated = 2019-02-16]
@@ -836,7 +834,6 @@
 %   Sets the \meta{tl var} to the result of applying
 %   \cs{file_timestamp:n} to the \meta{file}. If the file is not found,
 %   the \meta{tl var} will be set to \cs{q_no_value}.
-%   This is not available in older versions of \XeTeX{}.
 % \end{function}
 %
 % \begin{function}[added = 2019-05-13, updated = 2019-09-20, pTF, EXP]
@@ -863,7 +860,6 @@
 %   \end{verbatim}
 %   to work when the derived file is entirely absent. The timestamp
 %   of two absent files is regarded as different.
-%   This is not available in older versions of \XeTeX{}.
 % \end{function}
 %
 % \begin{function}[noTF, updated = 2019-02-16]

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -909,7 +909,6 @@
 %   \end{syntax}
 %   Evaluates the two \meta{int expr}s and produces a
 %   pseudo-random number between the two (with bounds included).
-%   This is not available in older versions of \XeTeX{}.
 % \end{function}
 %
 % \begin{function}[EXP, added = 2018-05-05]{\int_rand:n}
@@ -918,7 +917,6 @@
 %   \end{syntax}
 %   Evaluates the \meta{int expr} then produces a
 %   pseudo-random number between $1$ and the \meta{int expr} (included).
-%   This is not available in older versions of \XeTeX{}.
 % \end{function}
 %
 % \section{Viewing integers}

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -354,7 +354,6 @@
 %   \end{syntax}
 %   Selects a pseudo-random item of the \meta{seq~var}.  If the
 %   \meta{seq~var} is empty the result is empty.
-%   This is not available in older versions of \XeTeX{}.
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -994,7 +994,6 @@
 %   \end{syntax}
 %   Selects a pseudo-random item of the \meta{token list}.  If the
 %   \meta{token list} is blank, the result is empty.
-%   This is not available in older versions of \XeTeX{}.
 %   \begin{texnote}
 %     The result is returned within the \tn{unexpanded}
 %     primitive (\cs{exp_not:n}), which means that the \meta{item}


### PR DESCRIPTION
Since l3kernel 2022-02-21 relevant primitives are all marked required, thus "This is not available in older versions XeTeX." docs can be removed.

See df25bca5 (Update primitive requirements docs, 2022-02-21).