### PR TITLE
A small carelessness in the manual of l3doc

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -4716,7 +4716,7 @@ and all files in that bundle must be distributed together.
 %    \begin{macrocode}
 \tl_const:Nn \Team
   {
-    The~\LaTeX~Project~team\thanks
+    The~\LaTeX{}~Project~team\thanks
       {\url{https://www.latex-project.org/latex3/}}
   }
 %    \end{macrocode}


### PR DESCRIPTION
#### A small carelessness in the manual for `l3doc`
`The~\LaTeX~Project~team`, which is equal to `The \LaTeX Project team` out of expl3 syntax, will output "The LaTeXProject team", while `The~\LaTeX{}~Project~team` could output "The LaTeX Project team". Obviously, the latter one is correct.