### PR TITLE
standardize argument types in interface3

### DIFF
--- a/l3kernel/doc/source3body.tex
+++ b/l3kernel/doc/source3body.tex
@@ -415,12 +415,12 @@ show this more clearly. They will carry out the same function but will take
 different types of argument:
 \begin{function}[label = ]{\seq_new:N, \seq_new:c}
   \begin{syntax}
-    |\seq_new:N| \meta{sequence}
+    |\seq_new:N| \meta{seq var}
   \end{syntax}
   When a number of variants are described, the arguments are usually
-  illustrated only for the base function. Here, \meta{sequence} indicates
-  that |\seq_new:N| expects the name of a sequence. From the argument
-  specifier, |\seq_new:c| also expects a sequence name, but as a
+  illustrated only for the base function. Here, \meta{seq var} indicates
+  that |\seq_new:N| expects a sequence variable. From the argument
+  specifier, |\seq_new:c| also expects a sequence variable, but as a
   name rather than as a control sequence. Each argument given in the
   illustration should be described in the following text.
 \end{function}
@@ -448,7 +448,7 @@ an \texttt{f}-type argument. In this case a hollow star is used to indicate
 this:
 \begin{function}[rEXP, label = ]{\seq_map_function:NN}
   \begin{syntax}
-    |\seq_map_function:NN| \meta{seq} \meta{function}
+    |\seq_map_function:NN| \meta{seq var} \meta{function}
   \end{syntax}
 \end{function}
 

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -1326,8 +1326,8 @@
 %
 % \begin{function}[added = 2017-07-16, updated = 2023-05-23]{\debug_on:n, \debug_off:n}
 %   \begin{syntax}
-%     \cs{debug_on:n} |{| \meta{comma-separated list} |}|
-%     \cs{debug_off:n} |{| \meta{comma-separated list} |}|
+%     \cs{debug_on:n} \Arg{comma-separated list}
+%     \cs{debug_off:n} \Arg{comma-separated list}
 %   \end{syntax}
 %   Turn on and off within a group various debugging code, some of which
 %   is also available as \pkg{expl3} load-time options.  The items that

--- a/l3kernel/l3fparray.dtx
+++ b/l3kernel/l3fparray.dtx
@@ -63,7 +63,7 @@
 %     \cs{fparray_new:Nn} \meta{fparray~var} \Arg{size}
 %   \end{syntax}
 %   Evaluates the integer expression \meta{size} and allocates an
-%   \meta{floating point array variable} with that number of (zero)
+%   \meta{fparray var} with that number of (zero)
 %   entries.  The variable name should start with |\g_| because
 %   assignments are always global.
 % \end{function}
@@ -72,7 +72,7 @@
 %   \begin{syntax}
 %     \cs{fparray_gzero:N} \meta{fparray~var}
 %   \end{syntax}
-%   Sets all entries of the \meta{floating point array variable} to
+%   Sets all entries of the \meta{fparray var} to
 %   $+0$.  Assignments are always global.
 % \end{function}
 %
@@ -83,7 +83,7 @@
 %     \cs{fparray_gset:Nnn} \meta{fparray~var} \Arg{position} \Arg{value}
 %   \end{syntax}
 %   Stores the result of evaluating the floating point expression
-%   \meta{value} into the \meta{floating point array variable} at the
+%   \meta{value} into the \meta{fparray var} at the
 %   (integer expression) \meta{position}.  If the \meta{position} is not
 %   between $1$ and the \cs{fparray_count:N}, an error occurs.
 %   Assignments are always global.
@@ -95,8 +95,8 @@
 %   \begin{syntax}
 %     \cs{fparray_count:N} \meta{fparray~var}
 %   \end{syntax}
-%   Expands to the number of entries in the \meta{floating point array
-%   variable}.  This is performed in constant time.
+%   Expands to the number of entries in the \meta{fparray
+%   var}.  This is performed in constant time.
 % \end{function}
 %
 % \section{Using a single entry}
@@ -111,7 +111,7 @@
 %   \end{syntax}
 %   Applies \cs{fp_use:N} or \cs{fp_to_tl:N} (respectively) to the
 %   floating point entry stored at the (integer expression)
-%   \meta{position} in the \meta{floating point array variable}.  If the
+%   \meta{position} in the \meta{fparray var}.  If the
 %   \meta{position} is not between $1$ and the
 %   \cs{fparray_count:N} \meta{fparray~var}, an error occurs.
 % \end{function}

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -315,10 +315,10 @@
 %     \int_gset_regex_count:NNn, \int_gset_regex_count:cNn,
 %   }
 %   \begin{syntax}
-%     \cs{int_set_regex_count:Nnn} \meta{int var} \Arg{regex} \Arg{token list}
-%     \cs{int_set_regex_count:NNn} \meta{int var} \meta{regex~var} \Arg{token list}
+%     \cs{int_set_regex_count:Nnn} \meta{integer} \Arg{regex} \Arg{token list}
+%     \cs{int_set_regex_count:NNn} \meta{integer} \meta{regex~var} \Arg{token list}
 %   \end{syntax}
-%   Sets \meta{int var} equal to the number of times
+%   Sets \meta{integer} equal to the number of times
 %   \meta{regular expression} appears in \meta{token list}.
 %   The search starts by finding the left-most longest match,
 %   respecting greedy and lazy (non-greedy) operators. Then the search
@@ -333,7 +333,7 @@
 %   \end{verbatim}
 %   results in \cs[no-index]{l_foo_int} taking the value $5$.
 %   Theses are alternative names for \cs{regex_count:nnN} and friends,
-%   with arguments re-ordered for \meta{int~var} setting;
+%   with arguments re-ordered for \meta{integer} setting;
 %   see \pkg{l3regex} chapter for more details of the \meta{regex}
 %   format.
 % \end{function}

--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -184,9 +184,9 @@
 % \begin{function}[updated = 2013-07-08]
 %   {.bool_set:N, .bool_set:c, .bool_gset:N, .bool_gset:c}
 %   \begin{syntax}
-%     \meta{key} .bool_set:N = \meta{boolean variable}
+%     \meta{key} .bool_set:N = \meta{boolean}
 %   \end{syntax}
-%   Defines \meta{key} to set \meta{boolean variable} to \meta{value}. If the
+%   Defines \meta{key} to set \meta{boolean} to \meta{value}. If the
 %   \meta{value} is given, it must be one either \enquote{\texttt{true}} or
 %   \enquote{\texttt{false}}); it may be omitted, which is equivalent to
 %   \texttt{true}. If the variable does not exist, it will be created globally
@@ -199,12 +199,12 @@
 %     .bool_gset_inverse:N, .bool_gset_inverse:c
 %   }
 %   \begin{syntax}
-%     \meta{key} .bool_set_inverse:N = \meta{boolean variable}
+%     \meta{key} .bool_set_inverse:N = \meta{boolean}
 %   \end{syntax}
-%   Defines \meta{key} to set \meta{boolean variable} to the logical
+%   Defines \meta{key} to set \meta{boolean} to the logical
 %   inverse of \meta{value} (which  must be either \enquote{\texttt{true}} or
 %   \enquote{\texttt{false}}).
-%   If the \meta{boolean variable} does not exist, it will be created globally
+%   If the \meta{boolean} does not exist, it will be created globally
 %   at the point that the key is set up.
 % \end{function}
 %
@@ -311,9 +311,9 @@
 % \begin{function}[updated = 2020-01-17]
 %   {.fp_set:N, .fp_set:c, .fp_gset:N, .fp_gset:c}
 %   \begin{syntax}
-%     \meta{key} .fp_set:N = \meta{floating point}
+%     \meta{key} .fp_set:N = \meta{fp var}
 %   \end{syntax}
-%   Defines \meta{key} to set \meta{floating point} to \meta{value}
+%   Defines \meta{key} to set \meta{fp var} to \meta{value}
 %   (which must a floating point expression).  If the variable does not exist,
 %   it is created globally at the point that the key is set up. The key will
 %   require a value at point-of-use unless a default is set.

--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -587,8 +587,8 @@
 % \begin{function}[EXP, added = 2017-12-04]
 %   {\msg_show_item:n, \msg_show_item_unbraced:n, \msg_show_item:nn, \msg_show_item_unbraced:nn}
 %   \begin{syntax}
-%     \cs{seq_map_function:NN} \meta{seq} \cs{msg_show_item:n}
-%     \cs{prop_map_function:NN} \meta{prop} \cs{msg_show_item:nn}
+%     \cs{seq_map_function:NN} \meta{seq var} \cs{msg_show_item:n}
+%     \cs{prop_map_function:NN} \meta{property list} \cs{msg_show_item:nn}
 %   \end{syntax}
 %   Used in the text of messages for \cs{msg_show:nnnnnn} to show or log
 %   a list of items or key--value pairs.  The output of
@@ -647,7 +647,7 @@
 %   \end{syntax}
 %   Issues an \enquote{Undefined error} message from \TeX{} itself
 %   using the undefined control sequence \cs{???} then prints
-%   \enquote{! \meta{module}: }\meta{error message}, which should be
+%   \enquote{! \meta{module}: \meta{error message}}, which should be
 %   short.  With default settings, anything beyond approximately $60$
 %   characters long (or bytes in some engines) is cropped.  A leading
 %   space might be removed as well.

--- a/l3kernel/l3pdf.dtx
+++ b/l3kernel/l3pdf.dtx
@@ -112,7 +112,7 @@
 %
 % \begin{function}[added = 2024-04-01]{\pdf_object_new_indexed:nn}
 %   \begin{syntax}
-%     \cs{pdf_object_new_indexed:nn}  \Arg{class} \Arg{index}
+%     \cs{pdf_object_new_indexed:nn} \Arg{class} \Arg{index}
 %   \end{syntax}
 %   Declares a PDF object of \meta{class} and \meta{index}. The object may be
 %   referenced from this point on, and written later using
@@ -122,7 +122,7 @@
 % \begin{function}[added = 2024-04-01]
 %   {\pdf_object_write_indexed:nnnn, \pdf_object_write_indexed:nnne}
 %   \begin{syntax}
-%     \cs{pdf_object_write_indexed:nnnn}  \Arg{class} \Arg{index} \Arg{type} \Arg{content}
+%     \cs{pdf_object_write_indexed:nnnn} \Arg{class} \Arg{index} \Arg{type} \Arg{content}
 %   \end{syntax}
 %   Writes the \meta{content} as content of the object of \meta{class} and
 %   \meta{index}. Depending on the

--- a/l3kernel/l3prg.dtx
+++ b/l3kernel/l3prg.dtx
@@ -325,7 +325,7 @@
 %   {\bool_to_str:N, \bool_to_str:c, \bool_to_str:n}
 %   \begin{syntax}
 %     \cs{bool_to_str:N} \meta{boolean}
-%     \cs{bool_to_str:n} \meta{boolean expression}
+%     \cs{bool_to_str:n} \Arg{boolean expression}
 %   \end{syntax}
 %   Expands to the string \texttt{true} or \texttt{false} depending on
 %   the logical truth of the \meta{boolean} or \meta{boolean

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -183,8 +183,8 @@
 %   \begin{syntax}
 %     \cs{prop_set_from_keyval:Nn} \meta{property list} \\
 %     ~~\{ \\
-%     ~~~~\meta{key1} |=| \meta{value1} |,| \\
-%     ~~~~\meta{key2} |=| \meta{value2} |,| \ldots{} \\
+%     ~~~~\meta{key_1} |=| \meta{value_1} |,| \\
+%     ~~~~\meta{key_2} |=| \meta{value_2} |,| \ldots{} \\
 %     ~~\}
 %   \end{syntax}
 %   Sets \meta{property list} to contain key--value pairs given in the second
@@ -207,8 +207,8 @@
 %   \begin{syntax}
 %     \cs{prop_const_from_keyval:Nn} \meta{property list} \\
 %     ~~\{ \\
-%     ~~~~\meta{key1} |=| \meta{value1} |,| \\
-%     ~~~~\meta{key2} |=| \meta{value2} |,| \ldots{} \\
+%     ~~~~\meta{key_1} |=| \meta{value_1} |,| \\
+%     ~~~~\meta{key_2} |=| \meta{value_2} |,| \ldots{} \\
 %     ~~\}
 %   \end{syntax}
 %   Creates a new constant \enquote{flat} \meta{property list} or raises
@@ -224,15 +224,15 @@
 % \begin{function}[added = 2024-02-12]
 %   {\prop_const_linked_from_keyval:Nn, \prop_const_linked_from_keyval:cn}
 %   \begin{syntax}
-%     \cs{prop_const_linked_from_keyval:Nn} \meta{prop~var} \\
+%     \cs{prop_const_linked_from_keyval:Nn} \meta{property list} \\
 %     ~~\{ \\
-%     ~~~~\meta{key1} |=| \meta{value1} |,| \\
-%     ~~~~\meta{key2} |=| \meta{value2} |,| \ldots{} \\
+%     ~~~~\meta{key_1} |=| \meta{value_1} |,| \\
+%     ~~~~\meta{key_2} |=| \meta{value_2} |,| \ldots{} \\
 %     ~~\}
 %   \end{syntax}
-%   Creates a new constant \enquote{linked} \meta{prop~var} or raises an
+%   Creates a new constant \enquote{linked} \meta{property list} or raises an
 %   error if the
-%   name is already taken. The \meta{prop~var} is set globally to
+%   name is already taken. The \meta{property list} is set globally to
 %   contain key--value pairs given in the second argument, processed in
 %   the way described for \cs{prop_set_from_keyval:Nn}.  If duplicate
 %   keys appear only the last of the values is kept.
@@ -332,7 +332,7 @@
 %     \prop_gconcat:NNN, \prop_gconcat:ccc
 %   }
 %   \begin{syntax}
-%     \cs{prop_concat:NNN} \meta{property list_1} \meta{property list_2} \meta{property list3}
+%     \cs{prop_concat:NNN} \meta{property list_1} \meta{property list_2} \meta{property list_3}
 %   \end{syntax}
 %   Combines the key--value pairs of \meta{property list_2} and
 %   \meta{property list_3}, and saves the result in \meta{property list_1}.  If a
@@ -349,8 +349,8 @@
 %   \begin{syntax}
 %     \cs{prop_put_from_keyval:Nn} \meta{property list} \\
 %     ~~\{ \\
-%     ~~~~\meta{key1} |=| \meta{value1} |,| \\
-%     ~~~~\meta{key2} |=| \meta{value2} |,| \ldots{} \\
+%     ~~~~\meta{key_1} |=| \meta{value_1} |,| \\
+%     ~~~~\meta{key_2} |=| \meta{value_2} |,| \ldots{} \\
 %     ~~\}
 %   \end{syntax}
 %   Updates the \meta{property list} by adding entries for each key--value
@@ -384,11 +384,11 @@
 %     \cs{prop_get:NnN} \meta{property list} \Arg{key} \meta{tl var}
 %   \end{syntax}
 %   Recovers the \meta{value} stored with \meta{key} from the
-%   \meta{property list}, and places this in the \meta{token list
-%   variable}. If the \meta{key} is not found in the
+%   \meta{property list}, and places this in the \meta{tl
+%   var}. If the \meta{key} is not found in the
 %   \meta{property list} then the \meta{tl~var} is set
-%   to the special marker \cs{q_no_value}. The \meta{token list
-%     variable} is set within the current \TeX{} group. See also
+%   to the special marker \cs{q_no_value}. The \meta{tl
+%     var} is set within the current \TeX{} group. See also
 %   \cs{prop_get:NnNTF}.
 % \end{function}
 %
@@ -403,8 +403,8 @@
 %     \cs{prop_pop:NnN} \meta{property list} \Arg{key} \meta{tl var}
 %   \end{syntax}
 %   Recovers the \meta{value} stored with \meta{key} from the
-%   \meta{property list}, and places this in the \meta{token list
-%   variable}. If the \meta{key} is not found in the
+%   \meta{property list}, and places this in the \meta{tl
+%   var}. If the \meta{key} is not found in the
 %   \meta{property list} then the \meta{tl~var} is set
 %   to the special marker \cs{q_no_value}. The \meta{key} and
 %   \meta{value} are then deleted from the property list. Both
@@ -422,8 +422,8 @@
 %     \cs{prop_gpop:NnN} \meta{property list} \Arg{key} \meta{tl var}
 %   \end{syntax}
 %   Recovers the \meta{value} stored with \meta{key} from the
-%   \meta{property list}, and places this in the \meta{token list
-%   variable}. If the \meta{key} is not found in the
+%   \meta{property list}, and places this in the \meta{tl
+%   var}. If the \meta{key} is not found in the
 %   \meta{property list} then the \meta{tl~var} is set
 %   to the special marker \cs{q_no_value}. The \meta{key} and
 %   \meta{value} are then deleted from the property list.

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -610,9 +610,9 @@
 %     \regex_count:NnN, \regex_count:NVN
 %   }
 %   \begin{syntax}
-%     \cs{regex_count:nnN} \Arg{regex} \Arg{token list} \meta{int var}
+%     \cs{regex_count:nnN} \Arg{regex} \Arg{token list} \meta{integer}
 %   \end{syntax}
-%   Sets \meta{int var} within the current \TeX{} group level
+%   Sets \meta{integer} within the current \TeX{} group level
 %   equal to the number of times
 %   \meta{regex} appears in \meta{token list}.
 %   The search starts by finding the left-most longest match,
@@ -804,8 +804,8 @@
 %     ~~\Arg{true code} \Arg{false code}
 %   \end{syntax}
 %   Replaces the earliest match of the regular expression
-%   "(?|"\meta{regex_1}"|"\dots"|"\meta{regex_n}")" in the \meta{token
-%   list variable} by the \meta{replacement} corresponding to which
+%   "(?|"\meta{regex_1}"|"\dots"|"\meta{regex_n}")" in the
+%   \meta{tl var} by the \meta{replacement} corresponding to which
 %   \meta{regex_i} matched, then leaves the \meta{true code} in the
 %   input stream.  If none of the \meta{regex} match, then the
 %   \meta{tl~var} is not modified, and the \meta{false code} is left in

--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -108,10 +108,10 @@
 %     \seq_gset_from_clist:Nn, \seq_gset_from_clist:cn
 %   }
 %   \begin{syntax}
-%     \cs{seq_set_from_clist:NN} \meta{seq~var} \meta{comma-list}
+%     \cs{seq_set_from_clist:NN} \meta{seq~var} \meta{clist~var}
 %   \end{syntax}
-%   Converts the data in the \meta{comma list} into a \meta{seq~var}:
-%   the original \meta{comma list} is unchanged.
+%   Converts the data in the \meta{clist~var} into a \meta{seq~var}:
+%   the original \meta{clist~var} is unchanged.
 % \end{function}
 %
 % \begin{function}[added = 2017-11-28]
@@ -747,10 +747,10 @@
 %     \seq_map_pairwise_function:cNN, \seq_map_pairwise_function:ccN
 %   }
 %   \begin{syntax}
-%     \cs{seq_map_pairwise_function:NNN} \meta{seq_1} \meta{seq_2} \meta{function}
+%     \cs{seq_map_pairwise_function:NNN} \meta{seq var_1} \meta{seq var_2} \meta{function}
 %   \end{syntax}
 %   Applies \meta{function} to every pair of items
-%   \meta{seq_1-item}--\meta{seq_2-item} from the two sequences, returning
+%   \meta{seq var_1-item}--\meta{seq var_2-item} from the two sequences, returning
 %   items from both sequences from left to right.   The \meta{function}
 %   receives two \texttt{n}-type arguments for each iteration. The  mapping
 %   terminates when


### PR DESCRIPTION
This standardizes several argument types across interface3. I didn't try to deal with `⟨bool expr⟩` vs. `⟨boolean expression⟩`, `⟨int expr⟩` vs. `⟨integer expression⟩`, or `⟨tokens⟩` vs. `⟨token list⟩` since there were too many instances of each to pick one as the clearly intended choice.