### PR TITLE
Step copyright (top-level README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ This code is developed by [The LaTeX Project](https://latex-project.org).
 
 ## Copyright
 
-This README file is copyright 2021-2024 The LaTeX Project.
+This README file is copyright 2021-2025 The LaTeX Project.


### PR DESCRIPTION
Reading the commit message of 2d3c3e35 (Step copyright (l3kernel), 2025-01-01), it seems to me that the copyright in the top-level README can be updated too.

> We can be sure there will be changes in l3kernel in 2025 - other parts may
or may not change, so copyright update there has to wait for at least one
'real' commit.