### PR TITLE
Typeset curly braces in ttfamily

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -333,8 +333,8 @@
 %   Tests if the \meta{token list} and the special \cs{c_novalue_tl} marker
 %   contain the same list of tokens, both in respect of character codes and
 %   category codes. This means that
-%   \cs{exp_args:No} \cs{tl_if_novalue:nTF} \{ \cs{c_novalue_tl} \} is 
-%   logically \texttt{true} but \cs{tl_if_novalue:nTF} \{  \cs{c_novalue_tl} \}
+%   \cs{exp_args:No} \cs{tl_if_novalue:nTF} \texttt\{ \cs{c_novalue_tl} \texttt\} is 
+%   logically \texttt{true} but \cs{tl_if_novalue:nTF} \texttt\{ \cs{c_novalue_tl} \texttt\}
 %   is logically \texttt{false}.
 %   This function is intended to allow construction
 %   of flexible document interface structures in which missing optional


### PR DESCRIPTION
Maybe `l3doc` could provide a new command for this kind of markup, like
```tex
% b for braced; \arg is taken by amsmath as one of math operator commands
\NewDocumentCommand\barg{m}{\texttt{\char`\{} #1 \texttt{\char`\}}}
```

Before
<img width="768" alt="image" src="https://github.com/user-attachments/assets/07c6badd-fb80-42c5-b031-4df0c20d4742">

After
<img width="760" alt="image" src="https://github.com/user-attachments/assets/bf045f18-c3b3-4fc9-93f9-3ab096c45359">

