### PR TITLE
Fix typos

### DIFF
--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -697,14 +697,14 @@
 % \begin{macro}{\@@_convert:nnnN, \@@_convert:nVnN, \@@_convert:nnVN}
 % \begin{macro}[EXP]
 %   {
-%     \@@_convert_gray_gray:w
-%     \@@_convert_gray_rgb:w
-%     \@@_convert_gray_cmyk:w
-%     \@@_convert_cmyk_gray:w
-%     \@@_convert_cmyk_rgb:w
-%     \@@_convert_cmyk_cmyk:w
-%     \@@_convert_rgb_gray:w
-%     \@@_convert_rgb_rgb:w
+%     \@@_convert_gray_gray:w,
+%     \@@_convert_gray_rgb:w,
+%     \@@_convert_gray_cmyk:w,
+%     \@@_convert_cmyk_gray:w,
+%     \@@_convert_cmyk_rgb:w,
+%     \@@_convert_cmyk_cmyk:w,
+%     \@@_convert_rgb_gray:w,
+%     \@@_convert_rgb_rgb:w,
 %     \@@_convert_rgb_cmyk:w
 %   }
 %  \begin{macro}[EXP]{\@@_convert_rgb_cmyk:nnn}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -649,8 +649,6 @@
 %           { key }                              % Name of choice key
 %           { choice-a , choice-b ,  choice-c }  % Valid choices
 %           { \exp_not:n {#1} }                  % Invalid choice given
-%       %
-%       %
 %     }
 % \end{verbatim}
 %

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -181,11 +181,11 @@
 %     \prop_gset_from_keyval:Nn, \prop_gset_from_keyval:cn,
 %   }
 %   \begin{syntax}
-%     \cs{prop_set_from_keyval:Nn} \meta{property list}
-%       \{
-%         \meta{key1} |=| \meta{value1} |,|
-%         \meta{key2} |=| \meta{value2} |,| \ldots{}
-%       \}
+%     \cs{prop_set_from_keyval:Nn} \meta{property list} \\
+%     ~~\{ \\
+%     ~~~~\meta{key1} |=| \meta{value1} |,| \\
+%     ~~~~\meta{key2} |=| \meta{value2} |,| \ldots{} \\
+%     ~~\}
 %   \end{syntax}
 %   Sets \meta{property list} to contain key--value pairs given in the second
 %   argument.  If duplicate keys appear only the last of the values is kept.
@@ -205,11 +205,11 @@
 % \begin{function}[added = 2017-11-28, updated = 2021-11-07]
 %   {\prop_const_from_keyval:Nn, \prop_const_from_keyval:cn}
 %   \begin{syntax}
-%     \cs{prop_const_from_keyval:Nn} \meta{property list}
-%       \{
-%         \meta{key1} |=| \meta{value1} |,|
-%         \meta{key2} |=| \meta{value2} |,| \ldots{}
-%       \}
+%     \cs{prop_const_from_keyval:Nn} \meta{property list} \\
+%     ~~\{ \\
+%     ~~~~\meta{key1} |=| \meta{value1} |,| \\
+%     ~~~~\meta{key2} |=| \meta{value2} |,| \ldots{} \\
+%     ~~\}
 %   \end{syntax}
 %   Creates a new constant \enquote{flat} \meta{property list} or raises
 %   an error if the
@@ -224,11 +224,11 @@
 % \begin{function}[added = 2024-02-12]
 %   {\prop_const_linked_from_keyval:Nn, \prop_const_linked_from_keyval:cn}
 %   \begin{syntax}
-%     \cs{prop_const_linked_from_keyval:Nn} \meta{prop~var}
-%       \{
-%         \meta{key1} |=| \meta{value1} |,|
-%         \meta{key2} |=| \meta{value2} |,| \ldots{}
-%       \}
+%     \cs{prop_const_linked_from_keyval:Nn} \meta{prop~var} \\
+%     ~~\{ \\
+%     ~~~~\meta{key1} |=| \meta{value1} |,| \\
+%     ~~~~\meta{key2} |=| \meta{value2} |,| \ldots{} \\
+%     ~~\}
 %   \end{syntax}
 %   Creates a new constant \enquote{linked} \meta{prop~var} or raises an
 %   error if the
@@ -347,11 +347,11 @@
 %     \prop_gput_from_keyval:Nn, \prop_gput_from_keyval:cn,
 %   }
 %   \begin{syntax}
-%     \cs{prop_put_from_keyval:Nn} \meta{property list}
-%       \{
-%         \meta{key1} |=| \meta{value1} |,|
-%         \meta{key2} |=| \meta{value2} |,| \ldots{}
-%       \}
+%     \cs{prop_put_from_keyval:Nn} \meta{property list} \\
+%     ~~\{ \\
+%     ~~~~\meta{key1} |=| \meta{value1} |,| \\
+%     ~~~~\meta{key2} |=| \meta{value2} |,| \ldots{} \\
+%     ~~\}
 %   \end{syntax}
 %   Updates the \meta{property list} by adding entries for each key--value
 %   pair given in the second argument.  The addition is done through


### PR DESCRIPTION
Address typos reported in #1553 except for the two similar TeX hackers notes in `l3int`.