### PR TITLE
Correct typos

### DIFF
--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -144,7 +144,7 @@
 %     \TeX{} programmers to define higher-level commands, and their
 %     idiosyncratic syntax is not at all popular with this community.
 %     Moreover, many of them have names that could be very useful as
-%     document mark-up tags were they not pre-empted as primitives
+%     document mark-up tags were they not pre-emptied as primitives
 %     (\emph{e.g.}~\tn{box} or \tn{special}).
 %
 %   \item[Designer interface] This relates a (human) typographic
@@ -254,7 +254,7 @@
 % \begin{quote}
 %   \meta{module} and \meta{description}
 % \end{quote}
-% these both give information about the command.
+% that both give information about the command.
 %
 % A \emph{module} is a collection of closely related functions and
 % variables. Typical module names include~|int| for integer parameters

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -144,7 +144,7 @@
 %     \TeX{} programmers to define higher-level commands, and their
 %     idiosyncratic syntax is not at all popular with this community.
 %     Moreover, many of them have names that could be very useful as
-%     document mark-up tags were they not pre-emptied as primitives
+%     document mark-up tags were they not pre-empted as primitives
 %     (\emph{e.g.}~\tn{box} or \tn{special}).
 %
 %   \item[Designer interface] This relates a (human) typographic
@@ -254,7 +254,7 @@
 % \begin{quote}
 %   \meta{module} and \meta{description}
 % \end{quote}
-% that both give information about the command.
+% and these two both give information about the command.
 %
 % A \emph{module} is a collection of closely related functions and
 % variables. Typical module names include~|int| for integer parameters

--- a/l3kernel/l3clist.dtx
+++ b/l3kernel/l3clist.dtx
@@ -2185,9 +2185,9 @@
 % \begin{macro}{\@@_rand_item:nn}
 %   The |N|-type function is not implemented through the |n|-type
 %   function for efficiency: for instance comma-list variables do not
-%   require space-trimming of their items.  Even testing for emptyness
+%   require space-trimming of their items.  Even testing for emptiness
 %   of an |n|-type comma-list is slow, so we count items first and use
-%   that both for the emptyness test and the pseudo-random integer.
+%   that both for the emptiness test and the pseudo-random integer.
 %   Importantly, \cs{clist_item:Nn} and \cs{clist_item:nn} only evaluate
 %   their argument once.
 %    \begin{macrocode}

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -2440,14 +2440,14 @@
 %  \begin{macro}[EXP]{\@@_model_devicen_mix:nw}
 % \begin{macro}{\@@_model_devicen_init:nnn}
 % \begin{macro}{\@@_model_devicen_init:nnnn}
-% \begin{macro}{\@@_model_devicen_tranform:w}
+% \begin{macro}{\@@_model_devicen_transform:w}
 % \begin{macro}
 %   {
-%     \@@_model_devicen_tranform_1:nnnnn ,
-%     \@@_model_devicen_tranform_3:nnnnn ,
-%     \@@_model_devicen_tranform_4:nnnnn ,
+%     \@@_model_devicen_transform_1:nnnnn ,
+%     \@@_model_devicen_transform_3:nnnnn ,
+%     \@@_model_devicen_transform_4:nnnnn ,
 %   }
-% \begin{macro}{\@@_model_devicen_tranform:nnn}
+% \begin{macro}{\@@_model_devicen_transform:nnn}
 % \begin{macro}[EXP]{\@@_model_devicen_colorant:n}
 % \begin{macro}{\@@_model_devicen_convert:nnn}
 % \begin{macro}

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -1097,7 +1097,7 @@ end
 %
 % \begin{macro}[EXP]{\sys_timer:, \@@_elapsedtime:}
 % \begin{macro}[EXP, pTF]{\sys_if_timer_exist:}
-%   In \LuaTeX{}, create a pseudo-primitve, otherwise try to
+%   In \LuaTeX{}, create a pseudo-primitive, otherwise try to
 %   locate the real primitive.  The elapsed time will be
 %   available if this succeeds.
 %    \begin{macrocode}

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -2248,7 +2248,7 @@
 %   as our~\meta{A}.  The argument~|#2| only serves to collect~|?|
 %   characters for~|#1|.  Note that the order of the tests means that
 %   the first two are done every time, which is wasteful (for instance,
-%   we repeatedly test for the emptyness of~|#6|).  However, this is
+%   we repeatedly test for the emptiness of~|#6|).  However, this is
 %   rare enough not to matter.  Finally, choose~\meta{B} to be
 %   \cs{q_@@_nil} or~\cs{q_@@_stop} such that it is not equal to~|#6|.
 %
@@ -2546,7 +2546,7 @@
 %   \TeX{} skips spaces when reading a non-delimited arguments. Thus,
 %   a \meta{token list} is blank if and only if \cs{use_none:n}
 %   \meta{token list} |?| is empty after one expansion.  The auxiliary
-%   \cs{@@_if_empty_if:o} is a fast emptyness test, converting its
+%   \cs{@@_if_empty_if:o} is a fast emptiness test, converting its
 %   argument to a string (after one expansion) and using the test
 %   \cs{if:w} \cs{scan_stop:} |...| \cs{scan_stop:}.
 %    \begin{macrocode}
@@ -2691,7 +2691,7 @@
 %   starts with |-NoValue-|, while the second argument is empty if |##1|
 %   is exactly |-NoValue-| or if it has a question mark just following
 %   |-NoValue-|.  In this second case, however, the material after the
-%   first |?!| remains and makes the emptyness test return
+%   first |?!| remains and makes the emptiness test return
 %   \texttt{false}.
 %    \begin{macrocode}
 \cs_set_protected:Npn \@@_tmp:w #1

--- a/l3kernel/l3unicode.dtx
+++ b/l3kernel/l3unicode.dtx
@@ -506,7 +506,7 @@
 %    \begin{macrocode}
   \cs_set_nopar:Npn \l_@@_matched_block_tl { 0 }
 %    \end{macrocode}
-% For Unicode general category and the various breaking properies, there needs
+% For Unicode general category and the various breaking properties, there needs
 % to be numerical representation of each possible value. As we need to go from
 % string to number here, but the other way elsewhere, we set up fast mappings
 % both ways, but one set local and the other as constants.
@@ -558,7 +558,7 @@
     \q_recursion_stop
   \cs_set_eq:NN \l_@@_wordbreak_default_tl \l_@@_wordbreak_Other_tl
 %    \end{macrocode}
-%  For the the property fiels, we need to use a two-step procedure
+%  For the the property fields, we need to use a two-step procedure
 %  as the file is ordered by class not codepoint. First, we parse the content
 %  into the hash table locally: there are around $1400$ codepoints to handle,
 %  which is workable. Reading this is quite easy: we store any end-of-range


### PR DESCRIPTION
All except for the 'these' -> `that` one were caught by [`typos`](https://github.com/crate-ci/typos), command [`typos l3kernel/*.dtx`](https://github.com/crate-ci/typos).

The `typos` cli provides a GitHub Action, which can be used as `uses: crate-ci/typos@v1`. A whitelist is needed if we'd like to add it to CI.