### PR TITLE
Update l3tl.dtx

### DIFF
--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -307,7 +307,8 @@
 %   \meta{tl~var}. The \meta{token list} cannot contain
 %   the tokens |{|, |}| or |#|
 %   (more precisely, explicit character tokens with category code $1$
-%   (begin-group) or $2$ (end-group), and tokens with category code $6$).
+%   (begin-group) or $2$ (end-group), and tokens with category code $6$),
+%   use \cs{tl_if_regex_match:VnTF} in that case.
 % \end{function}
 %
 % \begin{function}[TF]
@@ -321,7 +322,8 @@
 %   Tests if \meta{token list_2} is found inside \meta{token list_1}.
 %   The \meta{token list_2} cannot contain the tokens |{|, |}| or |#|
 %   (more precisely, explicit character tokens with category code $1$
-%   (begin-group) or $2$ (end-group), and tokens with category code $6$).
+%   (begin-group) or $2$ (end-group), and tokens with category code $6$),
+%   use \cs{tl_if_regex_match:nnTF} in that case.
 %   The search does \emph{not} enter brace (category code $1$/$2$) groups.
 % \end{function}
 %
@@ -1205,7 +1207,8 @@
 %   \meta{tl~var} with \meta{new tokens}. \meta{Old tokens}
 %   cannot contain |{|, |}| or |#|
 %   (more precisely, explicit character tokens with category code $1$
-%   (begin-group) or $2$ (end-group), and tokens with category code $6$).
+%   (begin-group) or $2$ (end-group), and tokens with category code $6$),
+%   use \cs{tl_regex_replace_once:Nnn} in that case.
 % \end{function}
 %
 % \begin{function}[updated = 2011-08-11]
@@ -1226,7 +1229,8 @@
 %   \meta{tl~var} with \meta{new tokens}. \meta{Old tokens}
 %   cannot contain |{|, |}| or |#|
 %   (more precisely, explicit character tokens with category code $1$
-%   (begin-group) or $2$ (end-group), and tokens with category code $6$).
+%   (begin-group) or $2$ (end-group), and tokens with category code $6$),
+%   use \cs{tl_regex_replace_all:Nnn} in that case.
 %   As this function
 %   operates from left to right, the pattern \meta{old tokens}
 %   may remain after the replacement (see \cs{tl_remove_all:Nn}
@@ -1291,7 +1295,8 @@
 %   Removes the first (leftmost) occurrence of \meta{tokens} from the
 %   \meta{tl~var}. The \meta{tokens} cannot contain |{|, |}| or |#|
 %   (more precisely, explicit character tokens with category code $1$
-%   (begin-group) or $2$ (end-group), and tokens with category code $6$).
+%   (begin-group) or $2$ (end-group), and tokens with category code $6$),
+%   use \cs{tl_regex_replace_once:Nnn} in that case.
 % \end{function}
 %
 % \begin{function}[updated = 2011-08-11]
@@ -1307,7 +1312,8 @@
 %   Removes all occurrences of \meta{tokens} from the
 %   \meta{tl~var}. The \meta{tokens} cannot contain |{|, |}| or |#|
 %   (more precisely, explicit character tokens with category code $1$
-%   (begin-group) or $2$ (end-group), and tokens with category code $6$).
+%   (begin-group) or $2$ (end-group), and tokens with category code $6$),
+%   use \cs{tl_regex_replace_all:Nnn} in that case.
 %   As this function
 %   operates from left to right, the pattern \meta{tokens}
 %   may remain after the removal, for instance,


### PR DESCRIPTION
Some editing methods do not accept `{`,  `}`, `#` in the argument.
A short indication is added to suggest the use of a `\tl_regex...` function in that case.
