### PR TITLE
Add `\keyval_map_inline:nnn`

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -1096,6 +1096,76 @@
 %   \end{texnote}
 % \end{function}
 %
+% \begin{function}[added=2024-10-10]{\keyval_map_inline:nnn}
+%   \begin{syntax}
+%     \cs{keyval_map_inline:nnn} \Arg{key--value list} \Arg{inline function_1} \Arg{inline function_2}
+%   \end{syntax}
+%   Applies the \meta{inline function_1} to every key in the \meta{key--value
+%   list} which got no value, and \meta{inline function_2} to every key in the
+%   \meta{key--value list} which got a value. The \meta{inline function_1}
+%   should consist of code that receives keys without a value as |#1|, and
+%   \meta{inline function_2} receives each key as |#1| and each value as |#2|.
+% \end{function}
+%
+% \begin{function}[added=2024-10-10, rEXP]{\keyval_map_break:}
+%   Used to terminate a \cs[no-index]{keyval_map_\ldots{}} function before all
+%   entries in the \meta{key--value list} have been processed. This
+%   normally takes place within a conditional statement, for example
+%   \begin{verbatim}
+%     \keyval_map_inline:nnn { foo, bar = baz, bingo, boom, ... }
+%       {
+%         \str_if_eq:nnTF { #1 } { bingo }
+%           { \clist_map_break: }
+%           {
+%             % Do something useful
+%           }
+%       }
+%       {
+%         % Do more useful things
+%       }
+%   \end{verbatim}
+%   See also \cs{keyval_map_break:n}.
+%   Use outside of a \cs[no-index]{keyval_map_\ldots{}} scenario leads to low
+%   level \TeX{} errors.
+%   \begin{texnote}
+%     When the mapping is broken, additional tokens may be inserted
+%     before further items are taken
+%     from the input stream. This depends on the design of the mapping
+%     function.
+%   \end{texnote}
+% \end{function}
+%
+% \begin{function}[added=2024-10-10, rEXP]{\keyval_map_break:n}
+%   \begin{syntax}
+%     \cs{keyval_map_break:n} \Arg{code}
+%   \end{syntax}
+%   Used to terminate a \cs[no-index]{keyval_map_\ldots{}} function before all
+%   entries in the \meta{key--value list} have been processed, inserting
+%   the \meta{code} after the mapping has ended. This
+%   normally takes place within a conditional statement, for example
+%   \begin{verbatim}
+%     \keyval_map_inline:nnn { foo, bar = baz, bingo, boom, ... }
+%       {
+%         \str_if_eq:nnTF { #1 } { bingo }
+%           { \keyval_map_break:n { <code> } }
+%           {
+%             % Do something useful
+%           }
+%       }
+%       {
+%         % Do more useful things
+%       }
+%   \end{verbatim}
+%   Use outside of a \cs[no-index]{keyval_map_\ldots{}} scenario leads to low
+%   level \TeX{} errors.
+%   \begin{texnote}
+%     When the mapping is broken, additional tokens may be inserted
+%     before the \meta{code} is
+%     inserted into the input stream.
+%     This depends on the design of the mapping function.
+%   \end{texnote}
+% \end{function}
+%
 % \end{documentation}
 %
 % \begin{implementation}
@@ -1144,7 +1214,7 @@
 %   comma and |#2| will be the active equals sign.
 %    \begin{macrocode}
 \group_begin:
-  \cs_set_protected:Npn \@@_tmp:w #1#2
+  \cs_set_protected:Npn \@@_tmp:nn #1#2
     {
 %    \end{macrocode}
 %
@@ -1409,13 +1479,13 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% The parsing loops are done, so here ends the definition of \cs{@@_tmp:w},
+% The parsing loops are done, so here ends the definition of \cs{@@_tmp:nn},
 % which will finally set up the macros.
 %    \begin{macrocode}
     }
   \char_set_catcode_active:n { `\, }
   \char_set_catcode_active:n { `\= }
-  \@@_tmp:w , =
+  \@@_tmp:nn , =
 \group_end:
 \cs_generate_variant:Nn \keyval_parse:NNn { NNV , NNv }
 \cs_generate_variant:Nn \keyval_parse:nnn { nnV , nnv }
@@ -1429,7 +1499,7 @@
 %   iteration of the other loop.
 %    \begin{macrocode}
 \group_begin:
-  \cs_set_protected:Npn \@@_tmp:w #1#2
+  \cs_set_protected:Npn \@@_tmp:nn #1#2
     {
       \cs_new:Npn \@@_pair:nnnn ##1 ##2 ##3 ##4
         {
@@ -1450,7 +1520,7 @@
           \@@_loop_other:nnw {##2}
         }
     }
-  \@@_tmp:w { } { }
+  \@@_tmp:nn { } { }
 \group_end:
 %    \end{macrocode}
 % \end{macro}
@@ -1504,7 +1574,7 @@
 % worth it.
 %    \begin{macrocode}
 \group_begin:
-  \cs_set_protected:Npn \@@_tmp:w #1
+  \cs_set_protected:Npn \@@_tmp:n #1
     {
       \cs_new:Npn \@@_trim:nN ##1
         {
@@ -1545,10 +1615,45 @@
           ##2
         { ##2 { ##1 } }
     }
-  \@@_tmp:w { ~ }
+  \@@_tmp:n { ~ }
 \group_end:
 %    \end{macrocode}
 % \end{macro}
+% \end{macro}
+%
+% \begin{macro}{\keyval_map_inline:nnn}
+%   Unlike many other mapping functions we don't need to keep a global stack of
+%   definitions for our auxiliary macros, instead we can contain their
+%   definition in a group and use \cs{keyval_parse:NNn} which we fully expand
+%   twice before the group is closed. This has the drawback that any breaking of
+%   the map happens after the entire list was already parsed, so has a
+%   performance penalty in that case. However, these should be rather rare
+%   occasions and the simplicity of the code should warrant them. Another
+%   drawback of this approach is that the expansion of the internal macros is
+%   left in the input stream for every element.
+%
+%   The break point can remain outside of the braces containing the loop, since
+%   by the time user code is executed that might actually 
+%    \begin{macrocode}
+\cs_new_protected:Npn \keyval_map_inline:nnn #1#2#3
+  {
+    \group_begin:
+      \cs_set:Npn \@@_tmp:n ##1 { \exp_not:n {#2} }
+      \cs_set:Npn \@@_tmp:nn ##1##2 { \exp_not:n {#3} }
+      \exp_args:NNe \exp_last_unbraced:Ne
+    \group_end:
+    { \keyval_parse:NNn \@@_tmp:n \@@_tmp:nn {#1} }
+    \prg_break_point:Nn \keyval_map_break: { }
+  }
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\keyval_map_break:, \keyval_map_break:n}
+%   Simple code using the \cs{prg_map_break:Nn} mechanism.
+%    \begin{macrocode}
+\cs_new:Npn \keyval_map_break:  { \prg_map_break:Nn \keyval_map_break: { } }
+\cs_new:Npn \keyval_map_break:n { \prg_map_break:Nn \keyval_map_break: }
+%    \end{macrocode}
 % \end{macro}
 %
 % \subsection{Constants and variables}


### PR DESCRIPTION
This PR adds the function `\keyval_map_inline:nnn` and the corresponding `break`-functions.

-[ ] Unit tests