### PR TITLE
Exclude more files from spelling check

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -8,10 +8,11 @@ extend-exclude = [
   "*.tlg",
   "l3trial/l3htoks/tokens-use-count.txt",
   "LICENSE",
-  "support/texlive.sh",
-  "support/UShyphen.tex",
+  "support/**",
+  "!support/regression-test.cfg",
   "texmf/**",
   # historical dirs and files
+  "*-????-??-??.sty",
   "articles/**",
   "xpackages/**",
   "l3kernel/doc/l3news*.tex",

--- a/support/lualatex.ini
+++ b/support/lualatex.ini
@@ -9,9 +9,9 @@
   \catcode`\}=2 %
   % Set up job name quoting before latex.ltx
   % Web2c pdfTeX/XeTeX quote job names containing spaces, but LuaTeX does
-  % not do this at the engine level. The behavior can be changed using
+  % not do this at the engine level. The behaviour can be changed using
   % a callback. Originally this code was loaded via lualatexquotejobname.tex
-  % but that required a hack around latex.ltx: the behavior has been altered
+  % but that required a hack around latex.ltx: the behaviour has been altered
   % to allow the callback route to be used directly.
   \global\everyjob{\directlua{require("lualatexquotejobname.lua")}}
 \endgroup


### PR DESCRIPTION
Exclude all files in the top-level `./support` dir, except for the `regression-test.cfg`. This reverts two "behaviour" -> "behavior" corrections made to `./support/lualatex.ini`.

Exclude historical package versions like `xtemplate-2023-10-10.sty`.