### PR TITLE
Typo fixed [ci skip]

### DIFF
--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -297,7 +297,7 @@
 % \begin{function}[updated = 2011-10-22]
 %   {
 %     \int_set:Nn, \int_set:cn, \int_set:NV, \int_set:cV,
-%     \int_gset:Nn, \int_gset:cn, \int_gset:MV, \int_gset:cV
+%     \int_gset:Nn, \int_gset:cn, \int_gset:NV, \int_gset:cV
 %   }
 %   \begin{syntax}
 %     \cs{int_set:Nn} \meta{integer} \Arg{int expr}


### PR DESCRIPTION
On page 169 of the documentation `interface3.pdf`, the command `\int_gset:MV` is listed with `\int_set:Nn` and friends: I guess it is a typo and it should be `\int_gset:NV` instead.