### PR TITLE
Update model function for an `\exp_args:...` documentation group

### DIFF
--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -557,7 +557,7 @@
 %     \exp_args:Neee
 %   }
 %   \begin{syntax}
-%     \cs{exp_args:NNoo} \meta{token_1} \meta{token_2} \Arg{token_3} \Arg{tokens}
+%     \cs{exp_args:NNno} \meta{token_1} \meta{token_2} \Arg{token_3} \Arg{tokens}
 %   \end{syntax}
 %   These functions absorb four arguments and expand the second, third
 %   and fourth as detailed by their argument specifier. The first


### PR DESCRIPTION
After 0b063745 (Round out \exp_args:N... lists (closes #<span></span>1731), 2025-04-28), the old model function used in the syntax block, `\exp_args:NNoo` became the 7th (was 4th before that) on the longer list.
https://github.com/latex3/latex3/blob/0933a0fc292a0ed5ed996f7cf922bc3184d3ad89/l3kernel/l3expan.dtx#L511-L519

This PR replaces it with the top one, `\exp_args:NNno`.