### PR TITLE
Cleaup duplicate definitions in l3names

### DIFF
--- a/l3kernel/l3names.dtx
+++ b/l3kernel/l3names.dtx
@@ -580,7 +580,6 @@
   \@@_primitive:NN \pdfoutline            \tex_pdfoutline:D
   \@@_primitive:NN \pdfoutput             \tex_pdfoutput:D
   \@@_primitive:NN \pdfpageattr           \tex_pdfpageattr:D
-  \@@_primitive:NN \pdfpagesattr          \tex_pdfpagesattr:D
   \@@_primitive:NN \pdfpagebox            \tex_pdfpagebox:D
   \@@_primitive:NN \pdfpageref            \tex_pdfpageref:D
   \@@_primitive:NN \pdfpageresources      \tex_pdfpageresources:D
@@ -1242,13 +1241,11 @@
 %    \end{macrocode}
 % Primitives from \upTeX{}.
 %    \begin{macrocode}
-  \@@_primitive:NN \currentcjktoken       \tex_currentcjktoken:D
   \@@_primitive:NN \disablecjktoken       \tex_disablecjktoken:D
   \@@_primitive:NN \enablecjktoken        \tex_enablecjktoken:D
   \@@_primitive:NN \forcecjktoken         \tex_forcecjktoken:D
   \@@_primitive:NN \kchar                 \tex_kchar:D
   \@@_primitive:NN \kchardef              \tex_kchardef:D
-  \@@_primitive:NN \kuten                 \tex_kuten:D
   \@@_primitive:NN \uptexrevision         \tex_uptexrevision:D
   \@@_primitive:NN \uptexversion          \tex_uptexversion:D
 %    \end{macrocode}


### PR DESCRIPTION
Removed three definitions in l3names that simply repeat other definitions (at lines 587, 1178, and 1207). No other duplicates are found.