### PR TITLE
Update expansion type in comments, s/e/x/g

### DIFF
--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1400,12 +1400,12 @@
 %   is a repetition of the pattern
 %   \cs{@@_set_split:Nw} \cs{prg_do_nothing:}
 %   \meta{item with spaces} \cs{@@_set_split_end:}.
-%   Then, \texttt{e}-expansion causes \cs{@@_set_split:Nw}
+%   Then, \texttt{x}-expansion causes \cs{@@_set_split:Nw}
 %   to trim spaces, and leaves its result as
 %   \cs{@@_set_split:w} \meta{trimmed item}
 %   \cs{@@_set_split_end:}. This is then converted
 %   to the \pkg{l3seq} internal structure by another
-%   \texttt{e}-expansion. In the first step, we insert
+%   \texttt{x}-expansion. In the first step, we insert
 %   \cs{prg_do_nothing:} to avoid losing braces too early:
 %   that would cause space trimming to act within those
 %   lost braces. The second step is solely there to strip
@@ -1470,7 +1470,7 @@
 %   and skipping out of that would break horribly.
 %   The \cs{@@_wrap_item:n} function inserts the relevant
 %   \cs{@@_item:n} without expansion in the input stream,
-%   hence in the \texttt{e}-expanding assignment.
+%   hence in the \texttt{x}-expanding assignment.
 %    \begin{macrocode}
 \cs_new_protected:Npn \seq_set_filter:NNn
   { \@@_set_filter:NNNn \__kernel_tl_set:Nx }
@@ -1672,7 +1672,7 @@
 %
 % \begin{macro}{\@@_wrap_item:n}
 %   This function converts its argument to a proper sequence item
-%   in an \texttt{e}-expansion context.
+%   in an \texttt{e}- or \texttt{x}-expansion context.
 %    \begin{macrocode}
 \cs_new:Npn \@@_wrap_item:n #1 { \exp_not:n { \@@_item:n {#1} } }
 %    \end{macrocode}
@@ -1734,15 +1734,15 @@
 %   items one at a time to an intermediate sequence.
 %   The approach taken is therefore similar to
 %   that in \cs{@@_pop_right:NNN}, using a \enquote{flexible}
-%   \texttt{e}-type expansion to do most of the work. As \cs{tl_if_eq:nnT}
+%   \texttt{x}-type expansion to do most of the work. As \cs{tl_if_eq:nnT}
 %   is not expandable, a two-part strategy is needed. First, the
-%   \texttt{e}-type expansion uses \cs{str_if_eq:nnT} to find potential
+%   \texttt{x}-type expansion uses \cs{str_if_eq:nnT} to find potential
 %   matches. If one is found, the expansion is halted and the necessary
-%   set up takes place to use the \cs{tl_if_eq:NNT} test. The \texttt{e}-type
+%   set up takes place to use the \cs{tl_if_eq:NNT} test. The \texttt{x}-type
 %   is started again, including all of the items copied already. This
 %   happens repeatedly until the entire sequence has been scanned. The code
 %   is set up to avoid needing an intermediate scratch list: the lead-off
-%   \texttt{e}-type expansion (|#1 #2 {#2}|) ensures that nothing is lost.
+%   \texttt{x}-type expansion (|#1 #2 {#2}|) ensures that nothing is lost.
 %    \begin{macrocode}
 \cs_new_protected:Npn \seq_remove_all:Nn
   { \@@_remove_all_aux:NNn \__kernel_tl_set:Nx }
@@ -2185,7 +2185,7 @@
 %   use some of the same ideas as getting from the right. What is needed is a
 %   \enquote{flexible length} way to set a token list variable. This is
 %   supplied by the |{ \if_false: } \fi:| \ldots
-%   |\if_false: { \fi: }| construct. Using an \texttt{e}-type
+%   |\if_false: { \fi: }| construct. Using an \texttt{x}-type
 %   expansion and a \enquote{non-expanding} definition for \cs{@@_item:n},
 %   the left-most $n - 1$ entries in a sequence of $n$ items are stored
 %   back in the sequence. That needs a loop of unknown length, hence using the


### PR DESCRIPTION
Fixes #1645.

l3kernel once did an overall x-to-e conversion, then reverted `\__kernel_tl_(g)set:Ne` to `:Nx`, which may result in quite some wrong expansion types used in code comments.