### PR TITLE
Feat/speed up tl trim plus left right

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -3097,33 +3097,21 @@
 %   continuation, so that space trimming behaves correctly within an
 %   \texttt{e}-type or \texttt{x}-type expansion.
 %    \begin{macrocode}
-\cs_new:Npn \tl_trim_spaces:n #1
-  {
-    \@@_trim_spaces:nn
-      { #1 }
-      { \__kernel_exp_not:w \exp_after:wN }
-  }
-\cs_new:Npn \tl_trim_left_spaces:n #1
-  {
-    \@@_trim_left_spaces:nn
-      { #1 }
-      { \__kernel_exp_not:w \exp_after:wN }
-  }
-\cs_new:Npn \tl_trim_right_spaces:n #1
-  {
-    \@@_trim_right_spaces:nn
-      { #1 }
-      { \__kernel_exp_not:w \exp_after:wN }
-  }
-\cs_generate_variant:Nn \tl_trim_spaces:n { V , v , e , o }
-\cs_generate_variant:Nn \tl_trim_left_spaces:n { V , v , e , o }
+\cs_new:Npn \tl_trim_spaces:n
+  { \@@_trim_spaces:nn { \__kernel_exp_not:w \exp_after:wN } }
+\cs_new:Npn \tl_trim_left_spaces:n
+  { \@@_trim_left_spaces:nn { \__kernel_exp_not:w \exp_after:wN } }
+\cs_new:Npn \tl_trim_right_spaces:n
+  { \@@_trim_right_spaces:nn { \__kernel_exp_not:w \exp_after:wN } }
+\cs_generate_variant:Nn \tl_trim_spaces:n       { V , v , e , o }
+\cs_generate_variant:Nn \tl_trim_left_spaces:n  { V , v , e , o }
 \cs_generate_variant:Nn \tl_trim_right_spaces:n { V , v , e , o }
 \cs_new:Npn \tl_trim_spaces_apply:nN #1#2
-  { \@@_trim_spaces:nn { #1 } { \exp_args:No #2 } }
+  { \@@_trim_spaces:nn { \exp_args:No #2 } { #1 } }
 \cs_new:Npn \tl_trim_left_spaces_apply:nN #1#2
-  { \@@_trim_left_spaces:nn { #1 } { \exp_args:No #2 } }
+  { \@@_trim_left_spaces:nn { \exp_args:No #2 } { #1 } }
 \cs_new:Npn \tl_trim_right_spaces_apply:nN #1#2
-  { \@@_trim_right_spaces:nn { #1 } { \exp_args:No #2 } }
+  { \@@_trim_right_spaces:nn { \exp_args:No #2 } { #1 } }
 \cs_generate_variant:Nn \tl_trim_spaces_apply:nN { o }
 \cs_generate_variant:Nn \tl_trim_left_spaces_apply:nN { o }
 \cs_generate_variant:Nn \tl_trim_right_spaces_apply:nN { o }
@@ -3170,7 +3158,7 @@
 %   list: then |##1| is the token list and |##3| is
 %   \cs{@@_trim_spaces_auxii:w}. This hands the relevant tokens to the
 %   loop \cs{@@_trim_spaces_auxiii:w}, responsible for trimming
-%   trailing spaces. The end is reached when \verb*+ + \cs{s_@@_nil}
+%   trailing spaces. The end is reached when \verb*+ +\cs{s_@@_nil}
 %   matches the one present in the definition of \cs{tl_trim_spaces:n}.
 %   Then \cs{@@_trim_spaces_auxiv:w} puts the token list into a group,
 %   with a lingering \cs{@@_trim_mark:} at the start (which will expand to
@@ -3181,70 +3169,61 @@
 %   starts with \cs{@@_trim_spaces_auxi:w}, but when it loops until
 %   \cs{@@_trim_mark:}\verb*+ + matches the end of the token list, |##1|
 %   is the token list \emph{but} |##3| is \cs{@@_trim_spaces_auxv:w}.
-%   Like \cs{@@_trim_spaces_auxii:w}, this directly hands the relevant
-%   tokens to the exit \cs{@@_trim_spaces_auxiv:w}.
+%   Like \cs{@@_trim_spaces_auxiv:w}, this directly hands the relevant
+%   tokens to the exit \meta{continuation}.
 %   Trimming just trailing spaces (see \cs{@@_trim_right_spaces:nn})
 %   starts with the (second) loop \cs{@@_trim_spaces_auxiii:w}.
 %    \begin{macrocode}
 \cs_set_protected:Npn \@@_tmp:w #1
   {
-    \cs_new:Npn \@@_trim_spaces:nn ##1
+    \cs_new:Npn \@@_trim_spaces:nn ##1##2
       {
         \@@_trim_spaces_auxi:w
-          \@@_trim_mark: ##1 \s_@@_nil
-          \@@_trim_mark: #1 { }
+          \@@_trim_mark: ##2 \s_@@_nil
+          \@@_trim_mark: \@@_trim_spaces_auxi:w
+          \@@_trim_mark: #1
           \@@_trim_mark: \@@_trim_spaces_auxii:w
-          \@@_trim_spaces_auxiii:w
-          #1 \s_@@_nil
-          \@@_trim_spaces_auxiv:w
-        \s_@@_stop
+        {##1}
       }
-    \cs_new:Npn \@@_trim_left_spaces:nn ##1
+    \cs_new:Npn \@@_trim_left_spaces:nn ##1##2
       {
         \@@_trim_spaces_auxi:w
-          \@@_trim_mark: ##1 \s_@@_nil
-          \@@_trim_mark: #1 { }
+          \@@_trim_mark: ##2 \s_@@_nil
+          \@@_trim_mark: \@@_trim_spaces_auxi:w
+          \@@_trim_mark: #1
           \@@_trim_mark: \@@_trim_spaces_auxv:w
-        \s_@@_stop
+        {##1}
       }
-    \cs_new:Npn \@@_trim_right_spaces:nn ##1
+    \cs_new:Npn \@@_trim_right_spaces:nn ##1##2
       {
         \@@_trim_spaces_auxiii:w
-          \@@_trim_mark: ##1 \s_@@_nil
-          \@@_trim_spaces_auxiii:w
-          #1 \s_@@_nil
-          \@@_trim_spaces_auxiv:w
-        \s_@@_stop
+          \@@_trim_mark: ##2 \s_@@_nil \@@_trim_spaces_auxiii:w
+          #1 \s_@@_nil \@@_trim_spaces_auxiv:w
+        {##1}
       }
     \cs_new:Npn \@@_trim_spaces_auxi:w
         ##1 \@@_trim_mark: #1 ##2 \@@_trim_mark: ##3
-      {
-        ##3
-        \@@_trim_spaces_auxi:w
-        \@@_trim_mark:
-        ##2
-        \@@_trim_mark: #1 {##1}
-      }
+      { ##3 ##1 \@@_trim_mark: ##2 \@@_trim_mark: \@@_trim_spaces_auxi:w }
     \cs_new:Npn \@@_trim_spaces_auxii:w
-        \@@_trim_spaces_auxi:w \@@_trim_mark: \@@_trim_mark: ##1
+        \@@_trim_mark: ##1 \@@_trim_mark: ##2 \@@_trim_spaces_auxi:w
+        \@@_trim_mark: \@@_trim_mark: \@@_trim_spaces_auxi:w
       {
         \@@_trim_spaces_auxiii:w
-        ##1
+          \@@_trim_mark: ##1 \@@_trim_spaces_auxiii:w
+          #1 \s_@@_nil \@@_trim_spaces_auxiv:w
       }
     \cs_new:Npn \@@_trim_spaces_auxiii:w ##1 #1 \s_@@_nil ##2
-      {
-        ##2
+      { ##2 ##1 \s_@@_nil \@@_trim_spaces_auxiii:w }
+    \cs_new:Npn \@@_trim_spaces_auxiv:w
         ##1 \s_@@_nil
-        \@@_trim_spaces_auxiii:w
-      }
-    \cs_new:Npn \@@_trim_spaces_auxiv:w ##1 \s_@@_nil ##2 \s_@@_stop ##3
-      { ##3 { ##1 } }
+        \@@_trim_spaces_auxiii:w \s_@@_nil \@@_trim_spaces_auxiii:w
+        ##2
+      { ##2 {##1} }
     \cs_new:Npn \@@_trim_spaces_auxv:w
-        \@@_trim_spaces_auxi:w \@@_trim_mark: \@@_trim_mark: ##1
-      {
-        \@@_trim_spaces_auxiv:w
-        ##1
-      }
+        ##1 \s_@@_nil
+        \@@_trim_mark: \@@_trim_spaces_auxi:w \@@_trim_mark:
+        \@@_trim_mark: \@@_trim_spaces_auxi:w ##2
+      { ##2 {##1} }
     \cs_new:Npn \@@_trim_mark: {}
   }
 \@@_tmp:w { ~ }


### PR DESCRIPTION
This PR contains all relevant changes from https://github.com/latex3/latex3/pull/1678 but also speeds up `\tl_trim_spaces:n`, `\tl_trim_left_spaces:n` and `\tl_trim_right_spaces:n`. Benchmarking results:

Benchmarking results comparing my branch with the currently released `tl`:

```none
benchmarking `':
  my:
6.28e-7 seconds (4.86 ops)
6.3e-7 seconds (4.83 ops)
6.41e-7 seconds (4.88 ops)
  tl:
6.54e-7 seconds (5.02 ops)
6.59e-7 seconds (5.01 ops)
6.61e-7 seconds (5.02 ops)

benchmarking `abc':
  my:
7.97e-7 seconds (6 ops)
7.99e-7 seconds (6.01 ops)
8.02e-7 seconds (6.02 ops)
  tl:
8.43e-7 seconds (6.28 ops)
8.67e-7 seconds (6.21 ops)
8.45e-7 seconds (6.36 ops)

benchmarking ` abc':
  my:
9.24e-7 seconds (6.81 ops)
9.23e-7 seconds (6.82 ops)
9.59e-7 seconds (7.11 ops)
  tl:
1e-6 seconds (7.16 ops)
1.01e-6 seconds (7.17 ops)
1.01e-6 seconds (7.18 ops)

benchmarking `abc ':
  my:
9.21e-7 seconds (6.6 ops)
9.42e-7 seconds (6.89 ops)
9.32e-7 seconds (6.79 ops)
  tl:
9.65e-7 seconds (7.07 ops)
9.71e-7 seconds (7.09 ops)
9.69e-7 seconds (7.07 ops)

benchmarking ` abc ':
  my:
1.05e-6 seconds (7.73 ops)
1.06e-6 seconds (7.75 ops)
1.05e-6 seconds (7.74 ops)
  tl:
1.11e-6 seconds (8.05 ops)
1.12e-6 seconds (8.09 ops)
1.11e-6 seconds (8.1 ops)

benchmarking `     a':
  my:
1.3e-6 seconds (9.47 ops)
1.3e-6 seconds (9.43 ops)
1.3e-6 seconds (9.44 ops)
  tl:
1.41e-6 seconds (10.4 ops)
1.42e-6 seconds (10.3 ops)
1.42e-6 seconds (10.3 ops)

benchmarking `a     ':
  my:
1.32e-6 seconds (9.57 ops)
1.32e-6 seconds (9.59 ops)
1.3e-6 seconds (9.43 ops)
  tl:
1.34e-6 seconds (9.68 ops)
1.34e-6 seconds (9.77 ops)
1.35e-6 seconds (9.8 ops)

benchmarking `     a     ':
  my:
2.18e-6 seconds (15.6 ops)
2.16e-6 seconds (15.5 ops)
2.15e-6 seconds (15.6 ops)
  tl:
2.28e-6 seconds (16.6 ops)
2.27e-6 seconds (16.5 ops)
2.29e-6 seconds (16.5 ops)

benchmarking `abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcab
cabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc
abcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabca
bcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabcabc':

  my:
1.84e-5 seconds (136 ops)
1.86e-5 seconds (132 ops)
1.78e-5 seconds (126 ops)
  tl:
2.02e-5 seconds (143 ops)
2.03e-5 seconds (143 ops)
1.97e-5 seconds (139 ops)
```