### PR TITLE
Add quark (`\q_`) and scan mark (`\s_`) prefixes to naming scheme

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+- Add quark (`\q_`) and scan mark (`\s_`) prefixes to naming scheme
+  (issue \#1565)
+
 ## [2024-07-20]
 
 ### Fixed

--- a/l3kernel/doc/source3body.tex
+++ b/l3kernel/doc/source3body.tex
@@ -344,6 +344,19 @@ are never used by the core code. The nature of \TeX{} grouping means that as
 with any other scratch variable, these should only be set and used with no
 intervening third-party code.
 
+There are two more special types of constants:
+\begin{description}
+  \item[\texttt{q}] Quark constants.
+  \item[\texttt{s}] Scan mark constants.
+\end{description}
+Similarly, each quark or scan mark name starts with the module name,
+but doesn't end with a variable type, because the type is already
+marked by the prefix \texttt{q} or \texttt{s}.
+Some general quarks and scan marks provided by \LaTeX3 don't start
+with a module name, for example \cs{s_stop}.
+See documentation of quarks and scan marks in Chapter~\ref{sec:l3quarks}
+for more info.
+
 \subsection{Terminological inexactitude}
 
 A word of warning. In this document, and others referring to the \pkg{expl3}

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -454,6 +454,15 @@
 % implementation in \LaTeX3 means that |toks| are not required, and that
 % all operations for storing tokens can use the |tl| variable type.
 %
+% There are two more special types of constants:
+% \begin{arg-description}
+%   \item[q] constants of quark type;
+%   \item[s] constants of scan mark type.
+% \end{arg-description}
+% The \meta{type} part of quark and scan mark constants is omitted, and
+% the \meta{module} part of general quarks and scan marks is often
+% omitted too.
+%
 % Experienced \TeX{} programmers will notice that some of the variable
 % types listed are native \TeX{} registers whilst others are not. In
 % general, the underlying \TeX{} implementation for a data structure may

--- a/l3kernel/l3quark.dtx
+++ b/l3kernel/l3quark.dtx
@@ -32,7 +32,7 @@
 %
 % \title{^^A
 %   The \pkg{l3quark} module\\ Quarks and scan marks^^A
-% }
+% }\ifdefined\thechapter\label{sec:l3quarks}\fi
 %
 % \author{^^A
 %  The \LaTeX{} Project\thanks


### PR DESCRIPTION
Closes #1565.