### PR TITLE
Fix handling of `ltcmd` newlines (`\obeyedline`) in l3doc

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -11,6 +11,9 @@ this project uses date-based 'snapshot' version identifiers.
 - Reduce memory usage when building Unicode data storage
 - Avoid recursive doc for `\file_if_exist:n(TF)` (issue \#1573)
 
+### Fixed
+- Handling of `ltcmd` newlines (`\obeyedline`) in `l3doc` (issue \#1577)
+
 ## [2024-08-16]
 
 ### Added

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1151,10 +1151,9 @@
 %     argument (a single token denoted by |N|) is still free for definition.
 %     It would be used in constructions like
 %     \begin{quote}
-%       |\bool_if:nTF {| \\
-%       \verb"  \cs_if_free_p:N \l_tmpz_tl || \cs_if_free_p:N \g_tmpz_tl " \\
-%       |}|
-%       \Arg{true code} \Arg{false code}
+%       "\bool_if:nTF" \\
+%       "  { \cs_if_free_p:N \l_tmpz_tl || \cs_if_free_p:N \g_tmpz_tl }" \\
+%       "  "\Arg{true code} \Arg{false code}
 %     \end{quote}
 %
 %     For each predicate defined, a \enquote{branching conditional}

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -2160,10 +2160,18 @@ and all files in that bundle must be distributed together.
 %
 % \begin{macro}{\@@_names_get_seq:nN}
 %   The argument~|#1| (argument of a |function| or |macro| environment)
-%   has catcodes $10$ (space), $12$ (other) and $13$ (active).  Sanitize
-%   catcodes.  If the |verb| option was used, output a one-item
-%   sequence.  Otherwise, remove any \enquote{\%} character at the
-%   beginning of a line.  Remove tabs and newlines.  Finally, convert
+%   has catcodes $10$ (space), $12$ (other) and $13$ (active), and
+%   since \LaTeX{} 2024-06-01 also macro \cs{obeyedline} in replacement
+%   of active |^^M| tokens (due to the revised behavior of |+v|
+%   argument type in |ltcmd|).
+%   If the |verb| option was used, sanitize catcodes and output
+%   a one-item sequence.
+%   Otherwise, remove any \enquote{\%} character at the beginning of
+%   a line using new end-of-line marker \cs{obeyedline}.  Remove any
+%   remaining \cs{obeyedline}.  Then sanitize catcodes so we keep those
+%   verbatim \cs{obeyedline} typed in by user.  Remove remaining
+%   \enquote{\%} character at the beginning of a line using traditional
+%   |^^M| marker. Remove tabs and newlines.  Finally, convert
 %   |_@@| and |@@| to |__|\meta{module name} (if it is non-empty).  At
 %   this point, \cs{l_@@_tmpa_tl} contains a comma-delimited list of
 %   names, where |@| and~|_| have category code letter.  Turn it to a
@@ -2172,17 +2180,20 @@ and all files in that bundle must be distributed together.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_names_get_seq:nN #1#2
   {
-    \__kernel_tl_set:Nx \l_@@_tmpa_tl { \tl_to_str:n {#1} }
     \bool_if:NTF \l_@@_names_verb_bool
       {
         \seq_clear:N #2
-        \seq_put_right:NV #2 \l_@@_tmpa_tl
+        \seq_put_right:Ne #2 { \tl_to_str:n {#1} }
       }
       {
+        \tl_set:Nn \l_@@_tmpa_tl {#1}
+        \tl_remove_all:Ne \l_@@_tmpa_tl
+          { \exp_not:N \obeyedline \c_percent_str }
+        \tl_remove_all:Ne \l_@@_tmpa_tl
+          { \exp_not:N \obeyedline }
+        \__kernel_tl_set:Nx \l_@@_tmpa_tl { \tl_to_str:N \l_@@_tmpa_tl }
         \tl_remove_all:Ne \l_@@_tmpa_tl
           { \iow_char:N \^^M \c_percent_str }
-        \tl_remove_all:Ne \l_@@_tmpa_tl
-          { \token_to_str:N \obeyedline \c_space_tl \c_percent_str }
         \tl_remove_all:Ne \l_@@_tmpa_tl { \tl_to_str:n { ^ ^ A } }
         \tl_remove_all:Ne \l_@@_tmpa_tl { \iow_char:N \^^I }
         \tl_remove_all:Ne \l_@@_tmpa_tl { \iow_char:N \^^M }

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -75,8 +75,8 @@
 % If \cs{seq_gpush:No} was not defined it could be coded in the following way:
 % \begin{verbatim}
 %   \exp_args:NNo \seq_gpush:Nn
-%      \g_file_name_stack
-%      { \l_tmpa_tl }
+%     \g_file_name_stack
+%     { \l_tmpa_tl }
 % \end{verbatim}
 % In other words, the first argument to \cs{exp_args:NNo} is the base
 % function and the other arguments are preprocessed and then passed to

--- a/l3kernel/testfiles-l3doc/github-1577.lvt
+++ b/l3kernel/testfiles-l3doc/github-1577.lvt
@@ -34,6 +34,11 @@
   doc
 \end{function}
 
+\begin{function}{
+  \obeyedline}
+  doc
+\end{function}
+
 \end{documentation}
 
 \DocInput{\jobname.lvt}
@@ -49,7 +54,6 @@
 %    \end{macrocode}
 %
 % \begin{macro}{\foo:NN}
-% This function is interesting.
 %    \begin{macrocode}
 \cs_new:Npn \foo:NN #1#2 {}
 %    \end{macrocode}
@@ -60,10 +64,16 @@
 %     \foo_b:NN,
 %     \foo_b:cN
 %   }
-% This function is interesting.
 %    \begin{macrocode}
 \cs_new:Npn \foo_b:NN #1#2 {}
 \cs_generate_variant:Nn \foo_b:NN {c}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\obeyedline
+% }
+%    \begin{macrocode}
+\cs_new_protected:Npn \obeyedline { \par }
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/testfiles-l3doc/github-1577.lvt
+++ b/l3kernel/testfiles-l3doc/github-1577.lvt
@@ -1,0 +1,73 @@
+%
+% Copyright (C) The LaTeX Project
+%
+
+% \iffalse
+%<*driver>
+\input regression-test.tex
+\documentclass{l3doc}
+
+\ExplSyntaxOn
+% relies on some internal implementation
+\hook_gput_code:nnn {env/function/end} {.}
+  { \TIMO \seq_show:N \l__codedoc_names_seq \OMIT }
+
+\hook_gput_code:nnn {env/macro/end} {.}
+  { \TIMO \seq_show:N \l__codedoc_names_seq \OMIT }
+\ExplSyntaxOff
+
+\begin{document}
+\START
+\OMIT
+
+\begin{documentation}
+
+\begin{function}{\foo:NN}
+  doc
+\end{function}
+
+\begin{function}
+  {
+    \foo_b:NN,
+    \foo_b:cN
+  }
+  doc
+\end{function}
+
+\end{documentation}
+
+\DocInput{\jobname.lvt}
+
+\TIMO
+\END
+\end{document}
+%</driver>
+% \fi
+% \begin{implementation}
+%    \begin{macrocode}
+%<*package>
+%    \end{macrocode}
+%
+% \begin{macro}{\foo:NN}
+% This function is interesting.
+%    \begin{macrocode}
+\cs_new:Npn \foo:NN #1#2 {}
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}
+%   {
+%     \foo_b:NN,
+%     \foo_b:cN
+%   }
+% This function is interesting.
+%    \begin{macrocode}
+\cs_new:Npn \foo_b:NN #1#2 {}
+\cs_generate_variant:Nn \foo_b:NN {c}
+%    \end{macrocode}
+% \end{macro}
+%
+%    \begin{macrocode}
+%</package>
+%    \end{macrocode}
+% \end{implementation}

--- a/l3kernel/testfiles-l3doc/github-1577.tlg
+++ b/l3kernel/testfiles-l3doc/github-1577.tlg
@@ -10,11 +10,19 @@ The sequence \l__codedoc_names_seq contains the items (without outer braces):
 <recently read> }
 l. ...\end{function}
 The sequence \l__codedoc_names_seq contains the items (without outer braces):
+>  {\obeyedline}.
+<recently read> }
+l. ...\end{function}
+The sequence \l__codedoc_names_seq contains the items (without outer braces):
 >  {\foo:NN}.
 <recently read> }
 l. ...% \end{macro}
 The sequence \l__codedoc_names_seq contains the items (without outer braces):
 >  {\foo_b:NN}
 >  {\foo_b:cN}.
+<recently read> }
+l. ...% \end{macro}
+The sequence \l__codedoc_names_seq contains the items (without outer braces):
+>  {\obeyedline}.
 <recently read> }
 l. ...% \end{macro}

--- a/l3kernel/testfiles-l3doc/github-1577.tlg
+++ b/l3kernel/testfiles-l3doc/github-1577.tlg
@@ -1,0 +1,20 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+The sequence \l__codedoc_names_seq contains the items (without outer braces):
+>  {\foo:NN}.
+<recently read> }
+l. ...\end{function}
+The sequence \l__codedoc_names_seq contains the items (without outer braces):
+>  {\foo_b:NN}
+>  {\foo_b:cN}.
+<recently read> }
+l. ...\end{function}
+The sequence \l__codedoc_names_seq contains the items (without outer braces):
+>  {\foo:NN}.
+<recently read> }
+l. ...% \end{macro}
+The sequence \l__codedoc_names_seq contains the items (without outer braces):
+>  {\foo_b:NN}
+>  {\foo_b:cN}.
+<recently read> }
+l. ...% \end{macro}


### PR DESCRIPTION
Fixes #1577.