### PR TITLE
Register various prefixes

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -224,6 +224,7 @@ postnotes,postnotes,gusbrs,https://github.com/gusbrs/postnotes,https://github.co
 prelim,prelim2e,Marei Peischl,https://github.com/TeXhackse/prelim2e,https://github.com/TeXhackse/prelim2e.git,https://github.com/TeXhackse/prelim2e/issues,2020-11-24,2020-11-24,
 prg,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 primargs,morewrites,Bruno Le Floch,https://github.com/blefloch/latex-morewrites,https://github.com/blefloch/latex-morewrites.git,https://github.com/blefloch/latex-morewrites/issues,2013-03-16,2015-09-22,
+prooftrees,prooftrees,Clea F. Rees,https://codeberg.org/cfr/prooftrees,https://codeberg.org/cfr/prooftrees.git,https://codeberg.org/cfr/prooftrees/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/prooftrees
 prop,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 property,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex2e.git,https://github.com/latex3/latex2e/issues,2021-01-20,2021-03-03,
 pseudo,pseudo,Magnus Lie Hetland,https://github.com/mlhetland/pseudo.sty,https://github.com/mlhetland/pseudo.sty.git,https://github.com/mlhetland/pseudo.sty/issues,2019-06-24,2019-06-24,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -5,6 +5,9 @@ MOdiagram,modiagram,Clemens Niederberger,https://bitbucket.org/cgnieder/modiagra
 UFca,citeall,Ulrike Fischer,,,,2015-04-09,2016-02-26,
 acro,acro,Clemens Niederberger,https://github.com/cgnieder/acro/,https://github.com/cgnieder/acro.git,https://github.com/cgnieder/acro/issues,2013-03-16,2020-04-14,
 affiliations,langsci-affiliations,Felix Kopecky,https://ctan.org/pkg/langsci-affiliations,https://github.com/langsci/langsci-affiliations,https://github.com/langsci/langsci-affiliations/issues,2021-02-18,2021-02-18,
+adforn,adforn,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+adfarrows,adfarrows,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+adfbullets,adfbullets,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 akshar,akshar,Vu Van Dung,https://github.com/joulev/akshar,https://github.com/joulev/akshar.git,https://github.com/joulev/akshar/issues,2020-05-27,2020-05-27,
 algobox,algobox,Julien Rivaud,,,,2018-06-13,2018-06-13,
 alignment,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -236,6 +236,7 @@ reverse,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,htt
 right,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 rivbook,rivbook,Julien Rivaud,,,,2018-06-13,2018-06-14,
 rivmath,rivmath,Julien Rivaud,,,,2018-06-13,2018-06-13,
+romande,romandeadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 rpgicons,rpgicons,Jasper Habicht,https://github.com/jasperhabicht/rpgicons,https://github.com/jasperhabicht/rpgicons/rpgicons.git,https://github.com/jasperhabicht/rpgicons/issues,2024-04-29,2024-04-29,
 sanuml,sanitize-umlaut,Thomas F. Sturm,https://github.com/T-F-S/sanitize-umlaut,https://github.com/T-F-S/sanitize-umlaut.git,https://github.com/T-F-S/sanitize-umlaut/issues,2022-07-19,2022-07-19,
 scaletextbullet,scaletextbullet,Oliver Beery,https://github.com/beeryoliver/scaletextbullet,https://github.com/beeryoliver/scaletextbullet/scaletextbullet.git,https://github.com/beeryoliver/scaletextbullet/issues,2024-11-15,2024-11-15,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -101,6 +101,7 @@ fdulogo,fduthesis,Xiangdong Zeng,https://github.com/stone-zeng/fduthesis,https:/
 fi,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-28,2012-09-28,
 file,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 filehook,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex2e.git,https://github.com/latex3/latex2e/issues,2020-10-01,2021-03-03,
+fillwith,fillwith,Clea F. Rees,https://codeberg.org/cfr/fillwith,https://codeberg.org/cfr/fillwith.git,https://codeberg.org/cfr/fillwith/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/fillwith
 fingering,recorder-fingering,Alan Munn,https://github.com/amunn/recorder-fingering,https://github.com/amunn/recorder-fingering,https://github.com/amunn/recorder-fingering/issues,2023-02-17,2023-02-17,
 flag,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2017-02-13,
 fltr,newlfm,Paul Thomson,,,,2013-01-29,2013-01-29,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -6,8 +6,8 @@ UFca,citeall,Ulrike Fischer,,,,2015-04-09,2016-02-26,
 acro,acro,Clemens Niederberger,https://github.com/cgnieder/acro/,https://github.com/cgnieder/acro.git,https://github.com/cgnieder/acro/issues,2013-03-16,2020-04-14,
 affiliations,langsci-affiliations,Felix Kopecky,https://ctan.org/pkg/langsci-affiliations,https://github.com/langsci/langsci-affiliations,https://github.com/langsci/langsci-affiliations/issues,2021-02-18,2021-02-18,
 adforn,adforn,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
-adfarrows,adfarrows,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
-adfbullets,adfbullets,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+adfarrows,adfsymbols,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+adfbullets,adfsymbols,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 akshar,akshar,Vu Van Dung,https://github.com/joulev/akshar,https://github.com/joulev/akshar.git,https://github.com/joulev/akshar/issues,2020-05-27,2020-05-27,
 algobox,algobox,Julien Rivaud,,,,2018-06-13,2018-06-13,
 alignment,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -43,6 +43,7 @@ chemformula,chemformula,Clemens Niederberger,https://github.com/cgnieder/chemfor
 chemmacros,chemmacros,Clemens Niederberger,https://github.com/cgnieder/chemmacros/,https://github.com/cgnieder/chemmacros.git,https://github.com/cgnieder/chemmacros/issues,2013-03-16,2020-04-14,
 chemnum,chemnum,Clemens Niederberger,https://github.com/cgnieder/chemnum/,https://github.com/cgnieder/chemnum.git,https://github.com/cgnieder/chemnum/issues,2013-03-16,2020-04-14,
 chk,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,Currently internal-only but reserved
+chronos,chronos,Clea F. Rees,https://codeberg.org/cfr/chronos,https://codeberg.org/cfr/chronos.git,https://codeberg.org/cfr/chronos/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/chronos
 circumflex,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 classics,classics,Eduardo C. Lourenço de Lima,,,,2013-03-16,2013-03-16,
 clist,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -75,6 +75,7 @@ dry,dry,Michiel Helvensteijn,,,,2013-01-18,2013-01-18,
 ducksay,ducksay,Jonathan P. Spratte,https://github.com/Skillmon/ltx_ducksay,git@github.com:Skillmon/ltx_ducksay.git,https://github.com/Skillmon/ltx_ducksay/issues,2019-06-07,2019-06-07,
 duckuments,duckuments,Jonathan P. Spratte,https://github.com/Skillmon/ltx_duckuments,git@github.com:Skillmon/ltx_duckuments.git,https://github.com/Skillmon/ltx_duckuments/issues,2019-06-07,2019-06-07,
 e,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
+electrum,electrumadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 else,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-28,2012-09-28,
 emoji,emoji,Xiangdong Zeng,https://github.com/stone-zeng/latex-emoji,https://github.com/stone-zeng/latex-emoji.git,https://github.com/stone-zeng/latex-emoji/issues,2020-03-08,2020-03-08,
 emojicite,emojicite,Leon Sixt,https://github.com/berleon/emojicite,https://github.com/berleon/emojicite.git,https://github.com/berleon/emojicite/issues/,2020-04-14,2020-04-20,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -22,6 +22,7 @@ avm,langsci-avm,Felix Kopecky,https://ctan.org/pkg/langsci-avm,https://github.co
 babellatin,babel-latin,Keno Wehr,https://ctan.org/pkg/babel-latin,https://github.com/wehro/babel-latin,https://github.com/wehro/babel-latin/issues,2021-08-23,2021-08-23,
 backend,l3backend,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2019-06-04,2019-06-04,
 backslash,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
+baskervald,baskervaldadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 bearwear,bearwear,Ulrike Fischer,https://github.com/u-fischer/bearwear,https://github.com/u-fischer/bearwear,https://github.com/u-fischer/bearwear/issues,2020-04-24,2020-04-24,
 beuron,beuron,Keno Wehr,https://ctan.org/pkg/beuron,,,2021-08-23,2021-08-23,
 bitset,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2020-12-26,2020-12-26,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -23,6 +23,7 @@ babellatin,babel-latin,Keno Wehr,https://ctan.org/pkg/babel-latin,https://github
 backend,l3backend,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2019-06-04,2019-06-04,
 backslash,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 baskervald,baskervaldadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+berenis,berenisadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 bearwear,bearwear,Ulrike Fischer,https://github.com/u-fischer/bearwear,https://github.com/u-fischer/bearwear,https://github.com/u-fischer/bearwear/issues,2020-04-24,2020-04-24,
 beuron,beuron,Keno Wehr,https://ctan.org/pkg/beuron,,,2021-08-23,2021-08-23,
 bitset,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2020-12-26,2020-12-26,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -103,6 +103,7 @@ file,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https:
 filehook,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex2e.git,https://github.com/latex3/latex2e/issues,2020-10-01,2021-03-03,
 fillwith,fillwith,Clea F. Rees,https://codeberg.org/cfr/fillwith,https://codeberg.org/cfr/fillwith.git,https://codeberg.org/cfr/fillwith/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/fillwith
 fingering,recorder-fingering,Alan Munn,https://github.com/amunn/recorder-fingering,https://github.com/amunn/recorder-fingering,https://github.com/amunn/recorder-fingering/issues,2023-02-17,2023-02-17,
+fixtounicode,fixtounicode,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 flag,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2017-02-13,
 fltr,newlfm,Paul Thomson,,,,2013-01-29,2013-01-29,
 fmdug,dashundergaps,Frank Mittelbach,https://www.latex-project.org/,https://github.com/FrankMittelbach/fmitex-dashundergaps.git,https://github.com/FrankMittelbach/fmitex-dashundergaps/issues,2018-06-24,2021-10-11,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -79,6 +79,7 @@ enotez,enotez,Clemens Niederberger,https://github.com/cgnieder/enotez/,https://g
 enumext,enumext,Pablo González,https://github.com/pablgonz/enumext,git@github.com:pablgonz/enumext.git,https://github.com/pablgonz/enumext/issues,2024-11-18,2024-11-18,
 etex,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 etl,etl,Jonathan P. Spratte,https://github.com/Skillmon/ltx_etl,git@github.com:Skillmon/ltx_etl.git,https://github.com/Skillmon/ltx_etl/issues,2021-08-16,2021-08-16,
+exfs,nfssext-cfr,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 exp,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 expl,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 expltools,expltools,Vít Starý Novotný,https://github.com/witiko/expltools/,https://github.com/witiko/expltools.git,https://github.com/witiko/expltools/issues,2024-06-26,2024-06-26,Development tools for expl3 programmers

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -298,6 +298,9 @@ use,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https:/
 utex,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2015-07-28,2015-07-28,
 vbox,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 vcoffin,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-28,2012-09-28,
+venturis,venturisadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+venturisii,venturisadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+venturisold,venturisadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 wheelchart,wheelchart,Matthias Floré,,,,2023-12-07,2023-12-07,
 withargs,withargs,Michiel Helvensteijn,,,,2014-02-05,2014-02-05,
 witharrows,witharrows,François Pantigny,,,,2019-12-19,2019-12-19,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -41,6 +41,7 @@ chk,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https:/
 circumflex,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 classics,classics,Eduardo C. Lourenço de Lima,,,,2013-03-16,2013-03-16,
 clist,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
+clm,cfr-lm,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 cmd,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex2e.git,https://github.com/latex3/latex2e/issues,2021-01-20,2021-03-03,
 code,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2021-04-23,2021-04-23,
 codedesc,codedescribe,Alceu Frigeri,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe,https://github.com/alceu-frigeri/codedescribe/issues,2023-05-15,2023-05-15,

--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -151,6 +151,7 @@ kivitendo,"kiviletter, kivitables",Marei Peischl for Kivitendo,https://www.kivit
 knot,spath3,Andrew Stacey,https://github.com/loopspace/spath3,https://github.com/loopspace/spath3.git,https://github.com/loopspace/spath3/issues,2024-07-18,2024-07-18,
 langsci,langscibook,Language Science Press,https://langsci-press.org,https://github.com/langsci/langscibook,https://github.com/langsci/langscibook/issues,2021-07-20,2021-07-21,
 left,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
+libris,libris,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 liftarm,liftarm,Matthias Floré,,,,2024-05-25,2024-05-25,
 lltxmath,lualatex-math,Philipp Stephani,https://github.com/phst/lualatex-math,https://github.com/phst/lualatex-math.git,https://github.com/phst/lualatex-math/issues,2012-11-07,2012-11-07,
 log,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,


### PR DESCRIPTION
Not really sure you want all/any of these.

CTAN packages:
- adforn: adforn
- adfsymbols: adfarrows (for pkg adfarrows), adfbullets (for pkg adfbullets)
- baskervaldadf: baskervald
- berenisadf: berenis
- cfr-lm: clm
- chronos: chronos
- electrumadf: electrum
- fillwith: fillwith
- libris: libris
- nfssext-cfr: exfs (matches the 2e prefix from nfssext used by nfssext-cfr)
- prooftrees: prooftrees
- romandeadf: romande
- venturisadf: venturis (for pkg venturis), venturisii (for pkg venturis2), venturisold (for pkg venturisold)

Public but not yet CTAN:
- fixtounicode: fixtounicode