### PR TITLE
Fix implementation of deprecated `\tl_mixed_case:n(n)`

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Fixed
+- Implementation of deprecated `\tl_mixed_case:n(n)`
+
 ## [2024-06-19]
 
 ### Fixed

--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -505,10 +505,10 @@
   { \text_uppercase:nn {#1} {#2} }
 \__kernel_patch_deprecation:nnNNpn { 2020-01-03 } { \text_titlecase_first:n }
 \cs_new:Npn \tl_mixed_case:n #1
-  { \text_titlecase_first:n {#1} }
+  { \text_titlecase_first:n { \text_lowercase:n {#1} } }
 \__kernel_patch_deprecation:nnNNpn { 2020-01-03 } { \text_titlecase_first:nn }
 \cs_new:Npn \tl_mixed_case:nn #1#2
-  { \text_titlecase_first:nn {#1} {#2} }
+  { \text_titlecase_first:nn {#1} { \text_lowercase:n {#2} } }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3deprecation.dtx
+++ b/l3kernel/l3deprecation.dtx
@@ -571,7 +571,7 @@
 %     \char_lower_case:N, \char_upper_case:N,
 %     \char_mixed_case:Nn, \char_fold_case:N,
 %     \char_str_lower_case:N, \char_str_upper_case:N,
-%     \char_str_mixed_case:Nn, \char_str_fold_case:N,
+%     \char_str_mixed_case:N, \char_str_fold_case:N,
 %   }
 %    \begin{macrocode}
 \__kernel_patch_deprecation:nnNNpn { 2020-01-03 } { \text_lowercase:n }

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -757,7 +757,7 @@
 %     \item Case changing text for typesetting: see the
 %       \cs[index=text_lowercase:n]{text_lowercase:n(n)},
 %       \cs[index=text_uppercase:n]{text_uppercase:n(n)} and
-%       \cs[index=text_titlecase_all:n]{text_titlecase_(all|once):n(n)} functions which
+%       \cs[index=text_titlecase_all:n]{text_titlecase_(all|first):n(n)} functions which
 %       correctly deal with context-dependence and other factors appropriate
 %       to text case changing.
 %   \end{itemize}


### PR DESCRIPTION
Sync their implementation with that of `\text_titlecase:n(n)`.