### PR TITLE
remove extra brace in l3fp.dtx

### DIFF
--- a/l3kernel/l3fp.dtx
+++ b/l3kernel/l3fp.dtx
@@ -775,7 +775,7 @@
 %   \begin{quote}
 %     \cs{fp_new_function:n} |{ npow }| \\
 %     \cs{fp_set_function:nnn} |{ npow } { a,b } { a**b }| \\
-%     \cs{fp_show:n} |{ npow(16,0.25) } }|
+%     \cs{fp_show:n} |{ npow(16,0.25) }|
 %   \end{quote}
 %   shows |2|. The names of the \meta{vars} must
 %   consist entirely of Latin letters |[a-zA-Z]|, but are otherwise not


### PR DESCRIPTION
Removes an extra brace in the example under `\fp_set_function:nnn`.