### PR TITLE
Drop unnecessary empty lines

### DIFF
--- a/l3backend/l3backend-opacity.dtx
+++ b/l3backend/l3backend-opacity.dtx
@@ -123,7 +123,6 @@
           }
         ifelse
       }
-
   }
 \cs_new_protected:Npn \@@_backend_reset_fill:
   {

--- a/l3experimental/l3draw/l3draw.dtx
+++ b/l3experimental/l3draw/l3draw.dtx
@@ -1064,7 +1064,6 @@
 %   \end{demo}
 %   If the \meta{point} is given, the pole intersection of the coffine is
 %   placed there: otherwise it is positioned at the origin of the drawing.
-
 % \end{function}
 %
 % \subsection{Transformations}

--- a/l3kernel/l3box.dtx
+++ b/l3kernel/l3box.dtx
@@ -2519,7 +2519,6 @@
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
-
 %
 %    \begin{macrocode}
 %</code>

--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -2032,7 +2032,6 @@
   \@@_tmp:w { HTML }           { rgb }
   \@@_tmp:w { space-sep-cmyk } { cmyk }
   \@@_tmp:w { space-sep-rgb }  { rgb }
-
 \group_end:
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -2837,7 +2837,6 @@ and all files in that bundle must be distributed together.
         \multicolumn { 2 } { @{} r @{} }
           { \scriptsize New: \, \l_@@_date_added_tl } \\
       }
-
     \tl_if_empty:NF \l_@@_date_updated_tl
       {
         \multicolumn { 2 } { @{} r @{} }
@@ -4620,7 +4619,6 @@ and all files in that bundle must be distributed together.
   {
     \tl_to_str:n
       {
-
         alignment, ampersand, atsign, backslash, catcode, circumflex,
         code, colon, document, dollar, e, empty, false, hash, inf,
         initex, job, left, log, math, mark, max, minus, nan, nil, no,
@@ -4628,7 +4626,6 @@ and all files in that bundle must be distributed together.
         stop, term, tilde, tmpa, tmpb, true, underscore, zero, one, two,
         three, four, five, six, seven, eight, nine, ten, eleven, twelve,
         thirteen, fourteen, fifteen, sixteen, thirty, hundred
-
       }
   }
 %    \end{macrocode}

--- a/l3kernel/l3fp-round.dtx
+++ b/l3kernel/l3fp-round.dtx
@@ -98,7 +98,6 @@
   }
 \cs_new:Npn \@@_parse_round:Nw #1 #2 \@@_round_to_nearest:NNN #3#4
   { #2 #1 #3 }
-
 %    \end{macrocode}
 % \end{macro}
 %

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -289,7 +289,6 @@
     The~feature~you~are~using~is~only~available~
     with~the~LuaTeX~engine.~LaTeX3~ignored~'#1'.
   }
-
 \msg_new:nnnn { luatex } { module-not-found }
   { Lua~module~`#1'~not~found. }
   {
@@ -299,7 +298,6 @@
     The~Lua~loader~provided~this~additional~information: \\
     #2
   }
-
 \prop_gput:Nnn \g_msg_module_name_prop { luatex } { LaTeX }
 \prop_gput:Nnn \g_msg_module_type_prop { luatex } { }
 %    \end{macrocode}

--- a/l3kernel/l3text-case.dtx
+++ b/l3kernel/l3text-case.dtx
@@ -1200,7 +1200,6 @@
                         \@@_change_case_store:e
                           { \@@_change_case_upper_el_stress:nn {#1} {#5} }
                         \@@_change_case_loop:nnnw {#2} {#3} {#4}
-
                       }
                       {
                         \@@_change_case_store:e

--- a/l3trial/l3doc/examples/basics.dtx
+++ b/l3trial/l3doc/examples/basics.dtx
@@ -1,4 +1,3 @@
-
 % \iffalse
 %<*driver>
 \documentclass[full]{l3doc}

--- a/l3trial/l3doc/examples/indexing.dtx
+++ b/l3trial/l3doc/examples/indexing.dtx
@@ -1,4 +1,3 @@
-
 % \iffalse
 %<*driver>
 \documentclass[full]{l3doc}

--- a/l3trial/xbox/xbox.dtx
+++ b/l3trial/xbox/xbox.dtx
@@ -1400,7 +1400,6 @@
      \IfNoValueTF {#2}
        { \xbox_parbox_to_wd:nnn {#4} {#1} {#5} }
        { \xbox_parbox_to_wd_and_ht:nnnnn {#4} {#2} {#1} {#3} {#5} }
-
   }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
It all started from spotting an unnecessary empty line introduced by https://github.com/latex3/latex3/commit/6908dd8636260c174b0afe7a824e371981d06f7a (more specifically [here](https://github.com/latex3/latex3/commit/6908dd8636260c174b0afe7a824e371981d06f7a#diff-8d622406df5e749465119bf293218a7296fdeb18c7a74116ac065861413af970R126)).