### PR TITLE
Redo the fix for LaTeX2e key properties

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Redo the fix for LaTeX2e key properties (issue latex3/latex2e\#1415)
+
 ## [2024-06-19]
 
 ### Fixed

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1924,19 +1924,20 @@
 % \end{macro}
 %
 % \begin{macro}{\@@_define_code:n}
-% \begin{macro}[EXP]{\@@_define_code:TF}
+% \begin{macro}[EXP]{\@@_define_code:nnn}
 % \begin{macro}[EXP]{\@@_define_code:w}
 %   Two possible cases. If there is a value for the key, then just use
 %   the function. If not, then a check to make sure there is no need for
 %   a value with the property. If there should be one then complain,
-%   otherwise execute it. There is no need to check for a |:| as if it
-%   was missing the earlier tests would have failed.
+%   otherwise execute it. If it's a \LaTeXe{} property like |.code|
+%   which doesn't contain a |:|, treat it as arity 1.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_define_code:n #1
   {
     \bool_if:NTF \l_@@_no_value_bool
       {
-        \@@_define_code:TF
+        \@@_define_code:nnn
+          { \use:c { \c_@@_props_root_str \l_@@_property_str } {#1} }
           { \use:c { \c_@@_props_root_str \l_@@_property_str } }
           {
             \msg_error:nnee { keys } { property-requires-value }
@@ -1945,7 +1946,7 @@
       }
       { \use:c { \c_@@_props_root_str \l_@@_property_str } {#1} }
   }
-\cs_new:Npe \@@_define_code:TF
+\cs_new:Npe \@@_define_code:nnn
   {
     \exp_not:N \exp_after:wN \exp_not:N \@@_define_code:w
       \exp_not:N \l_@@_property_str
@@ -1957,7 +1958,15 @@
     \cs_new:Npn \exp_not:N \@@_define_code:w
       #1 \c_colon_str #2 \c_colon_str #3 \exp_not:N \s_@@_stop
   }
-    { \tl_if_empty:nTF {#2} }
+    {
+      \tl_if_empty:nTF {#3}
+        { \use_i:nnn }
+        {
+          \tl_if_empty:nTF {#2}
+            { \use_ii:nnn }
+            { \use_iii:nnn }
+        }
+    }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1929,8 +1929,9 @@
 %   Two possible cases. If there is a value for the key, then just use
 %   the function. If not, then a check to make sure there is no need for
 %   a value with the property. If there should be one then complain,
-%   otherwise execute it. If it's a \LaTeXe{} property like |.code|
-%   which doesn't contain a |:|, treat it as arity 1.
+%   otherwise execute it. For a \LaTeXe{} property like |.code| which
+%   doesn't contain a |:|, treat it as having arity 1 and pass the
+%   (empty) value to it.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_define_code:n #1
   {

--- a/l3kernel/testfiles/m3keys001.lvt
+++ b/l3kernel/testfiles/m3keys001.lvt
@@ -311,11 +311,12 @@
 \TEST { Known~property~but~missing~argument }
   {
     \OMIT
-    \cs_gset_protected:cpn { \c__keys_props_root_str .demo } { }
+    \cs_new_eq:cc
+      { \c__keys_props_root_str .demo }
+      { \c__keys_props_root_str .code:n }
     \TIMO
-  }
-  {
     \keys_define:nn { module } { key-one .demo }
+    \keys_show:nn { module } { key-one }
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3keys001.tlg
+++ b/l3kernel/testfiles/m3keys001.tlg
@@ -151,6 +151,11 @@ LaTeX did not find a '.' to indicate the start of a property.
 ============================================================
 TEST 11: Known property but missing argument
 ============================================================
+Defining key module/key-one on line ...
+The key module/key-one has the properties:
+>  code  =>  .
+<recently read> }
+l. ...  }
 ============================================================
 ============================================================
 TEST 12: Empty module


### PR DESCRIPTION
Fixes the flawed previous fix 76bdd69d (Avoid an error if a key prop. is lacking a value, 2024-06-19), see my analysis https://github.com/latex3/latex2e/issues/1415#issuecomment-2227205603.

Unlike what @Skillmon suggested in latex3/latex2e#1415, this PR still treats `\DeclareKeys{foo .code}` the same as `\DeclareKeys{foo .code = {}}`, rather than raising an error.