### PR TITLE
Use common `update_tag()` for l3backend

### DIFF
--- a/l3backend/build.lua
+++ b/l3backend/build.lua
@@ -26,49 +26,15 @@ if main_branch then
   tdslocations = {"dvips/l3backend/*.pro"}
 end
 
--- Detail how to set the version automatically
-function update_tag(file,content,tagname,tagdate)
+-- Extra operations in setting the version 
+function update_tag_extra(file,content,tagname,tagdate)
   local iso = "%d%d%d%d%-%d%d%-%d%d"
-  local url = "https://github.com/latex3/latex3/compare/"
-  if string.match(content,"%(C%)%s*[%d%-,]+ The LaTeX Project") then
-    local year = os.date("%Y")
-    content = string.gsub(content,
-      "%(C%)%s*([%d%-,]+) The LaTeX Project",
-      "(C) %1," .. year .. " The LaTeX Project")
-    content = string.gsub(content,year .. "," .. year,year)
-    content = string.gsub(content,
-      "%-" .. math.tointeger(year - 1) .. "," .. year,
-      "-" .. year)
-    content = string.gsub(content,
-      math.tointeger(year - 2) .. "," .. math.tointeger(year - 1) .. "," .. year,
-      math.tointeger(year - 2).. "-" .. year)
-  end
   if string.match(file,"l3backend%-basics%.dtx$") then
     content = string.gsub(content,
       "\n  ({l3backend%-%w+%.def}){" .. iso .. "}",
       "\n  %1{" .. tagname .. "}")
   end
-  if string.match(file,"%.dtx$") or string.match(file,"%.tex$") then
-    return string.gsub(content,
-      "\n(%%*%s*)\\date{Released " .. iso .. "}\n",
-      "\n%1\\date{Released " .. tagname .. "}\n")
-  elseif string.match(file, "%.md$") then
-    if string.match(file,"CHANGELOG.md") then
-      local previous = string.match(content,"compare/(" .. iso .. ")%.%.%.HEAD")
-      if tagname == previous then return content end
-      content = string.gsub(content,
-        "## %[Unreleased%]",
-        "## [Unreleased]\n\n## [" .. tagname .."]")
-      return string.gsub(content,
-        iso .. "%.%.%.HEAD",
-        tagname .. "...HEAD\n[" .. tagname .. "]: " .. url .. previous
-          .. "..." .. tagname)
-    end
-    return string.gsub(content,
-      "\nRelease " .. iso .. "\n",
-      "\nRelease " .. tagname .. "\n")
-  end
-  return content
+  return(content)
 end
 
 uploadconfig = {


### PR DESCRIPTION
The common `./build-config.lua` defines a common `update_tag()` and an empty hook `update_tag_extra()` for customization. Among all the modules in this repository, `./l3backend/build.lua` is the only one which defines its own `update_tag()`.

Since the two `update_tag()`s are more similar than not, this PR drops the `update_tag()` in `./l3backend/build.lua` and moves the customization in `update_tag_extra()`.

Tested locally by executing `l3build tag 2025-03-01` in `./l3backend`.

<details><summary>Comparison on the two <code>update_tag()</code>s.</summary>
<p>

```diff
diff --git a/build-config.lua b/l3backend/build.lua
index 4a719bd..3a508b5 100644
--- a/build-config.lua
+++ b/l3backend/build.lua
@@ -1,43 +1,44 @@
 -- Detail how to set the version automatically
 function update_tag(file,content,tagname,tagdate)
   local iso = "%d%d%d%d%-%d%d%-%d%d"
   local url = "https://github.com/latex3/latex3/compare/"
-  content =  update_tag_extra(file,content,tagname,tagdate)
   if string.match(content,"%(C%)%s*[%d%-,]+ The LaTeX Project") then
     local year = os.date("%Y")
     content = string.gsub(content,
       "%(C%)%s*([%d%-,]+) The LaTeX Project",
       "(C) %1," .. year .. " The LaTeX Project")
     content = string.gsub(content,year .. "," .. year,year)
     content = string.gsub(content,
       "%-" .. math.tointeger(year - 1) .. "," .. year,
       "-" .. year)
     content = string.gsub(content,
       math.tointeger(year - 2) .. "," .. math.tointeger(year - 1) .. "," .. year,
-      math.tointeger(year - 2) .. "-" .. year)
+      math.tointeger(year - 2).. "-" .. year)
   end
-  if string.match(file,"%.dtx$") then
+  if string.match(file,"l3backend%-basics%.dtx$") then
     content = string.gsub(content,
-      "\n( *)\\ProvidesExpl" .. "(%w+ *{[^}]+} *){" .. iso .. "}",
-      "\n%1\\ProvidesExpl%2{" .. tagname .. "}")
+      "\n  ({l3backend%-%w+%.def}){" .. iso .. "}",
+      "\n  %1{" .. tagname .. "}")
+  end
+  if string.match(file,"%.dtx$") or string.match(file,"%.tex$") then
     return string.gsub(content,
-      "\n%% \\date{Released " .. iso .. "}\n",
-      "\n%% \\date{Released " .. tagname .. "}\n")
+      "\n(%%*%s*)\\date{Released " .. iso .. "}\n",
+      "\n%1\\date{Released " .. tagname .. "}\n")
   elseif string.match(file, "%.md$") then
     if string.match(file,"CHANGELOG.md") then
       local previous = string.match(content,"compare/(" .. iso .. ")%.%.%.HEAD")
       if tagname == previous then return content end
       content = string.gsub(content,
         "## %[Unreleased%]",
         "## [Unreleased]\n\n## [" .. tagname .."]")
       return string.gsub(content,
         iso .. "%.%.%.HEAD",
         tagname .. "...HEAD\n[" .. tagname .. "]: " .. url .. previous
           .. "..." .. tagname)
     end
     return string.gsub(content,
       "\nRelease " .. iso .. "\n",
       "\nRelease " .. tagname .. "\n")
   end
   return content
 end
```

</p>
</details> 