### PR TITLE
Update l3prefixes.csv

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -45,6 +45,7 @@ cmd,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://
 code,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2021-04-23,2021-04-23,
 codedesc,codedescribe,Alceu Frigeri,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe/issues,2023-05-15,2023-05-15,
 codedoc,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,Somewhat experimental: may change
+codehigh,codehigh,Jianrui Lyu,https://github.com/lvjr/codehigh,https://github.com/lvjr/codehigh.git,https://github.com/lvjr/codehigh/issues,2022-04-02,2022-04-02,
 codelist,codelisting,Alceu Frigeri,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe/issues,2023-05-15,2023-05-15,
 codepoint,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 coffin,"l3kernel,xcoffins",The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -30,6 +30,7 @@ cal,spath3,Andrew Stacey,https://github.com/loopspace/spath3,https://github.com/
 cascade,cascade,F. Pantigny,,,,2020-07-21,2020-07-21,
 catcode,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 cctab,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-28,2012-09-28,
+cdhh,codehigh,Jianrui Lyu,https://github.com/lvjr/codehigh,https://github.com/lvjr/codehigh.git,https://github.com/lvjr/codehigh/issues,2025-02-16,2025-02-16,
 cellprops,cellprops,Julien Rivaud,,,,2018-06-13,2018-06-13,
 chaos,"chaos,schleuderpackung",Marei Peischl,https://ds.ccc.de/,,,2021-05-28,2021-05-28,
 char,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
@@ -44,7 +45,6 @@ cmd,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://
 code,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2021-04-23,2021-04-23,
 codedesc,codedescribe,Alceu Frigeri,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe/issues,2023-05-15,2023-05-15,
 codedoc,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,Somewhat experimental: may change
-codehigh,codehigh,Jianrui Lyu,https://github.com/lvjr/codehigh,https://github.com/lvjr/codehigh.git,https://github.com/lvjr/codehigh/issues,2022-04-02,2022-04-02,
 codelist,codelisting,Alceu Frigeri,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe/issues,2023-05-15,2023-05-15,
 codepoint,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 coffin,"l3kernel,xcoffins",The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
@@ -249,6 +249,7 @@ socket,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https
 sort,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2017-02-13,
 space,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 spath,spath3,Andrew Stacey,https://github.com/loopspace/spath3,https://github.com/loopspace/spath3.git,https://github.com/loopspace/spath3/issues,2024-07-18,2024-07-18,
+speg,pegmatch,Jianrui Lyu,https://github.com/lvjr/pegmatch,https://github.com/lvjr/pegmatch.git,https://github.com/lvjr/pegmatch/issues,2025-02-16,2025-02-16,
 starray,starray,Alceu Frigeri,https://github.com/alceu-frigeri/starray,https://github.com/alceu-frigeri/starray,https://github.com/alceu-frigeri/starray/issues,2023-05-15,2023-05-15,
 statistics,statistics,Julien Rivaud,https://gitlab.com/frnchfrgg-latex/statistics,https://gitlab.com/frnchfrgg-latex/statistics.git,https://gitlab.com/frnchfrgg-latex/statistics/issues,2018-06-25,2018-06-25,
 stm,lt3-stm,CV Radhakrishnan,http://www.cvr.cc/,,,2014-02-26,2014-02-26,
@@ -275,6 +276,7 @@ tl,"l3kernel,l3tl-build",The LaTeX Project,https://www.latex-project.org/latex3.
 tmpa,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 tmpb,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 token,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
+tpeg,pegmatch,Jianrui Lyu,https://github.com/lvjr/pegmatch,https://github.com/lvjr/pegmatch.git,https://github.com/lvjr/pegmatch/issues,2025-02-16,2025-02-16,
 true,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2021-04-23,2021-04-23,
 twmk,menukeys,Tobias Weh,https://github.com/tweh/menukeys,git@github.com:tweh/menukeys.git,https://github.com/tweh/menukeys/issues,2020-10-31,2020-10-31,“classic” L2 package using only some expl3 code
 ufcombo,combofont,Ulrike Fischer,https://github.com/u-fischer/combofont,https://github.com/u-fischer/combofont,https://github.com/u-fischer/combofont/issues,2020-04-24,2020-04-24,


### PR DESCRIPTION
Rename prefix `codehigh` as `cdhh`; register prefixes `speg` and `tpeg`.