### PR TITLE
Doc typos

### DIFF
--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -411,7 +411,7 @@
 %   \end{syntax}
 %   This function evaluates the \meta{test int expr} and
 %   compares this in turn to each of the
-%   \meta{int expr cases} until a match is found.
+%   \meta{int expr case}s until a match is found.
 %   If the two are equal then the
 %   associated \meta{code} is left in the input stream
 %   and other cases are discarded. If any of the

--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -664,7 +664,7 @@
 %     ~~\Arg{true code}
 %     ~~\Arg{false code}
 %   \end{syntax}
-%   Evaluates in turn each of the \meta{boolean expression cases} until
+%   Evaluates in turn each of the \meta{boolean expression case}s until
 %   the first one that evaluates to \texttt{true}.
 %   The \meta{code} associated to this first case is left in the input
 %   stream, followed by the \meta{true code}, and other cases are

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -643,7 +643,7 @@
 %   \end{syntax}
 %   Determines which of the \meta{regular expressions} matches at the
 %   earliest point in the \meta{token list}, and leaves the
-%   corresponding \meta{code_i} followed by the \meta{true code} in the
+%   corresponding \meta{code} followed by the \meta{true code} in the
 %   input stream.  If several \meta{regex} match starting at the same
 %   point, then the first one in the list is selected and the others are
 %   discarded.  If none of the \meta{regex} match, the \meta{false code}

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -747,7 +747,7 @@
 %   Applies \meta{inline function} to every \meta{item} stored
 %   within the \meta{seq~var_2}. The \meta{inline function} should
 %   consist of code which will receive the \meta{item} as |#1|.
-%   The sequence resulting applying \meta{inline function} to each
+%   The sequence resulting from applying \meta{inline function} to each
 %   \meta{item} is assigned to \meta{seq~var_1}.
 %   \begin{texnote}
 %     Contrarily to other mapping functions, \cs{seq_map_break:} cannot

--- a/l3kernel/l3skip.dtx
+++ b/l3kernel/l3skip.dtx
@@ -277,7 +277,7 @@
 %   \end{syntax}
 %   This function evaluates the \meta{test dim expr} and
 %   compares this in turn to each of the
-%   \meta{dim expr cases} until a match is found.
+%   \meta{dim expr case}s until a match is found.
 %   If the two are equal then the
 %   associated \meta{code} is left in the input stream
 %   and other cases are discarded. If any of the

--- a/l3kernel/l3skip.dtx
+++ b/l3kernel/l3skip.dtx
@@ -277,7 +277,7 @@
 %   \end{syntax}
 %   This function evaluates the \meta{test dim expr} and
 %   compares this in turn to each of the
-%   \meta{dim expr cases} until a a match is found.
+%   \meta{dim expr cases} until a match is found.
 %   If the two are equal then the
 %   associated \meta{code} is left in the input stream
 %   and other cases are discarded. If any of the

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -781,7 +781,7 @@
 %     ~~\Arg{false code}
 %   \end{syntax}
 %   This function compares the \meta{test token} in turn with each of
-%   the \meta{token cases}. If the two are equal (as described for
+%   the \meta{token case}s. If the two are equal (as described for
 %   \cs{token_if_eq_catcode:NNTF}, \cs{token_if_eq_charcode:NNTF} and
 %   \cs{token_if_eq_meaning:NNTF}, respectively) then the associated
 %   \meta{code} is left in the input stream and other cases are


### PR DESCRIPTION
Triggered by the doubled "a" found in 39e8bbd8 (Extend docs for dim/str case functions, 2024-09-06).