### PR TITLE
Shorten/standardize tmp var names in docs

### DIFF
--- a/l3kernel/l3seq.dtx
+++ b/l3kernel/l3seq.dtx
@@ -1060,7 +1060,7 @@
 % The code as written here only works if \meta{seq~var_3} is different
 % from the other two sequence variables.  To cover all cases, items
 % should first be collected in a sequence
-% |\l__|\meta{pkg}|_internal_seq|, then \meta{seq~var_3} should be set
+% |\l__|\meta{pkg}|_tmp_seq|, then \meta{seq~var_3} should be set
 % equal to this internal sequence.  The same remark applies to other set
 % functions.
 %
@@ -1094,17 +1094,17 @@
 % The symmetric difference of two sets \meta{seq~var_1} and
 % \meta{seq~var_2} can be stored into \meta{seq~var_3} by computing the
 % difference between \meta{seq~var_1} and \meta{seq~var_2} and storing
-% the result as |\l__|\meta{pkg}|_internal_seq|, then the difference
+% the result as |\l__|\meta{pkg}|_tmp_seq|, then the difference
 % between \meta{seq~var_2} and \meta{seq~var_1}, and finally
 % concatenating the two differences to get the symmetric differences.
 % \begin{quote}\ttfamily\parskip=0pt\obeylines
-%   \cs{seq_set_eq:NN} |\l__|\meta{pkg}|_internal_seq| \meta{seq~var_1}
+%   \cs{seq_set_eq:NN} |\l__|\meta{pkg}|_tmp_seq| \meta{seq~var_1}
 %   \cs{seq_map_inline:Nn} \meta{seq~var_2}
-%   |  |\{ \cs{seq_remove_all:Nn} |\l__|\meta{pkg}|_internal_seq| \{\#1\} \}
+%   |  |\{ \cs{seq_remove_all:Nn} |\l__|\meta{pkg}|_tmp_seq| \{\#1\} \}
 %   \cs{seq_set_eq:NN} \meta{seq~var_3} \meta{seq~var_2}
 %   \cs{seq_map_inline:Nn} \meta{seq~var_1}
 %   |  |\{ \cs{seq_remove_all:Nn} \meta{seq~var_3} \{\#1\} \}
-%   \cs{seq_concat:NNN} \meta{seq~var_3} \meta{seq~var_3} |\l__|\meta{pkg}|_internal_seq|
+%   \cs{seq_concat:NNN} \meta{seq~var_3} \meta{seq~var_3} |\l__|\meta{pkg}|_tmp_seq|
 % \end{quote}
 %
 % \section{Constant and scratch sequences}


### PR DESCRIPTION
Follow-up to f65556b1b (Shorten/standardize tmp var names, 2025-05-16). Full changes https://github.com/latex3/latex3/compare/963a29951d...6fedc63d51.