### PR TITLE
Register ptxtools + zugferd prefix

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -300,4 +300,5 @@ zhnum,zhnumber,Qing Lee,https://github.com/CTeX-org/ctex-kit,https://github.com/
 zrefcheck,zref-check,gusbrs,https://github.com/gusbrs/zref-check,https://github.com/gusbrs/zref-check,https://github.com/gusbrs/zref-check/issues,2021-08-05,2021-08-05,
 zrefclever,zref-clever,gusbrs,https://github.com/gusbrs/zref-clever,https://github.com/gusbrs/zref-clever,https://github.com/gusbrs/zref-clever/issues,2021-11-29,2021-11-29,
 zrefvario,zref-vario,gusbrs,https://github.com/gusbrs/zref-vario,https://github.com/gusbrs/zref-vario,https://github.com/gusbrs/zref-vario/issues,2022-02-02,2022-02-02,
+zugferd,zugferd,Marei Peischl,https://github.com/TeXhackse/LaTeX-ZUGFeRD,https://github.com/TeXhackse/LaTeX-ZUGFeRD.git,https://github.com/TeXhackse/LaTeX-ZUGFeRD/issues,2024-07-09,2024-07-09,
 zxjt,zxjatype,Takayuki Yato,,,,2013-03-16,2013-03-16,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -210,6 +210,7 @@ property,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,htt
 pseudo,pseudo,Magnus Lie Hetland,https://github.com/mlhetland/pseudo.sty,https://github.com/mlhetland/pseudo.sty.git,https://github.com/mlhetland/pseudo.sty/issues,2019-06-24,2019-06-24,
 ptex,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2015-07-28,2015-07-28,
 ptxcd,ptxcd,Marei Peischl,,,,2020-07-27,2020-07-27,Used for specific corporate design templates
+ptxtools,"depp, ptxtools",Marei Peischl,https://gitlab.com/islandoftex/texmf/depp,https://gitlab.com/islandoftex/texmf/depp.git,https://gitlab.com/islandoftex/texmf/depp,2024-07-09,2024-07-09,
 qrbill,qrbill,Marei Peischl,https://github.com/peiTeX/qrbill,https://github.com/peiTeX/qrbill.git,https://github.com/peiTeX/qrbill/issues,2020-06-27,2020-06-27,
 quark,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 rainbow,beamertheme-rainbow,samcarter,https://github.com/samcarter/beamertheme-rainbow,https://github.com/samcarter/beamertheme-rainbow,https://github.com/samcarter/beamertheme-rainbow/issues,2023-07-04,2023-07-04,


### PR DESCRIPTION
I hope it's okay to do 2 at once.

I wonder if it would be better to have kind of overview page for the older ptxcd and the ptxtools prefix. If you think that would be useful I'd create something like that. as it's actually spanning across multiple projects which by design would not overlap.