### PR TITLE
Support 'opt' cmds in \GetDocumentCommandArgSpec

### DIFF
--- a/l3packages/CHANGELOG.md
+++ b/l3packages/CHANGELOG.md
@@ -8,6 +8,8 @@ this project uses date-based 'snapshot' version identifiers.
 ## [Unreleased]
 
 ### Fixed
+- Support for optimised commands using `\GetDocumentCommandArgSpec` (issue
+  [\#1550](https://github.com/latex3/latex3/issues/1550))
 - Unmatched `macrocode` environment in `xtemplate`
 
 ## [2024-05-08]

--- a/l3packages/xparse/testfiles/xparse009.lvt
+++ b/l3packages/xparse/testfiles/xparse009.lvt
@@ -87,5 +87,14 @@
     \ShowDocumentEnvironmentArgSpec { undefined }
   }
 
+\TEST { Optimised~specs }
+  {
+    \OMIT
+    \DeclareDocumentCommand \fooa { } { }
+    \DeclareDocumentCommand \foob { mmm } { }
+    \TIMO
+    \ShowDocumentCommandArgSpec { \fooa }
+    \ShowDocumentCommandArgSpec { \foob }
+  }
 
 \END

--- a/l3packages/xparse/testfiles/xparse009.tlg
+++ b/l3packages/xparse/testfiles/xparse009.tlg
@@ -4,8 +4,8 @@ Author: Joseph Wright
 ============================================================
 TEST 1: Get and show argument spec
 ============================================================
-|\null code |
-> \ArgumentSpecification=\null code .
+||
+> \ArgumentSpecification=.
 <recently read> }
 l. ...  }
 ||
@@ -208,7 +208,7 @@ For immediate help type H <return>.
 l. ...  }
 You have used \NewExpandableDocumentCommand with a command that already has a definition.
 The existing definition of '\?' will not be altered.
-> \ArgumentSpecification=\? code .
+> \ArgumentSpecification=m.
 <recently read> }
 l. ...  }
 ============================================================
@@ -237,4 +237,14 @@ For immediate help type H <return>.
  ...                                              
 l. ...  }
 You have asked for the argument specification for the environment 'undefined', but it is not defined.
+============================================================
+============================================================
+TEST 4: Optimised specs
+============================================================
+> \ArgumentSpecification=.
+<recently read> }
+l. ...  }
+> \ArgumentSpecification=mmm.
+<recently read> }
+l. ...  }
 ============================================================

--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -1442,7 +1442,22 @@
   {
     \__kernel_cmd_if_xparse:NTF #1
       {
-        \tl_set:Ne \ArgumentSpecification { \tl_item:Nn #1 { 2 } }
+        \tl_set:Ne \ArgumentSpecification
+          {
+            \exp_args:No \tl_if_head_eq_meaning:nNTF {#1} \@@_start_optimized:
+              {
+                \prg_replicate:nn
+                  {
+                    \str_count:e
+                      {
+                        \exp_args:Nc \cs_parameter_spec:N
+                          { \cs_to_str:N #1 \c_space_tl code }
+                      } / 2
+                  }
+                  { m }
+              }
+              { \tl_item:Nn #1 { 2 } }
+          }
         #2
       }
       {#3}

--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -1436,7 +1436,9 @@
 %
 % \begin{macro}{\@@_get_arg_spec:NTF}
 %   If the command is not an \pkg{xparse} command, complain.  If it is,
-%   its second \enquote{item} is the argument specification.
+%   its second \enquote{item} is the argument specification unless the
+%   command is optimised: in the latter case, we can reconstruct the
+%   spec.
 %    \begin{macrocode}
 \cs_gset_protected:Npn \@@_get_arg_spec:NTF #1#2#3
   {


### PR DESCRIPTION
Fixes #1550.