### PR TITLE
Replace remaining ";" and "semi(-)colon" in comments

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -2310,7 +2310,7 @@
 %     \@@_wrap_line_end:nw,
 %     \@@_wrap_end_chunk:w
 %   }
-%   This is followed by \Arg{string} \meta{int expr} |;|.  It stores the
+%   This is followed by \Arg{string} \meta{int expr} \cs{@@_sep:}.  It stores the
 %   \meta{string} and up to \meta{int expr} characters from the current
 %   chunk into \cs{l_@@_line_part_tl}.  Characters are grabbed 8~at a
 %   time and left in \cs{l_@@_line_part_tl} by the \texttt{line_loop}

--- a/l3kernel/l3fp-aux.dtx
+++ b/l3kernel/l3fp-aux.dtx
@@ -168,7 +168,7 @@
 %
 % Calculations are done in base $10000$, i.e. one myriad.
 %
-% \subsection{Using arguments and semicolons}
+% \subsection{Using arguments and \cs{@@_sep:}s}
 %
 % \begin{macro}[EXP]{\@@_use_none_stop_f:n}
 %   This function removes an argument (typically a digit) and replaces
@@ -180,7 +180,7 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]{\@@_use_s:n, \@@_use_s:nn}
-%   Those functions place a semicolon after one or two arguments
+%   Those functions place a \cs{@@_sep:} after one or two arguments
 %   (typically digits).
 %    \begin{macrocode}
 \cs_new:Npn \@@_use_s:n #1 { #1\@@_sep: }
@@ -191,7 +191,7 @@
 % \begin{macro}[EXP]
 %   {\@@_use_none_until_s:w, \@@_use_i_until_s:nw, \@@_use_ii_until_s:nnw}
 %   Those functions select specific arguments among a set of arguments
-%   delimited by a semicolon.
+%   delimited by a \cs{@@_sep:}.
 %    \begin{macrocode}
 \cs_new:Npn \@@_use_none_until_s:w #1\@@_sep: { }
 \cs_new:Npn \@@_use_i_until_s:nw #1#2\@@_sep: {#1}
@@ -200,7 +200,7 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]{\@@_reverse_args:Nww}
-%   Many internal functions take arguments delimited by semicolons, and
+%   Many internal functions take arguments delimited by \cs{@@_sep:}s, and
 %   it is occasionally useful to swap two such arguments.
 %    \begin{macrocode}
 \cs_new:Npn \@@_reverse_args:Nww #1 #2\@@_sep: #3\@@_sep:
@@ -209,7 +209,7 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]{\@@_rrot:www}
-%   Rotate three arguments delimited by semicolons.  This is the inverse
+%   Rotate three arguments delimited by \cs{@@_sep:}s.  This is the inverse
 %   (or the square) of the Forth primitive |ROT|, hence the name.
 %    \begin{macrocode}
 \cs_new:Npn \@@_rrot:www #1\@@_sep: #2\@@_sep: #3\@@_sep:
@@ -218,7 +218,7 @@
 % \end{macro}
 %
 % \begin{macro}[EXP]{\@@_use_i:ww, \@@_use_i:www}
-%   Many internal functions take arguments delimited by semicolons, and
+%   Many internal functions take arguments delimited by \cs{@@_sep:}s, and
 %   it is occasionally useful to remove one or two such arguments.
 %    \begin{macrocode}
 \cs_new:Npn \@@_use_i:ww #1\@@_sep: #2\@@_sep: { #1\@@_sep: }
@@ -545,7 +545,7 @@
 % \begin{macro}[EXP]{\@@_tuple_count:w, \@@_array_count:n}
 % \begin{macro}[EXP]{\@@_tuple_count_loop:Nw}
 %   Count the number of items in a tuple of floating points by counting
-%   semicolons.  The technique is very similar to \cs{tl_count:n}, but
+%   \cs{@@_sep:}s.  The technique is very similar to \cs{tl_count:n}, but
 %   with the loop built-in.  Checking for the end of the loop is done
 %   with the |\use_none:n #1| construction.
 %    \begin{macrocode}
@@ -759,7 +759,7 @@
 % expect as long as the numbers to multiply are not too big; it
 % also works to some extent with negative results.  The \texttt{pack}
 % function puts the last $4$ of those $9$ digits into a brace group,
-% moves the semi-colon delimiter, and inserts a |+|, which combines the
+% moves the \cs{@@_sep:} delimiter, and inserts a |+|, which combines the
 % carry with the previous computation.  The shifts nicely combine into
 % $5\,0000\,0000 / 10^{4} + 4\,9995\,0000 = 5\,0000\,0000$.  As long as
 % the operands are in some range, the result of this second computation
@@ -845,9 +845,9 @@
 %   \begin{syntax}
 %     \cs{@@_pack_twice_four:wNNNNNNNN} \meta{tokens} \cs{@@_sep:} \meta{$\geq 8$ digits}
 %   \end{syntax}
-%   Grabs two sets of $4$ digits and places them before the semi-colon
+%   Grabs two sets of $4$ digits and places them before the \cs{@@_sep:}
 %   delimiter.  Putting several copies of this function before a
-%   semicolon packs more digits since each takes the digits
+%   \cs{@@_sep:} packs more digits since each takes the digits
 %   packed by the others in its first argument.
 %    \begin{macrocode}
 \cs_new:Npn \@@_pack_twice_four:wNNNNNNNN #1\@@_sep: #2#3#4#5 #6#7#8#9
@@ -859,9 +859,9 @@
 %   \begin{syntax}
 %     \cs{@@_pack_eight:wNNNNNNNN} \meta{tokens} \cs{@@_sep:} \meta{$\geq 8$ digits}
 %   \end{syntax}
-%   Grabs one set of $8$ digits and places them before the semi-colon
+%   Grabs one set of $8$ digits and places them before the \cs{@@_sep:}
 %   delimiter as a single group.  Putting several copies of this
-%   function before a semicolon packs more digits since each
+%   function before a \cs{@@_sep:} packs more digits since each
 %   takes the digits packed by the others in its first argument.
 %    \begin{macrocode}
 \cs_new:Npn \@@_pack_eight:wNNNNNNNN #1\@@_sep: #2#3#4#5 #6#7#8#9
@@ -1056,7 +1056,7 @@
 %   as an alternation of unbraced and braced blocks of $4$ digits,
 %   such that the first $5$ groups of token consist in $4$ single digits,
 %   and one brace group (in some order), and the next $5$ have the same
-%   structure. This is followed by some digits and a semicolon.
+%   structure. This is followed by some digits and a \cs{@@_sep:}.
 %    \begin{macrocode}
 \cs_new:Npn \@@_decimate_pack:nnnnnnnnnnw #1#2#3#4#5
   { \@@_decimate_pack:nnnnnnw { #1#2#3#4#5 } }
@@ -1114,8 +1114,8 @@
 %   This function ends a \TeX{} conditional, removes junk and a floating
 %   point, and places its first argument in the input stream.  A quirk
 %   is that we don't define this function requiring a floating point to
-%   follow, simply anything ending in a semicolon.  This, in turn, means
-%   that the \meta{junk} may not contain semicolons.
+%   follow, simply anything ending in a \cs{@@_sep:}.  This, in turn, means
+%   that the \meta{junk} may not contain \cs{@@_sep:}s.
 %    \begin{macrocode}
 \cs_new:Npn \@@_case_return:nw #1#2 \fi: #3 \@@_sep: { \fi: #1 }
 %    \end{macrocode}

--- a/l3kernel/l3fp-basics.dtx
+++ b/l3kernel/l3fp-basics.dtx
@@ -592,7 +592,7 @@
 %   too close a call to know yet, namely if $1 \meta{Y'_1} \meta{Y'_2} =
 %   \meta{X_1} \meta{X_2} \meta{X_3} \meta{X_4} 0$, then call the
 %   \texttt{quite_far} auxiliary.  We use the odd combination of space
-%   and semi-colon delimiters to allow the \texttt{not_far} auxiliary to
+%   and \cs{@@_sep:} delimiters to allow the \texttt{not_far} auxiliary to
 %   grab each piece individually, the \texttt{very_far} auxiliary to use
 %   \cs{@@_pack_eight:wNNNNNNNN}, and the \texttt{quite_far} to ignore
 %   the significands easily (using the \cs{@@_sep:} delimiter).
@@ -843,7 +843,7 @@
 %       \Arg{X_1} \Arg{X_2} \Arg{X_3} \Arg{X_4} \meta{sign}
 %       \Arg{Y_1} \Arg{Y_2} \Arg{Y_3} \Arg{Y_4}
 %   \end{quote}
-%   Note the three semicolons at the end of the definition.  One is for
+%   Note the three \cs{@@_sep:}s at the end of the definition.  One is for
 %   the last \cs{@@_mul_significand_drop:NNNNNw}; one is for
 %   \cs{@@_round_digit:Nw} later on; and one, preceded by
 %   \cs{exp_after:wN}, which is correctly expanded (within an
@@ -1013,7 +1013,7 @@
 %   \cs{@@_div_significand_i_o:wnnw}, namely an integer \meta{y} obtained
 %   by adding $1$ to the first $5$ digits of $Z$ (explanation given soon
 %   below), then the four \Arg{A_{i}}, then the four \Arg{Z_{i}}, a
-%   semi-colon, and the \meta{final sign}, used for rounding at the end.
+%   \cs{@@_sep:}, and the \meta{final sign}, used for rounding at the end.
 %    \begin{macrocode}
 \cs_new:Npn \@@_div_npos_o:Nww
     #1 \s_@@ \@@_chk:w 1 #2 #3 #4 \@@_sep:

--- a/l3kernel/l3fp-expo.dtx
+++ b/l3kernel/l3fp-expo.dtx
@@ -386,7 +386,7 @@
 %   in $[1,10]$, and \meta{exponent} is
 %   the exponent. Also, the expansion is done backwards. Then
 %   \cs{@@_div_significand_pack:NNN} puts things in the
-%   correct order to add the $Q_{i}$ together and put semicolons
+%   correct order to add the $Q_{i}$ together and put \cs{@@_sep:}s
 %   between each piece. Once those have been expanded, we get
 %   \begin{syntax}
 %     \cs{@@_ln_div_after:Nw} \meta{fixed-tl} \meta{1d} \cs{@@_sep:} \meta{4d} \cs{@@_sep:}
@@ -714,7 +714,7 @@
 %   10^{-1})$.  We compute $10$ terms of the Taylor series.  The
 %   first argument is irrelevant (rounding digit used by some other
 %   functions).  The next three arguments, at least $16$ digits,
-%   delimited by a semicolon, form a fixed point number, so we pack it
+%   delimited by a \cs{@@_sep:}, form a fixed point number, so we pack it
 %   in blocks of $4$ digits.
 %    \begin{macrocode}
 \cs_new:Npn \@@_exp_Taylor:Nnnwn #1#2#3 #4\@@_sep: #5 #6
@@ -834,7 +834,7 @@
 %   The first two arguments are irrelevant (a rounding digit, and a
 %   brace group with $8$ zeros).  The third argument is the integer part
 %   of our number, then we have the decimal part delimited by a
-%   semicolon, and finally the exponent, in the range $[0,5]$.  Remove
+%   \cs{@@_sep:}, and finally the exponent, in the range $[0,5]$.  Remove
 %   leading zeros from the integer part: putting |#4| in there too
 %   ensures that an integer part of $0$ is also removed.  Then read
 %   digits one by one, looking up $\exp(\meta{digit}\cdot
@@ -932,7 +932,7 @@
 %     \cs{@@_pow_normal_o:ww} followed by the two \texttt{fp} $a$ and $b$.
 %     For $a=+0$ or $+\inf$, call \cs{@@_pow_zero_or_inf:ww} instead, to
 %     return either $+0$ or $+\infty$ as appropriate.
-%   \item If $a$ is a \texttt{nan}, then skip to the next semicolon
+%   \item If $a$ is a \texttt{nan}, then skip to the next \cs{@@_sep:}
 %     (which happens to be conveniently the end of $b$) and return
 %     \texttt{nan}.
 %   \item Finally, if $a$ is negative, compute $|a|^b$

--- a/l3kernel/l3fp-extended.dtx
+++ b/l3kernel/l3fp-extended.dtx
@@ -93,7 +93,7 @@
 %   ~~\meta{operand_2} \cs{@@_sep:} \Arg{continuation}
 % \end{syntax}
 % They perform the \meta{calculation} on the two \meta{operands}, then
-% feed the result ($6$ brace groups followed by a semicolon) to the
+% feed the result ($6$ brace groups followed by a \cs{@@_sep:}) to the
 % \meta{continuation}, responsible for the next step of the calculation.
 % Some functions only accept an \texttt{N}-type \meta{continuation}.
 % This allows constructions such as
@@ -264,7 +264,7 @@
 %   last $9999$, giving the integer closest to $10000 + a_{6}/n$.
 %
 %   Each \texttt{pack} auxiliary receives $5$ digits followed by a
-%   semicolon.  The first digit is added as a carry to the integer
+%   \cs{@@_sep:}.  The first digit is added as a carry to the integer
 %   expression above, and the $4$ other digits are braced.  Each call to
 %   the \texttt{pack} auxiliary thus produces one brace group.  The last
 %   brace group is produced by the \texttt{after} auxiliary, which
@@ -624,7 +624,7 @@
 % In this section we manipulate floating point numbers with roughly $24$
 % significant figures (\enquote{extended-precision} numbers, in short,
 % \enquote{ep}), which take the form of an integer exponent, followed by a
-% comma, then six groups of digits, ending with a semicolon.  The first
+% comma, then six groups of digits, ending with a \cs{@@_sep:}.  The first
 % group of digit may be any non-negative integer, while other groups of
 % digits have $4$~digits.  In other words, an extended-precision number
 % is an exponent ending in a comma, then a fixed point number.  The

--- a/l3kernel/l3fp-parse.dtx
+++ b/l3kernel/l3fp-parse.dtx
@@ -642,7 +642,7 @@
 %   \cs{fi:} and removes \cs{@@_parse_expand:w} normally responsible for
 %   expansion.  That turns out to be useful.
 %    \begin{macrocode}
-\cs_new:Npn \@@_parse_return_semicolon:w
+\cs_new:Npn \@@_parse_return_sep:w
     #1 \fi: \@@_parse_expand:w { \fi: \@@_sep: #1 }
 %    \end{macrocode}
 % \end{macro}
@@ -682,7 +682,7 @@
         \if_int_compare:w 9 < 1 \token_to_str:N ##1 \exp_stop_f:
           \token_to_str:N ##1 \exp_after:wN #2 \exp:w
         \else:
-          \@@_parse_return_semicolon:w #3 ##1
+          \@@_parse_return_sep:w #3 ##1
         \fi:
         \@@_parse_expand:w
       }
@@ -1050,7 +1050,7 @@
       \exp:w \exp_after:wN \@@_parse_letters:N
       \exp:w
     \else:
-      \@@_parse_return_semicolon:w #1
+      \@@_parse_return_sep:w #1
     \fi:
     \@@_parse_expand:w
   }
@@ -1464,7 +1464,7 @@
         \exp:w
       \fi:
     \else:
-      \@@_parse_return_semicolon:w 0 #1
+      \@@_parse_return_sep:w 0 #1
     \fi:
     \@@_parse_expand:w
   }
@@ -1475,7 +1475,7 @@
       \exp_after:wN \@@_parse_round_up:N
       \exp:w
     \else:
-      \@@_parse_return_semicolon:w 1 #1
+      \@@_parse_return_sep:w 1 #1
     \fi:
     \@@_parse_expand:w
   }
@@ -1662,7 +1662,7 @@
       \exp_after:wN #1
       \exp:w
     \else:
-      0 \@@_parse_return_semicolon:w #1
+      0 \@@_parse_return_sep:w #1
     \fi:
     \@@_parse_expand:w
   }
@@ -1707,7 +1707,7 @@
       \exp:w
     \else:
       \@@_parse_exponent_keep:NTF #1
-        { \@@_parse_return_semicolon:w #1 }
+        { \@@_parse_return_sep:w #1 }
         {
           \exp_after:wN \@@_sep:
           \exp:w
@@ -1733,7 +1733,7 @@
       \exp_after:wN \@@_parse_exponent_digits:N
       \exp:w
     \else:
-      \@@_parse_return_semicolon:w #1
+      \@@_parse_return_sep:w #1
     \fi:
     \@@_parse_expand:w
   }

--- a/l3kernel/l3fp-parse.dtx
+++ b/l3kernel/l3fp-parse.dtx
@@ -199,7 +199,7 @@
 % second \cs{exp_after:wN} to expand, and to trigger the construction
 % \cs{exp:w}, which expands |\operand:w|, defined to read
 % what follows and make a number out of it, then leave \cs{exp_end:}, the
-% number, and a semicolon in the input stream.  Once |\operand:w| is
+% number, and a \cs{@@_sep:} in the input stream.  Once |\operand:w| is
 % done expanding, we obtain essentially
 % \begin{syntax}
 %   \cs{exp_after:wN} |\add:ww| \cs{int_value:w} 12345 \cs{@@_sep:}
@@ -637,7 +637,7 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}[EXP]{\@@_parse_return_semicolon:w}
+% \begin{macro}[EXP]{\@@_parse_return_sep:w}
 %   This very odd function swaps its position with the following
 %   \cs{fi:} and removes \cs{@@_parse_expand:w} normally responsible for
 %   expansion.  That turns out to be useful.
@@ -1648,7 +1648,7 @@
 %   This function should be called within an \cs{int_value:w}
 %   expansion (or within an integer expression).  It leaves digits of the
 %   exponent behind it in the input stream, and terminates the expansion
-%   with a semicolon.  If there is no~|e| (or~|E|), leave an exponent of~$0$.  If
+%   with a \cs{@@_sep:}.  If there is no~|e| (or~|E|), leave an exponent of~$0$.  If
 %   there is an~|e| or~|E|, expand the next token to run some tests on it.  The
 %   first rough test is that if the character code of~|#1| is greater
 %   than that of~|9| (largest code valid for an exponent, less than any
@@ -1720,7 +1720,7 @@
 %
 % \begin{macro}[rEXP]{\@@_parse_exponent_digits:N}
 %   Read digits one by one, and leave them behind in the input stream.
-%   When finding a non-digit, stop, and insert a semicolon.  Note that
+%   When finding a non-digit, stop, and insert a \cs{@@_sep:}.  Note that
 %   we do not check for overflow of the exponent, hence there can be a
 %   \TeX{} error.  It is mostly harmless, except when parsing
 %   |0e9876543210|, which should be a valid representation of $0$, but

--- a/l3kernel/l3fp-round.dtx
+++ b/l3kernel/l3fp-round.dtx
@@ -269,7 +269,7 @@
 %   \begin{syntax}
 %     \cs{@@_round_s:NNNw} \meta{final sign} \meta{digit} \meta{more digits} \cs{@@_sep:}
 %   \end{syntax}
-%   Similar to \cs{@@_round:NNN}, but with an extra semicolon, this
+%   Similar to \cs{@@_round:NNN}, but with an extra \cs{@@_sep:}, this
 %   function expands to |0\exp_stop_f:|\cs{@@_sep:} if rounding
 %   $\meta{final sign}\meta{digit}.\meta{more digits}$ to an integer
 %   truncates, and to |1\exp_stop_f:|\cs{@@_sep:} otherwise.
@@ -305,7 +305,7 @@
 %   or \cs{@@_int_eval:w} expansion; it may add an extra
 %   \cs{@@_int_eval:w}, which means that the integer or integer
 %   expression should not be ended with a synonym of \tn{relax}, but
-%   with a semi-colon for instance.
+%   with a \cs{@@_sep:} for instance.
 %    \begin{macrocode}
 \cs_new:Npn \@@_round_digit:Nw #1 #2\@@_sep:
   {

--- a/l3kernel/l3fp-trig.dtx
+++ b/l3kernel/l3fp-trig.dtx
@@ -832,8 +832,8 @@
 %   }
 %   First come the first $64$~digits of the fractional part of
 %   $10^{\text{\texttt{\#1}}-16}/(2\pi)$, arranged in $16$~blocks
-%   of~$4$, and ending with a semicolon.  Then a few more digits of the
-%   same fractional part, ending with a semicolon, then $4$~blocks of
+%   of~$4$, and ending with a \cs{@@_sep:}.  Then a few more digits of the
+%   same fractional part, ending with a \cs{@@_sep:}, then $4$~blocks of
 %   $4$~digits holding the significand of the original argument.
 %   Multiply the $16$-digit significand with the $64$-digit fractional
 %   part: the \texttt{auxvi} auxiliary receives the significand
@@ -845,7 +845,7 @@
 %   the last \texttt{middle} shift by the appropriate \texttt{trailing}
 %   shift, then discard the significand and remaining $3$~blocks from
 %   the fractional part, as there are not enough digits to compute any
-%   more step in the ladder.  The last semicolon closes the ladder, and
+%   more step in the ladder.  The last \cs{@@_sep:} closes the ladder, and
 %   we return control to the \texttt{auxvii} auxiliary.
 %    \begin{macrocode}
 \cs_new:Npn \@@_trig_large_auxv:www #1\@@_sep: #2\@@_sep: #3\@@_sep:
@@ -883,7 +883,7 @@
 %     \@@_trig_large_auxxi:w
 %   }
 %   The \texttt{auxvii} auxiliary is followed by $52$~digits and a
-%   semicolon.  We find the octant as the integer part of $8$~times what
+%   \cs{@@_sep:}.  We find the octant as the integer part of $8$~times what
 %   follows, or equivalently as the integer part of $|#1#2#3|/125$, and
 %   add it to the surrounding integer expression for the octant.  We
 %   then compute $8$~times the $52$-digit number, with a minus sign if
@@ -949,7 +949,7 @@
 %   Here we receive a conversion function \cs{@@_ep_to_float_o:wwN} or
 %   \cs{@@_ep_inv_to_float_o:wwN}, a \meta{sign} ($0$ or~$2$), a
 %   (non-negative) \meta{octant} delimited by a dot, a \meta{fixed
-%     point} number delimited by a semicolon, and an extended-precision
+%     point} number delimited by a \cs{@@_sep:}, and an extended-precision
 %   number.  The auxiliary receives:
 %   \begin{itemize}
 %   \item the conversion function~|#1|;
@@ -1300,7 +1300,7 @@
 % \begin{macro}[EXP]{\@@_atan_normal_o:NNnwNnw}
 %   Here we simply reorder the floating point data into a pair of signed
 %   extended-precision numbers, that is, a sign, an exponent ending with
-%   a comma, and a six-block mantissa ending with a semi-colon.  This
+%   a comma, and a six-block mantissa ending with a \cs{@@_sep:}.  This
 %   extended precision is required by other inverse trigonometric
 %   functions, to compute things like $\operatorname{atan}(x,\sqrt{1-x^2})$ without
 %   intermediate rounding errors.
@@ -1422,7 +1422,7 @@
 %   $\frac{1}{2k-1}$, then subtract from it $z^2$ times |#2|.  The loop
 %   stops when $k=0$: then |#2| is $(\operatorname{atan} z)/z$, and there is a need to
 %   clean up all the unnecessary data, end the integer expression
-%   computing the octant with a semicolon, and leave the result~|#2|
+%   computing the octant with a \cs{@@_sep:}, and leave the result~|#2|
 %   afterwards.
 %    \begin{macrocode}
 \cs_new:Npn \@@_atan_Taylor_loop:www #1\@@_sep: #2\@@_sep: #3\@@_sep:

--- a/l3kernel/l3regex.dtx
+++ b/l3kernel/l3regex.dtx
@@ -5408,7 +5408,7 @@
 %   and category from the query. Then unpack the array of active
 %   threads, and clear it by resetting its length
 %   (\texttt{max_thread}). This results in a sequence of
-%   \cs{@@_use_state_and_submatches:w} \meta{state}|,|\meta{submatch-clist}|;| and
+%   \cs{@@_use_state_and_submatches:w} \meta{state}|,|\meta{submatch-clist}\cs{@@_sep:} and
 %   we consider those states one by one in order. As soon as a thread
 %   succeeds, exit the step, and, if there are threads to consider at the
 %   next position, and we have not reached the end of the string,

--- a/l3kernel/l3skip.dtx
+++ b/l3kernel/l3skip.dtx
@@ -1867,8 +1867,8 @@
 \group_end:
 %    \end{macrocode}
 %   The tokens after \cs{@@_to_decimal_aux:w} shall have the following form:
-%   |<number>;<half of delta inverse>;|, where |<number>| represents the
-%   input dimension in |sp| unit.
+%   |<number>|\cs{@@_sep:}|<half of delta inverse>|\cs{@@_sep:}, where
+%   |<number>| represents the input dimension in |sp| unit.
 %   If |<number>| is positive, then |#1| is its leading digit and |#2|
 %   (possibly empty) is all the remaining digits;
 %   If |<number>| is zero, then |#1| is~|0|$_{12}$ and |#2| is empty;
@@ -1914,8 +1914,8 @@
 % \end{macro}
 % \begin{macro}[EXP]{\@@_chk_unit:w}
 %   The tokens after \cs{@@_chk_unit:w} shall have the following form:
-%   |<number2>;{<dimexpr1>}|, where |<number2>| represents |<dimexpr2>| in
-%   |sp| unit.
+%   |<number2>|\cs{@@_sep:}|{<dimexpr1>}|, where |<number2>| represents
+%   |<dimexpr2>| in |sp| unit.
 %   If |#1| is~|0|$_{12}$, the \enquote{unit} |<dimexpr2>| must also be zero.
 %   So we throw out a \enquote{division by zero} error message at this point.
 %   Otherwise, if |#1| is~|-|$_{12}$, we shall negate both |<dimexpr1>| and
@@ -1935,7 +1935,8 @@
 % \end{macro}
 % \begin{macro}[EXP]{\@@_branch_unit:w}
 %   The tokens after \cs{@@_branch_unit:w} shall have the following form:
-%   |<number1>;<number2>;|, where |<number1>| represents |<dimexpr1>| in
+%   |<number1>|\cs{@@_sep:}|<number2>|\cs{@@_sep:}, where |<number1>|
+%   represents |<dimexpr1>| in
 %   |sp| unit (whose sign is taken care of) and |<number2>| represents the
 %   absolute value of |<dimexpr2>| in |sp| unit (which is strictly positive).
 %
@@ -2011,7 +2012,7 @@
 %
 %   After \cs{@@_get_quotient:w} has done its job, either we have the
 %   decimal~|0|, or we have \cs{@@_get_remainder:w} followed by
-%   $q$|;|$\lvert X\rvert$|;|$n$|;<sign of X>;|.
+%   $q$\cs{@@_sep:}$\lvert X\rvert$\cs{@@_sep:}$n$\cs{@@_sep:}|<sign of X>|\cs{@@_sep:}.
 %    \begin{macrocode}
 \cs_new:Npn \@@_get_quotient:w #1#2 \@@_sep: #3 \@@_sep:
   {
@@ -2037,7 +2038,7 @@
 %   \cs{@@_get_remainder:w} does not need to read the sign.
 %   After finding the remainder~$r$, the number~$\lvert X\rvert$ is no longer
 %   needed. We should then have \cs{@@_convert_remainder:w} followed by
-%   $r$|;|$n$|;|$q$|;<sign of X>;|.
+%   $r$\cs{@@_sep:}$n$\cs{@@_sep:}$q$\cs{@@_sep:}|<sign of X>|\cs{@@_sep:}.
 %    \begin{macrocode}
 \cs_new:Npn \@@_get_remainder:w #1 \@@_sep: #2 \@@_sep: #3 \@@_sep:
   {
@@ -2050,7 +2051,7 @@
 % \begin{macro}[EXP]{\@@_convert_remainder:w}
 %   This is trivial. We compute $R'=\lfloor65536r/n+\frac{1}{2}\rfloor$,
 %   then leave \cs{@@_test_candidate:w} followed by
-%   $R'$|;|$r$|;|$n$|;|$q$|;<sign of X>;|.
+%   $R'$\cs{@@_sep:}$r$\cs{@@_sep:}$n$\cs{@@_sep:}$q$\cs{@@_sep:}|<sign of X>|\cs{@@_sep:}.
 %    \begin{macrocode}
 \cs_new:Npn \@@_convert_remainder:w #1 \@@_sep: #2 \@@_sep:
   {
@@ -2068,7 +2069,7 @@
 %   If the result is true, then we've found~$R'$;
 %   otherwise we add one to~$R'$.
 %   After this step, $r$ and~$n$ are no longer needed. We should then have
-%   \cs{@@_parse_decimal:w} followed by $R'$|;|$q$|;<sign of X>;|.
+%   \cs{@@_parse_decimal:w} followed by $R'$\cs{@@_sep:}$q$\cs{@@_sep:}|<sign of X>|\cs{@@_sep:}.
 %    \begin{macrocode}
 \cs_new:Npn \@@_test_candidate:w #1 \@@_sep: #2 \@@_sep: #3 \@@_sep:
   {
@@ -2086,7 +2087,7 @@
 %   result if necessary. These are all done expandably.
 %   If $0<R'/65536<1$, the integer summation is naturally terminated at the
 %   decimal point. If $R'/65536=0$ (or~$1$?), the summation is terminated
-%   at the semicolon. The auxiliary function \cs{@@_parse_decimal_aux:w}
+%   at the \cs{@@_sep:}. The auxiliary function \cs{@@_parse_decimal_aux:w}
 %   takes care of both cases.
 %    \begin{macrocode}
 \cs_new:Npn \@@_parse_decimal:w #1 \@@_sep: #2 \@@_sep: #3 \@@_sep:

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -310,7 +310,7 @@
 %   Counts the number of spaces in the string representation of its
 %   second argument, as well as the number of characters following the
 %   last space in that representation, and feeds the two numbers as
-%   semicolon-delimited arguments to the first argument. When this
+%   \cs{@@_sep:}-delimited arguments to the first argument. When this
 %   function is used, the escape character is printable and non-space.
 %    \begin{macrocode}
 \cs_new:Npe \@@_analysis_cs_space_count:NN #1 #2

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -3832,7 +3832,7 @@
 %   extra brace group avoids an off-by-one shift).  For the braced
 %   version \cs{@@_range_braced:w} sets up
 %   \cs{@@_range_collect_braced:w} which stores items one by one in an
-%   argument after the semicolon. Depending on the first token of the tail,
+%   argument after the \cs{@@_sep:}. Depending on the first token of the tail,
 %   either just move  it (if it is a space) or also decrement the number of
 %   items left to find.  Eventually, the result is a brace group followed by
 %   the rest of the token list, and \cs{tl_head:f} cleans up and gives the


### PR DESCRIPTION
Similar to #1671, this PR replaces not only the ";" characters but also the words "semicolon", "semicolons", "semi-colon" with `\cs{@@_sep:}`, in more dtx files.

An `l3fp` internal function `\@@_parse_return_semicolon:w` is also renamed to `\@@_parse_return_sep:w`.
