### PR TITLE
A carelessness in the implementation part of `l3opacity.dtx`

### DIFF
--- a/l3experimental/l3opacity/l3opacity.dtx
+++ b/l3experimental/l3opacity/l3opacity.dtx
@@ -106,7 +106,7 @@
   {L3 Experimental opacity support}
 %    \end{macrocode}
 %
-% \begin{variable}
+% \begin{variable}{\l_@@_tmp_fp}
 %   Temporary storage.
 %    \begin{macrocode}
 \fp_new:N \l_@@_tmp_fp


### PR DESCRIPTION
The `variable` environment will swallow an argument, or I couldn't successfully compile the `.dtx` file.