### PR TITLE
various documentation improvements

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 - Document variants of `\cs_if_eq:NNTF`
+- Document `\str_item:cn`
 
 ## [2024-09-10]
 

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -564,7 +564,8 @@
 %
 % \begin{function}[EXP, added = 2013-05-26]{\clist_use:Nnnn, \clist_use:cnnn}
 %   \begin{syntax}
-%     \cs{clist_use:Nnnn} \meta{clist~var} \Arg{separator~between~two} \Arg{separator~between~more~than~two} \Arg{separator~between~final~two}
+%     \cs{clist_use:Nnnn} \meta{clist~var} \Arg{separator~between~two} \\
+%     ~~\Arg{separator~between~more~than~two} \Arg{separator~between~final~two}
 %   \end{syntax}
 %   Places the contents of the \meta{clist~var} in the input stream,
 %   with the appropriate \meta{separator} between the items.  Namely, if
@@ -620,7 +621,8 @@
 %
 % \begin{function}[EXP, added = 2021-05-10]{\clist_use:nnnn, \clist_use:nn}
 %   \begin{syntax}
-%     \cs{clist_use:nnnn} \Arg{comma~list} \Arg{separator~between~two} \Arg{separator~between~more~than~two} \Arg{separator~between~final~two}
+%     \cs{clist_use:nnnn} \Arg{comma~list} \Arg{separator~between~two} \\
+%     ~~\Arg{separator~between~more~than~two} \Arg{separator~between~final~two}
 %     \cs{clist_use:nn} \Arg{comma~list} \Arg{separator}
 %   \end{syntax}
 %   Places the contents of the \meta{comma~list} in the input stream,

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -243,9 +243,9 @@
 %
 % \begin{function}{\color_set_eq:nn}
 %   \begin{syntax}
-%     \cs{color_set_eq:nn} \Arg{name1} \Arg{name2}
+%     \cs{color_set_eq:nn} \Arg{name_1} \Arg{name_2}
 %   \end{syntax}
-%   Copies the color specification in \meta{name2} to \meta{name1}. The
+%   Copies the color specification in \meta{name_2} to \meta{name_1}. The
 %   special name |.| may be used to represent the current color, allowing
 %   it to be saved to a name.
 % \end{function}
@@ -338,7 +338,7 @@
 %
 % \begin{function}[added = 2022-01-26]{\color_math:nn, \color_math:nnn}
 %   \begin{syntax}
-%     \cs{color_math:nn} \Arg{color expression}\Arg{content}
+%     \cs{color_math:nn} \Arg{color expression} \Arg{content}
 %     \cs{color_math:nnn} \Arg{model(s)} \Arg{value(s)} \Arg{content}
 %   \end{syntax}
 %   Works as for \cs[no-index]{color_select:n(n)} but applies color only to the math mode

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -867,8 +867,8 @@
 % \begin{function}[noTF, updated = 2019-02-16]
 %   {\file_get_full_name:nN, \file_get_full_name:VN}
 %   \begin{syntax}
-%     \cs{file_get_full_name:nN} \Arg{file name} \meta{tl}
-%     \cs{file_get_full_name:nNTF} \Arg{file name} \meta{tl} \Arg{true code} \Arg{false code}
+%     \cs{file_get_full_name:nN} \Arg{file name} \meta{tl var}
+%     \cs{file_get_full_name:nNTF} \Arg{file name} \meta{tl var} \Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   Searches for \meta{file name} in the path as detailed for
 %   \cs{file_if_exist:nTF}, and if found sets the \meta{tl var} the
@@ -943,15 +943,15 @@
 % \begin{function}[noTF, added = 2019-01-16, updated = 2019-02-16]
 %   {\file_get:nnN, \file_get:VnN}
 %   \begin{syntax}
-%     \cs{file_get:nnN} \Arg{file name} \Arg{setup} \meta{tl}
-%     \cs{file_get:nnNTF} \Arg{file name} \Arg{setup} \meta{tl} \Arg{true code} \Arg{false code}
+%     \cs{file_get:nnN} \Arg{file name} \Arg{setup} \meta{tl var}
+%     \cs{file_get:nnNTF} \Arg{file name} \Arg{setup} \meta{tl var} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Defines \meta{tl} to the contents of \meta{file name}.
+%   Defines \meta{tl var} to the contents of \meta{file name}.
 %   Category codes may need to be set appropriately via the \meta{setup}
 %   argument.
-%   The non-branching version sets the \meta{tl} to \cs{q_no_value} if the file is
+%   The non-branching version sets the \meta{tl var} to \cs{q_no_value} if the file is
 %   not found. The branching version runs the \meta{true code} after the
-%   assignment to \meta{tl} if the file is found, and \meta{false code}
+%   assignment to \meta{tl var} if the file is found, and \meta{false code}
 %   otherwise. The file content will be tokenized using the current
 %   category code régime,
 % \end{function}

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -226,7 +226,7 @@
 % \begin{function}[noTF, added = 2012-06-24, updated = 2019-03-23]{\ior_get:NN}
 %   \begin{syntax}
 %     \cs{ior_get:NN} \meta{stream} \meta{token list variable}
-%     \cs{ior_get:NNTF} \meta{stream} \meta{token list variable} \meta{true code} \meta{false code}
+%     \cs{ior_get:NNTF} \meta{stream} \meta{token list variable} \Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   Function that reads one or more lines (until an equal number of left
 %   and right braces are found) from the file input \meta{stream} and stores
@@ -268,7 +268,7 @@
 %   {\ior_str_get:NN}
 %   \begin{syntax}
 %     \cs{ior_str_get:NN} \meta{stream} \meta{token list variable}
-%     \cs{ior_str_get:NNTF} \meta{stream} \meta{token list variable} \meta{true code} \meta{false code}
+%     \cs{ior_str_get:NNTF} \meta{stream} \meta{token list variable} \Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   Function that reads one line from the file input \meta{stream} and stores
 %   the result locally in the \meta{token list} variable.

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -262,11 +262,11 @@
 % \begin{function}[EXP, pTF, added=2012-03-03]
 %   {\int_if_exist:N, \int_if_exist:c}
 %   \begin{syntax}
-%     \cs{int_if_exist_p:N} \meta{int}
-%     \cs{int_if_exist:NTF} \meta{int} \Arg{true code} \Arg{false code}
+%     \cs{int_if_exist_p:N} \meta{integer}
+%     \cs{int_if_exist:NTF} \meta{integer} \Arg{true code} \Arg{false code}
 %   \end{syntax}
-%   Tests whether the \meta{int} is currently defined.  This does not
-%   check that the \meta{int} really is an integer variable.
+%   Tests whether the \meta{integer} is currently defined.  This does not
+%   check that the \meta{integer} really is an integer variable.
 % \end{function}
 %
 % \section{Setting and incrementing integers}

--- a/l3kernel/l3intarray.dtx
+++ b/l3kernel/l3intarray.dtx
@@ -79,7 +79,7 @@
 % \begin{function}[added = 2018-05-04]
 %   {\intarray_const_from_clist:Nn, \intarray_const_from_clist:cn}
 %   \begin{syntax}
-%     \cs{intarray_const_from_clist:Nn} \meta{intarray~var} \meta{int expr clist}
+%     \cs{intarray_const_from_clist:Nn} \meta{intarray~var} \Arg{int expr clist}
 %   \end{syntax}
 %   Creates a new constant \meta{integer array variable} or raises an
 %   error if the name is already taken.  The \meta{integer array

--- a/l3kernel/l3str-convert.dtx
+++ b/l3kernel/l3str-convert.dtx
@@ -139,10 +139,10 @@
 %
 % \begin{function}{\str_set_convert:Nnnn, \str_gset_convert:Nnnn}
 %   \begin{syntax}
-%     \cs{str_set_convert:Nnnn} \meta{str~var} \Arg{string} \Arg{name~1} \Arg{name~2}
+%     \cs{str_set_convert:Nnnn} \meta{str~var} \Arg{string} \Arg{name_1} \Arg{name_2}
 %   \end{syntax}
 %   This function converts the \meta{string} from the encoding given by
-%   \meta{name~1} to the encoding given by \meta{name~2}, and stores the
+%   \meta{name_1} to the encoding given by \meta{name_2}, and stores the
 %   result in the \meta{str~var}.  Each \meta{name} can have the form
 %   \meta{encoding} or \meta{encoding}\texttt{/}\meta{escaping}, where
 %   the possible values of \meta{encoding} and \meta{escaping} are given
@@ -177,14 +177,14 @@
 %
 % \begin{function}[TF]{\str_set_convert:Nnnn, \str_gset_convert:Nnnn}
 %   \begin{syntax}
-%     \cs{str_set_convert:NnnnTF} \meta{str~var} \Arg{string} \Arg{name~1} \Arg{name~2} \Arg{true code} \Arg{false code}
+%     \cs{str_set_convert:NnnnTF} \meta{str~var} \Arg{string} \Arg{name_1} \Arg{name_2} \Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   As \cs{str_set_convert:Nnnn}, converts the \meta{string} from the
-%   encoding given by \meta{name~1} to the encoding given by
-%   \meta{name~2}, and assigns the result to \meta{str~var}. Contrarily
+%   encoding given by \meta{name_1} to the encoding given by
+%   \meta{name_2}, and assigns the result to \meta{str~var}. Contrarily
 %   to \cs{str_set_convert:Nnnn}, the conditional variant does not raise
 %   errors in case the \meta{string} is not valid according to the
-%   \meta{name~1} encoding, or cannot be expressed in the \meta{name~2}
+%   \meta{name_1} encoding, or cannot be expressed in the \meta{name_2}
 %   encoding. Instead, the \meta{false code} is performed.
 % \end{function}
 %
@@ -195,7 +195,7 @@
 %
 % \begin{function}[EXP]{\str_convert_pdfname:n}
 %   \begin{syntax}
-%     \cs{str_convert_pdfname:n} \meta{string}
+%     \cs{str_convert_pdfname:n} \Arg{string}
 %   \end{syntax}
 %   As \cs{str_set_convert:Nnnn}, converts the \meta{string} on a byte-by-byte
 %   basis with non-ASCII codepoints  escaped using hashes.

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -558,7 +558,7 @@
 % \end{function}
 %
 % \begin{function}[EXP, added = 2015-09-18]
-%   {\str_item:Nn, \str_item:nn, \str_item_ignore_spaces:nn}
+%   {\str_item:Nn, \str_item:cn, \str_item:nn, \str_item_ignore_spaces:nn}
 %   \begin{syntax}
 %     \cs{str_item:nn} \Arg{token list} \Arg{integer expression}
 %   \end{syntax}

--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -798,9 +798,9 @@
 %
 % \begin{function}[added = 2023-05-19, EXP]{\str_mdfive_hash:n, \str_mdfive_hash:e}
 %   \begin{syntax}
-%     \cs{str_mdfive_hash:n} \Arg{tl}
+%     \cs{str_mdfive_hash:n} \Arg{tokens}
 %   \end{syntax}
-%   Expands to the MD5 sum generated from the \meta{tl}, which is converted
+%   Expands to the MD5 sum generated from the \meta{tokens}, which is converted
 %   to a \meta{string} as described for \cs{tl_to_str:n}.
 % \end{function}
 %

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -374,11 +374,11 @@
 % \begin{function}[added = 2024-03-08]
 %   {\sys_split_query:nN, \sys_split_query:nnN, \sys_split_query:nnnN}
 %   \begin{syntax}
-%     \cs{sys_split_query:nN} \Arg{cmd} \meta{seq}
-%     \cs{sys_split_query:nnN} \Arg{cmd} \Arg{spec} \meta{seq}
-%     \cs{sys_split_query:nnnN} \Arg{cmd} \Arg{options} \Arg{spec} \meta{seq}
+%     \cs{sys_split_query:nN} \Arg{cmd} \meta{seq var}
+%     \cs{sys_split_query:nnN} \Arg{cmd} \Arg{spec} \meta{seq var}
+%     \cs{sys_split_query:nnnN} \Arg{cmd} \Arg{options} \Arg{spec} \meta{seq var}
 %   \end{syntax}
-%   Works as described for \cs{sys_split_query:nnnN}, but sets the \meta{seq}
+%   Works as described for \cs{sys_split_query:nnnN}, but sets the \meta{seq var}
 %   to contain one entry for each line returned by \texttt{l3sys-query}.
 %   This function should therefore be preferred where multi-line return is
 %   expected, e.g.~for the \texttt{ls} command.

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -336,9 +336,9 @@
 % \begin{function}[added = 2024-03-08, updated = 2024-04-08]
 %   {\sys_get_query:nN, \sys_get_query:nnN, \sys_get_query:nnnN}
 %   \begin{syntax}
-%     \cs{sys_get_query:nN} \Arg{cmd} \Arg{tl var}
-%     \cs{sys_get_query:nnN} \Arg{cmd} \Arg{spec} \Arg{tl var}
-%     \cs{sys_get_query:nnnN} \Arg{cmd} \Arg{options} \Arg{spec} \Arg{tl var}
+%     \cs{sys_get_query:nN} \Arg{cmd} \meta{tl var}
+%     \cs{sys_get_query:nnN} \Arg{cmd} \Arg{spec} \meta{tl var}
+%     \cs{sys_get_query:nnnN} \Arg{cmd} \Arg{options} \Arg{spec} \meta{tl var}
 %   \end{syntax}
 %   Sets the \meta{tl var} to the information returned by the
 %   \texttt{l3sys-query} \meta{cmd}, potentially supplying the \meta{options}
@@ -374,9 +374,9 @@
 % \begin{function}[added = 2024-03-08]
 %   {\sys_split_query:nN, \sys_split_query:nnN, \sys_split_query:nnnN}
 %   \begin{syntax}
-%     \cs{sys_split_query:nN} \Arg{cmd} \Arg{seq}
-%     \cs{sys_split_query:nnN} \Arg{cmd} \Arg{spec} \Arg{seq}
-%     \cs{sys_split_query:nnnN} \Arg{cmd} \Arg{options} \Arg{spec} \Arg{seq}
+%     \cs{sys_split_query:nN} \Arg{cmd} \meta{seq}
+%     \cs{sys_split_query:nnN} \Arg{cmd} \Arg{spec} \meta{seq}
+%     \cs{sys_split_query:nnnN} \Arg{cmd} \Arg{options} \Arg{spec} \meta{seq}
 %   \end{syntax}
 %   Works as described for \cs{sys_split_query:nnnN}, but sets the \meta{seq}
 %   to contain one entry for each line returned by \texttt{l3sys-query}.

--- a/l3kernel/l3text.dtx
+++ b/l3kernel/l3text.dtx
@@ -214,8 +214,9 @@
 %     \text_declare_uppercase_mapping:nnn
 %   }
 %   \begin{syntax}
-%     \cs{text_declare_lowercase_mapping:nn} \Arg{codepoint}  \Arg{replacement}
-%     \cs{text_declare_lowercase_mapping:nnn} \Arg{BCP-47} \Arg{codepoint} \Arg{replacement}
+%     \cs{text_declare_lowercase_mapping:nn} \Arg{codepoint} \Arg{replacement}
+%     \cs{text_declare_lowercase_mapping:nnn} \Arg{BCP-47} \Arg{codepoint} \\
+%     ~~\Arg{replacement}
 %   \end{syntax}
 %   Declares that the \meta{replacement} tokens should be used when case mapping
 %   the \meta{codepoint}, rather than the standard mapping given in the
@@ -305,7 +306,7 @@
 %
 % \begin{function}[rEXP, added = 2022-08-04]{\text_map_function:nN}
 %   \begin{syntax}
-%     \cs{text_map_function:nN} \meta{text} \Arg{function}
+%     \cs{text_map_function:nN} \Arg{text} \meta{function}
 %   \end{syntax}
 %   Takes user input \meta{text} and expands as described for
 %   \cs{text_expand:n}, then maps over the \emph{graphemes} within the
@@ -323,7 +324,7 @@
 %
 % \begin{function}[added = 2022-08-04]{\text_map_inline:nn}
 %   \begin{syntax}
-%     \cs{text_map_inline:nn} \meta{text} \Arg{inline function}
+%     \cs{text_map_inline:nn} \Arg{text} \Arg{inline function}
 %   \end{syntax}
 %   Takes user input \meta{text} and expands as described for
 %   \cs{text_expand:n}, then maps over the \emph{graphemes} within the


### PR DESCRIPTION
(I hope this is okay all in one PR.)

Various documentation improvements for interface3, including
- manual line breaks for long argument specs
- using e.g. `name_1` over `name1` or `name~1`
- fixing several `\meta` to `\Arg` and vice versa
- using `tl var` over just `tl`; also `tokens` over `tl` if `n`-type
- using `integer` over `int` (only occurs once)
- using `seq var` over `seq`
- documenting `\str_item:cn`