### PR TITLE
Enlarge left margin of description envs with one-liner items

### DIFF
--- a/l3kernel/doc/source3body.tex
+++ b/l3kernel/doc/source3body.tex
@@ -285,7 +285,7 @@ pass it to |\foo:N|.
 
 Variables are named in a similar manner to functions, but begin with
 a single letter to define the type of variable:
-\begin{description}
+\begin{description}[leftmargin=2\parindent, labelindent*=-\parindent]
   \item[\texttt{c}] Constant: global parameters whose value should not
     be changed.
   \item[\texttt{g}] Parameters whose value should only be set globally.
@@ -302,7 +302,7 @@ function, typically starting with the module\footnote{The module names are
   \texttt{\string\l_int_tmpa_int} would be very unreadable.}  name
 and then a descriptive part.
 Variables end with a short identifier to show the variable type:
-\begin{description}%  
+\begin{description}[leftmargin=2\parindent, labelindent*=-\parindent]
   \item[\texttt{bitset}] a set of bits (a string made up of a series of \texttt{0}
     and \texttt{1} tokens that are accessed by position).
   \item[\texttt{clist}] Comma separated list.
@@ -318,7 +318,7 @@ Variables end with a short identifier to show the variable type:
 Applying \texttt{V}-type or \texttt{v}-type expansion to variables of
 one of the above types is supported, while it is not supported for the
 following variable types:
-\begin{description}
+\begin{description}[leftmargin=2\parindent, labelindent*=-\parindent]
   \item[\texttt{bool}] Either true or false.
   \item[\texttt{box}] Box register.
   \item[\texttt{coffin}] A \enquote{box with handles} --- a higher-level
@@ -345,7 +345,7 @@ with any other scratch variable, these should only be set and used with no
 intervening third-party code.
 
 There are two more special types of constants:
-\begin{description}
+\begin{description}[leftmargin=2\parindent, labelindent*=-\parindent]
   \item[\texttt{q}] Quark constants.
   \item[\texttt{s}] Scan mark constants.
 \end{description}


### PR DESCRIPTION
This PR makes sentences between `description` envs consisting of mostly one-liner items more visible (in `interface3.pdf`, sec. 1.1 Naming functions and variables), by setting `enumitem` options to enlarge left margin of those `description` envs.

`enumitem` is loaded by `l3doc`.

| Before | After |
|--------|-------|
| ![image](https://github.com/user-attachments/assets/01dde00e-2d90-4bd2-8be4-9fb143cc77db) | ![image](https://github.com/user-attachments/assets/eba1b28c-46f8-4704-8ca0-f1a0f66f73d8) |

The first `description` env for function argument specifiers are not modified, since items in it all span multiple lines.

| Beginning | Ending |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/c6093b7b-4522-4d29-bd4c-4bfbd4d5c070) | ![image](https://github.com/user-attachments/assets/de96e1f4-2307-41be-92a9-19d4e7994686) | 


