### PR TITLE
AttachCoffin replaced by JoinCoffins*

### DIFF
--- a/l3experimental/xcoffins/xcoffins.dtx
+++ b/l3experimental/xcoffins/xcoffins.dtx
@@ -377,7 +377,7 @@
 %   processes are contrasted. In both cases, the small red coffin has been
 %   aligned with the large grey coffin. In the left-hand illustration,
 %   the \cs{JoinCoffins} function was used, resulting in an expanded
-%   bounding box. In contrast, on the right \cs{AttachCoffin} was used,
+%   bounding box. In contrast, on the right \cs{JoinCoffins*} was used,
 %   meaning that the bounding box does not include the area of the
 %   smaller coffin.
 %

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -297,7 +297,7 @@
 % \begin{function}[updated = 2011-10-22]
 %   {
 %     \int_set:Nn, \int_set:cn, \int_set:NV, \int_set:cV,
-%     \int_gset:Nn, \int_gset:cn, \int_gset:MV, \int_gset:cV
+%     \int_gset:Nn, \int_gset:cn, \int_gset:NV, \int_gset:cV
 %   }
 %   \begin{syntax}
 %     \cs{int_set:Nn} \meta{integer} \Arg{int expr}


### PR DESCRIPTION
`\AttachCoffin`, nowhere defined but used in the `xcoffins`'s documentation, replaced by `JoinCoffins*`.