### PR TITLE
Preserve intarray across multiple dumps

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -9,6 +9,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Fixed
 - Support for LuaMetaTeX in generic mode (issue \#1702)
+- Correctly keep `intarray` variables across multiple dumps (issue \#1597)
 
 ## [2025-04-14]
 

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -668,7 +668,6 @@ local register_luadata, get_luadata
 
 if luatexbase then
   local register = token_create'@expl@luadata@bytecode'.index
-  if status.ini_version then
 %    \end{macrocode}
 %
 % \begin{macro}[int]{register_luadata}
@@ -676,8 +675,11 @@ if luatexbase then
 % It accept a string which uniquely identifies the data object and has to be
 % provided to retrieve it later. Additionally it accepts a function which is
 % called in the \texttt{pre_dump} callback and which has to return a string that
-% evaluates to a valid Lua object to be preserved.
+% evaluates to a valid Lua object to be preserved. Note that format generation
+% does not necessarily mean the first run, because some packages such as
+% \pkg{mylatexformat} generates a format based on an existing format.
 %    \begin{macrocode}
+  if status.ini_version then
     local luadata, luadata_order = {}, {}
 
     function register_luadata(name, func)
@@ -703,19 +705,21 @@ if luatexbase then
         lua.bytecode[register] = assert(load(str .. "}"))
       end
     end, "ltx.luadata")
-  else
+  end
 %    \end{macrocode}
 %
 % \begin{macro}[int]{get_luadata}
 % \texttt{get_luadata} is only available if data should be restored.
 % It accept the identifier which was used when the data object was registered and
 % returns the associated object. Every object can only be retrieved once.
+% Note that it is possible for both \texttt{register_luadata} and \texttt{get_luadata}
+% to be available, for example while compiling a precompiled preamble.
+% In such a case, data must be registered again to be kept in the next run.
 %    \begin{macrocode}
-    local luadata = lua.bytecode[register]
-    if luadata then
-      lua.bytecode[register] = nil
-      luadata = luadata()
-    end
+  local luadata = lua.bytecode[register]
+  if luadata then
+    lua.bytecode[register] = nil
+    luadata = luadata()
     function get_luadata(name)
       if not luadata then return end
       local data = luadata[name]


### PR DESCRIPTION
Fixes https://github.com/latex3/latex3/issues/1597 . Uses the patch there.

I don't think there's any disadvantage (for users who doesn't use precompiled preamble, the only visible difference is that in the second run `register_luadata` is also available, but if they just don't use it then there's no difference)