### PR TITLE
correct global boolean, use TU with lualatex

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,6 +10,11 @@ this project uses date-based 'snapshot' version identifiers.
 ## [2024-09-10]
 
 ### Fixed
+- Use TU-encoding with lualatex and xelatex
+- global booleans are set locally in l3doc
+
+
+### Fixed
 - `\seq_map_pairwise_function:NNN` not work with `\seq_map_break:(n)` (issue \#1587)
 
 ### Changed

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,8 +10,8 @@ this project uses date-based 'snapshot' version identifiers.
 ## [2024-09-10]
 
 ### Fixed
-- Use TU-encoding with lualatex and xelatex
-- global booleans are set locally in l3doc
+- Use TU-encoding with lualatex and xelatex in `l3doc`
+- Global booleans were set locally in `l3doc`
 
 
 ### Fixed

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -1532,21 +1532,21 @@ and all files in that bundle must be distributed together.
 \bool_if:NT \g_@@_lmodern_bool
   {
     \bool_lazy_or:nnTF
-      {\sys_if_engine_luatex_p:}{\sys_if_engine_xetex_p:}
+      { \sys_if_engine_luatex_p: }{ \sys_if_engine_xetex_p: }
       {
-       \group_begin:
-        \ttfamily
-        \DeclareFontShape{TU}{lmtt}{m}{it}
-          {<-> \UnicodeFontFile{lmmonoslant10-regular}{}}{}
-       \group_end:      
+        \group_begin:
+          \ttfamily
+          \DeclareFontShape{TU}{lmtt}{m}{it}
+            {<-> \UnicodeFontFile{lmmonoslant10-regular}{}}{}
+        \group_end:      
       }
       {
-       \RequirePackage[T1]{fontenc}
-       \RequirePackage{lmodern}
-       \group_begin:
-         \ttfamily
-         \DeclareFontShape{T1}{lmtt}{m}{it}{<->ec-lmtto10}{}
-       \group_end:
+        \RequirePackage[T1]{fontenc}
+        \RequirePackage{lmodern}
+        \group_begin:
+          \ttfamily
+          \DeclareFontShape{T1}{lmtt}{m}{it}{<->ec-lmtto10}{}
+        \group_end:
       }
   }
 %    \end{macrocode}

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -959,8 +959,8 @@ and all files in that bundle must be distributed together.
 %    \begin{macrocode}
 \bool_new:N \g_@@_typeset_documentation_bool
 \bool_new:N \g_@@_typeset_implementation_bool
-\bool_set_true:N \g_@@_typeset_documentation_bool
-\bool_set_true:N \g_@@_typeset_implementation_bool
+\bool_gset_true:N \g_@@_typeset_documentation_bool
+\bool_gset_true:N \g_@@_typeset_implementation_bool
 %    \end{macrocode}
 % \end{variable}
 %
@@ -1531,12 +1531,23 @@ and all files in that bundle must be distributed together.
 %    \begin{macrocode}
 \bool_if:NT \g_@@_lmodern_bool
   {
-    \RequirePackage[T1]{fontenc}
-    \RequirePackage{lmodern}
-    \group_begin:
-      \ttfamily
-      \DeclareFontShape{T1}{lmtt}{m}{it}{<->ec-lmtto10}{}
-    \group_end:
+    \bool_lazy_or:nnTF
+      {\sys_if_engine_luatex_p:}{\sys_if_engine_xetex_p:}
+      {
+       \group_begin:
+        \ttfamily
+        \DeclareFontShape{TU}{lmtt}{m}{it}
+          {<-> \UnicodeFontFile{lmmonoslant10-regular}{}}{}
+       \group_end:      
+      }
+      {
+       \RequirePackage[T1]{fontenc}
+       \RequirePackage{lmodern}
+       \group_begin:
+         \ttfamily
+         \DeclareFontShape{T1}{lmtt}{m}{it}{<->ec-lmtto10}{}
+       \group_end:
+      }
   }
 %    \end{macrocode}
 %


### PR DESCRIPTION
Fixes:
* in l3doc two global bool are set locally. 
* With lualatex T1-encoding is used, this switches to TU-encoding. 

(dates are not changed as I think that is done at a release?)

