### PR TITLE
fix arg type for \clist_use:nnnn

### DIFF
--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -620,8 +620,8 @@
 %
 % \begin{function}[EXP, added = 2021-05-10]{\clist_use:nnnn, \clist_use:nn}
 %   \begin{syntax}
-%     \cs{clist_use:nnnn} \meta{comma~list} \Arg{separator~between~two} \Arg{separator~between~more~than~two} \Arg{separator~between~final~two}
-%     \cs{clist_use:nn} \meta{comma~list} \Arg{separator}
+%     \cs{clist_use:nnnn} \Arg{comma~list} \Arg{separator~between~two} \Arg{separator~between~more~than~two} \Arg{separator~between~final~two}
+%     \cs{clist_use:nn} \Arg{comma~list} \Arg{separator}
 %   \end{syntax}
 %   Places the contents of the \meta{comma~list} in the input stream,
 %   with the appropriate \meta{separator} between the items.  As for

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -393,7 +393,7 @@
 %     \cs{clist_if_empty_p:n} \Arg{comma list}
 %     \cs{clist_if_empty:nTF} \Arg{comma list} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Tests if the \meta{clist~var} is empty (containing no items).
+%   Tests if the \meta{comma~list} is empty (containing no items).
 %   The rules for space trimming are as for other \texttt{n}-type
 %   comma-list functions, hence the comma list |{~,~,,~}| (without
 %   outer braces) is empty, while |{~,{},}| (without outer braces)


### PR DESCRIPTION
Changes `\meta` to `\Arg` for `\clist_use:nnnn` and `\clist_use:nn`.

Also fixes the referenced arg in `\clist_if_empty:nTF` from `clist var` to `comma list`.

I also noticed there's not consistency in how the `N` and `n` clist commands are documented. Some of them are documented together but only the `N` type is shown, e.g. `\clist_if_in:...`, `\clist_map_function:...`, etc. Some are documented together and both are shown, e.g. `\clist_map_tokens:...`, `\clist_rand_item:...`. And some are documented separately, e.g. `\clist_use:...`, `\clist_show:...`. Maybe this is intentional, just thought I'd point it out.