### PR TITLE
fix \str_put_right:ce doc

### DIFF
--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -212,7 +212,7 @@
 % \begin{function}[added = 2015-09-18, updated = 2018-07-28]
 %   {
 %     \str_put_right:Nn, \str_put_right:NV, \str_put_right:Ne,
-%     \str_put_right:cn, \str_put_right:cV, \str_put_right:Ne,
+%     \str_put_right:cn, \str_put_right:cV, \str_put_right:ce,
 %     \str_gput_right:Nn, \str_gput_right:NV, \str_gput_right:Ne,
 %     \str_gput_right:cn, \str_gput_right:cV, \str_gput_right:ce
 %   }


### PR DESCRIPTION
The `Ne` variant is incorrectly documented twice and the `ce` variant is missing. This fixes that.