### PR TITLE
Add int_step_tokens:nnnn functions

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
+### Added
+- `\int_step_tokens:nn`, `\int_step_tokens:nnn`, and `\int_step_tokens:nnnn`
 
 ### Fixed
 - Check conditionals are defined when creating variants (see \#1189)

--- a/l3kernel/l3int.dtx
+++ b/l3kernel/l3int.dtx
@@ -629,6 +629,32 @@
 %   $1$. These functions are provided as simple short-cuts for code clarity.
 % \end{function}
 %
+% \begin{function}[added = 2025-01-13, rEXP]
+%   {\int_step_tokens:nn, \int_step_tokens:nnn, \int_step_tokens:nnnn} 
+%   \begin{syntax}
+%     \cs{int_step_tokens:nn} \Arg{final value} \Arg{code}
+%     \cs{int_step_tokens:nnn} \Arg{initial value} \Arg{final value} \Arg{code}
+%     \cs{int_step_tokens:nnnn} \Arg{initial value} \Arg{step} \Arg{final value} \Arg{code}
+%   \end{syntax}
+%   This function works just like \cs{int_step_function:nnnN} but
+%   instead of mapping a single function to each stepped \meta{value}
+%   between \meta{initial value} and \meta{final value} this maps
+%   the multiple tokens in \meta{code}, so that it gets the current
+%   \meta{value} as a braced argument following it.  For instance
+%   \begin{verbatim}
+%     \cs_set:Npn \my_product:nn #1#2
+%       { $#1 \times #2 = \int_eval:n { #1 * #2 }$ \quad }
+%     \int_step_tokens:nnnn { 1 } { 1 } { 4 } { \my_product:nn { 2 } }
+%   \end{verbatim}
+%   would print
+%   \begin{quote}
+%     $2 \times 1 = 2$ \quad
+%     $2 \times 2 = 4$ \quad
+%     $2 \times 3 = 6$ \quad
+%     $2 \times 4 = 8$ \quad
+%   \end{quote}
+% \end{function}
+%
 % \begin{function}[added = 2012-06-04, updated = 2018-04-22]
 %   {\int_step_inline:nn, \int_step_inline:nnn, \int_step_inline:nnnn}
 %   \begin{syntax}
@@ -1944,7 +1970,7 @@
 % \subsection{Integer step functions}
 %
 % \begin{macro}{\int_step_function:nnnN}
-% \begin{macro}{\@@_step:wwwN, \@@_step:NwnnN}
+% \begin{macro}{\@@_step:wwwn, \@@_step:Nwnnn}
 % \begin{macro}{\int_step_function:nN}
 % \begin{macro}{\int_step_function:nnN}
 %   Before all else, evaluate the initial value, step, and final value.
@@ -1952,49 +1978,68 @@
 %   of the steps. After that, do the function for the start value then
 %   step and loop around. It would be more symmetrical to test for a
 %   step size of zero before checking the sign, but we optimize for the
-%   most frequent case (positive step).
+%   most frequent case (positive step). And since when we're doing the
+%   test the step size is the result of \cs{@@_eval:w} we know that only
+%   the value $0$ has a leading token |0| which we can use for a faster
+%   test than \cs{int_compare:nNnTF}.
 %    \begin{macrocode}
 \cs_new:Npn \int_step_function:nnnN #1#2#3
   {
-    \exp_after:wN \@@_step:wwwN
+    \exp_after:wN \@@_step:wwwn
     \int_value:w \@@_eval:w #1 \exp_after:wN ;
     \int_value:w \@@_eval:w #2 \exp_after:wN ;
     \int_value:w \@@_eval:w #3 ;
   }
-\cs_new:Npn \@@_step:wwwN #1; #2; #3; #4
+\cs_new:Npn \@@_step:wwwn #1; #2; #3; #4
   {
     \int_compare:nNnTF {#2} > \c_zero_int
-      { \@@_step:NwnnN > }
+      { \@@_step:Nwnnn > }
       {
-        \int_compare:nNnTF {#2} = \c_zero_int
+        \if_meaning:w 0 #2
+          \exp_after:wN \use_ii:nn
+        \fi:
+        \use_none:n
           {
             \msg_expandable_error:nnn
               { kernel } { zero-step } {#4}
             \prg_break:
           }
-          { \@@_step:NwnnN < }
+        \@@_step:Nwnnn <
       }
-      #1 ; {#2} {#3} #4
+      #1 ; {#2} {#3} {#4}
     \prg_break_point:
   }
-\cs_new:Npn \@@_step:NwnnN #1#2 ; #3#4#5
+\cs_new:Npn \@@_step:Nwnnn #1#2 ; #3#4#5
   {
     \if_int_compare:w #2 #1 #4 \exp_stop_f:
       \prg_break:n
     \fi:
     #5 {#2}
-    \exp_after:wN \@@_step:NwnnN
+    \exp_after:wN \@@_step:Nwnnn
     \exp_after:wN #1
-    \int_value:w \@@_eval:w #2 + #3 ; {#3} {#4} #5
+    \int_value:w \@@_eval:w #2 + #3 ; {#3} {#4} {#5}
   }
 \cs_new:Npn \int_step_function:nN
-  { \int_step_function:nnnN { 1 } { 1 } }
+  { \int_step_function:nnnN \c_one_int \c_one_int }
 \cs_new:Npn \int_step_function:nnN #1
-  { \int_step_function:nnnN {#1} { 1 } }
+  { \int_step_function:nnnN {#1} \c_one_int }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
 % \end{macro}
+% \end{macro}
+%
+% \begin{macro}
+%   {\int_step_tokens:nn, \int_step_tokens:nnn, \int_step_tokens:nnnn} 
+%   Because the internals \cs{@@_step:wwwn} and \cs{@@_step:Nwnnn} are
+%   defined in such a way that they work with both a single token or a
+%   braced group of tokens these are really the same as the |function|
+%   variants.
+%    \begin{macrocode}
+\cs_new_eq:NN \int_step_tokens:nn   \int_step_function:nN
+\cs_new_eq:NN \int_step_tokens:nnn  \int_step_function:nnN
+\cs_new_eq:NN \int_step_tokens:nnnn \int_step_function:nnnN
+%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{\int_step_inline:nn, \int_step_inline:nnn, \int_step_inline:nnnn}


### PR DESCRIPTION
For `clist`, `tl`, `seq`, etc. there is a `map_tokens:` variant of the mapping functions. For `int` none such version exists. This PR adds it at almost zero cost (just three new control sequences).

I also added a micro-optimisation to the internal used by both `\int_step_function:nnnN` and `\int_step_tokens:nnnn`.