### PR TITLE
Fix miscellaneous typos and missing punctuation in the docs

### DIFF
--- a/l3kernel/l3box.dtx
+++ b/l3kernel/l3box.dtx
@@ -906,9 +906,9 @@
 %   \begin{syntax}
 %     \cs{box_set_trim:Nnnnn} \meta{box} \Arg{left} \Arg{bottom} \Arg{right} \Arg{top}
 %   \end{syntax}
-%   Adjusts the bounding box of the \meta{box} \meta{left} is removed from
+%   Adjusts the bounding box of the \meta{box}: \meta{left} is removed from
 %   the left-hand edge of the bounding box, \meta{right} from the right-hand
-%   edge and so fourth. All adjustments are \meta{dim exprs}.
+%   edge, and so forth. All adjustments are \meta{dim exprs}.
 %   Material outside of the bounding box is still displayed in the output
 %   unless \cs{box_set_clipped:N} is subsequently applied.
 %   The updated \meta{box} is an

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -103,7 +103,7 @@
 % \begin{itemize}
 %   \item \texttt{Gray} Grayscale color, with a single axis running from
 %     $0$ (fully black) to $15$ (fully white)
-%   \item \texttt{hsb} Hue-saturation-brightness color, with three axes,all
+%   \item \texttt{hsb} Hue-saturation-brightness color, with three axes, all
 %     real values in the range $[0,1]$ for hue saturation and brightness
 %   \item \texttt{Hsb} Hue-saturation-brightness color, with three axes, integer
 %     in the range $[0,360]$ for hue, real values in the range $[0,1]$ for
@@ -406,20 +406,20 @@
 %
 % \begin{function}{\color_export:nnN}
 %   \begin{syntax}
-%     \cs{color_export:nnN} \Arg{color expression} \Arg{format} \Arg{tl}
+%     \cs{color_export:nnN} \Arg{color expression} \Arg{format} \meta{tl var}
 %   \end{syntax}
 %   Parses the \meta{color expression} as described earlier,
 %   then converts to the \meta{format} specified and assigns the data to the
-%   \meta{tl}.
+%   \meta{tl var}.
 % \end{function}
 %
 % \begin{function}{\color_export:nnnN}
 %   \begin{syntax}
-%     \cs{color_export:nnnN} \Arg{model} \Arg{value(s)} \Arg{format} \Arg{tl}
+%     \cs{color_export:nnnN} \Arg{model} \Arg{value(s)} \Arg{format} \meta{tl var}
 %   \end{syntax}
 %   Expresses the combination of \meta{model} and \meta{value(s)} in an
 %   internal representation, then converts to the \meta{format} specified and
-%   assigns the data to the \meta{tl}.
+%   assigns the data to the \meta{tl var}.
 % \end{function}
 %
 % \section{Creating new color models}
@@ -495,7 +495,7 @@
 %
 % Color profiles are used to ensure color accuracy by linking to collaboration.
 % Applying a profile can be used to standardise color which is otherwise
-% device-dependence.
+% device-dependent.
 %
 % \begin{function}[added = 2021-02-23]{\color_profile_apply:nn}
 %   \begin{syntax}

--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -773,7 +773,7 @@
 %   The result may contain other functions, which are
 %   then replaced by their results if they have any.  For instance,
 %   \begin{quote}
-%     \cs{fp_new_function:n} |{ foo }| \\
+%     \cs{fp_new_function:n} |{ npow }| \\
 %     \cs{fp_set_function:nnn} |{ npow } { a,b } { a**b }| \\
 %     \cs{fp_show:n} |{ npow(16,0.25) } }|
 %   \end{quote}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -657,7 +657,7 @@
 % Multiple choices are created in a very similar manner to mutually-exclusive
 % choices, using the properties \texttt{.multichoice:} and
 % \texttt{.multichoices:nn}. As with mutually exclusive choices, multiple
-% choices are define as sub-keys. Thus both
+% choices are defined as sub-keys. Thus both
 % \begin{verbatim}
 %   \keys_define:nn { mymodule }
 %     {

--- a/l3kernel/l3pdf.dtx
+++ b/l3kernel/l3pdf.dtx
@@ -70,8 +70,8 @@
 %     \cs{pdf_object_write:nnn} \Arg{object} \Arg{type} \Arg{content}
 %   \end{syntax}
 %   Writes the \meta{content} as content of the \meta{object}. Depending on the
-%   \meta{type} declared for the object, the format required for the
-%   \meta{data} will vary
+%   \meta{type} declared for the object, the format required for
+%   \meta{content} will vary:
 %   \begin{itemize}
 %     \item[\texttt{array}] A space-separated list of values
 %     \item[\texttt{dict}] Key--value pairs in the form
@@ -159,7 +159,7 @@
 %     \cs{pdf_object_unnamed_write:nn} \Arg{type} \Arg{content}
 %   \end{syntax}
 %   Writes the \meta{content} as content of an anonymous object. Depending on the
-%   \meta{type}, the format required for the \meta{data} will vary
+%   \meta{type}, the format required for \meta{content} will vary:
 %   \begin{itemize}
 %     \item[\texttt{array}] A space-separated list of values
 %     \item[\texttt{dict}] Key--value pairs in the form
@@ -251,9 +251,9 @@
 %
 % \section{Destinations}
 %
-% Destinations are the places a link jumped too.
-% Unlike the name may suggest they don't described
-% an exact location in the PDF. Instead a destination contains a reference to
+% Destinations are the places a link jumped to.
+% Unlike the name may suggest, they don't describe
+% an exact location in the PDF. Instead, a destination contains a reference to
 % a page along with an instruction how to display this page.
 % The normally used \enquote{XYZ \textit{top left zoom}} for example instructs
 % the viewer to show the page with the given \textit{zoom} and

--- a/l3kernel/l3text.dtx
+++ b/l3kernel/l3text.dtx
@@ -65,11 +65,11 @@
 %   \end{syntax}
 %   Takes user input \meta{text} and expands the content.
 %   Protected commands (typically
-%   formatting) are left in place, and no processing takes place of
+%   formatting) are left in place, and no processing of
 %   math mode material (as delimited by pairs given in
 %   \cs{l_text_math_delims_tl} or as the argument to commands listed
-%   in \cs{l_text_math_arg_tl}). Commands which are neither engine-
-%   nor \LaTeX{} protected are expanded exhaustively.
+%   in \cs{l_text_math_arg_tl}) takes place. Commands which are neither engine-
+%   nor \LaTeX{}-protected are expanded exhaustively.
 %   Any commands listed in \cs{l_text_expand_exclude_tl} are excluded from
 %   expansion, as are those in \cs{l_text_case_exclude_arg_tl} and
 %   \cs{l_text_math_arg_tl}.
@@ -214,8 +214,8 @@
 %     \text_declare_uppercase_mapping:nnn
 %   }
 %   \begin{syntax}
-%     \cs{text_declare_lowercase_mapping:nn} \Arg{codeppoint}  \Arg{replacement}
-%     \cs{text_declare_lowercase_mapping:nnn} \Arg{BCP-47} \Arg{codeppoint} \Arg{replacement}
+%     \cs{text_declare_lowercase_mapping:nn} \Arg{codepoint}  \Arg{replacement}
+%     \cs{text_declare_lowercase_mapping:nnn} \Arg{BCP-47} \Arg{codepoint} \Arg{replacement}
 %   \end{syntax}
 %   Declares that the \meta{replacement} tokens should be used when case mapping
 %   the \meta{codepoint}, rather than the standard mapping given in the


### PR DESCRIPTION
This PR fixes miscellaneous typos and missing punctuation that I noticed while reading `interfaces3.pdf` back-to-back.

I manually ran `l3build doc` and eyeballed `interfaces3.pdf` to ensure that these changes do not produce poor line breaks.