### PR TITLE
Use a UTF-8 char, continued

### DIFF
--- a/l3kernel/l3bootstrap.dtx
+++ b/l3kernel/l3bootstrap.dtx
@@ -70,14 +70,14 @@
 %     \cs{ExplSyntaxOn} \meta{code} \cs{ExplSyntaxOff}
 %   \end{syntax}
 %   The \cs{ExplSyntaxOn} function switches to a category code
-%   regime in which spaces and new lines are ignored, and in which the colon (|:|)
+%   régime in which spaces and new lines are ignored, and in which the colon (|:|)
 %   and underscore (|_|) are treated as \enquote{letters}, thus allowing
 %   access to the names of code functions and variables. Within this
 %   environment, |~| is used to input a space. The \cs{ExplSyntaxOff}
-%   reverts to the document category code regime.
+%   reverts to the document category code régime.
 %   \begin{texnote}
 %     Spaces introduced by~|~| behave much in the same way as normal
-%     space characters in the standard category code regime: they are
+%     space characters in the standard category code régime: they are
 %     ignored after a control word or at the start of a line, and
 %     multiple consecutive~|~| are equivalent to a single one.  However,
 %     |~|~is \emph{not} ignored at the end of a line.

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -123,7 +123,7 @@
 %
 %   \cs{lua_now:n} passes its \Arg{token list} argument to the Lua interpreter
 %   as a single line, with characters interpreted under the current catcode
-%   regime. These two facts mean that \cs{lua_now:n} rarely behaves as expected
+%   régime. These two facts mean that \cs{lua_now:n} rarely behaves as expected
 %   for larger pieces of code. Therefore, package authors should \textbf{not}
 %   write significant amounts of Lua code in the arguments to \cs{lua_now:n}.
 %   Instead, it is strongly recommended that they write the majorty of their Lua

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -469,12 +469,12 @@
 % the same category codes as in the original token list.
 %
 % By default, the category code of characters inserted by the
-% replacement are determined by the prevailing category code regime at
+% replacement are determined by the prevailing category code régime at
 % the time where the replacement is made, with two exceptions:
 % \begin{itemize}
 % \item space characters (with character code $32$) inserted with
 %   \verb*|\ | or |\x20| or |\x{20}| have category code~$10$ regardless
-%   of the prevailing category code regime;
+%   of the prevailing category code régime;
 % \item if the category code would be $0$~(escape), $5$~(newline),
 %   $9$~(ignore), $14$~(comment) or $15$~(invalid), it is replaced by
 %   $12$~(other) instead.
@@ -5971,7 +5971,7 @@
 %   \cs{l_@@_replacement_category_tl}.
 %   The argument |#1| is a single character (including the case of a catcode-other space).
 %   In case no specific catcode is requested, we take into account the
-%   current catcode regime (at the time the replacement is performed)
+%   current catcode régime (at the time the replacement is performed)
 %   as much as reasonable, with all impossible catcodes (escape,
 %   newline, etc.) being mapped to \enquote{other}.
 %    \begin{macrocode}

--- a/l3kernel/l3str-convert.dtx
+++ b/l3kernel/l3str-convert.dtx
@@ -2068,7 +2068,7 @@
 %
 % \subsubsection{\textsc{utf-16} support}
 %
-% The definitions are done in a category code regime where the bytes
+% The definitions are done in a category code régime where the bytes
 % $254$ and $255$ used by the byte order mark have catcode~$12$.
 %    \begin{macrocode}
 \group_begin:
@@ -2393,7 +2393,7 @@
 %
 % \subsubsection{\textsc{utf-32} support}
 %
-% The definitions are done in a category code regime where the bytes
+% The definitions are done in a category code régime where the bytes
 % $0$, $254$ and $255$ used by the byte order mark have catcode
 % \enquote{other}.
 %    \begin{macrocode}

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -1344,7 +1344,7 @@
 %     read from a file.
 %
 %     Contrarily to the \tn{scantokens} \eTeX{} primitive, \cs{tl_rescan:nn}
-%     tokenizes the whole string in the same category code regime rather
+%     tokenizes the whole string in the same category code régime rather
 %     than one token at a time, so that directives such as \tn{verb}
 %     that rely on changing category codes will not function properly.
 %   \end{texnote}

--- a/l3kernel/l3token.dtx
+++ b/l3kernel/l3token.dtx
@@ -1012,7 +1012,7 @@
 %     In case the input stream has not yet been tokenized (converted
 %     from characters to tokens), characters are tokenized one by one as
 %     needed by \cs{peek_analysis_map_inline:n} using the current
-%     category code regime.
+%     category code régime.
 %   \end{texnote}
 % \end{function}
 %


### PR DESCRIPTION
02d28bb1 (Use a UTF-8 char, 2024-12-28)

Uses of 'regime' in `./l3trial` are not replaced.