### PR TITLE
Document restrictions of oklab implementation

### DIFF
--- a/l3kernel/l3color.dtx
+++ b/l3kernel/l3color.dtx
@@ -118,10 +118,16 @@
 %     (\url{https://bottosson.github.io/posts/oklab}), which models human
 %     perception, with three axes, real values in the range $[0,1]$ for
 %     lightness, real values in the range $[0, 0.4]$ for chromacity and real
-%     values in the range $[0, 360]$ for hue.
+%     values in the range $[0, 360]$ for hue\footnote{Be aware, that for now,
+%     this is an input model only. Color blending will not benefit from Oklab
+%     color space. It is advised to only input colors inside the sRGB gamut,
+%     i.e., mapping to $[0,1]^{3}$ in the core \texttt{rgb} model. Other colors
+%     will be crudely clipped to fit inside. Thus, for most hues and
+%     lightnesses, the chroma should actually remain below $0.2$.}
 %   \item \texttt{oklab} Oklab color, with three axes, real values in the range
 %     $[0,1]$ for lightness and real values in the range $[-0.4, 0.4]$ for the
-%     position on the green/red- and yellow/blue-axes.
+%     position on the green/red- and yellow/blue-axes^^A
+%     \addtocounter{footnote}{-1}\addtocounter{Hfootnote}{-1}\footnotemark
 %   \item \texttt{wave} Light wavelength, a real number in the range
 %     $380$ to $780$ (nanometres)
 % \end{itemize}


### PR DESCRIPTION
As noted in https://github.com/latex3/latex3/pull/1500#issuecomment-2896657265, the Oklab implementation does less than some people may assume. Maybe some day someone cares to implement the rest.

Typst, by the way, seems to support all kinds of fuss with color spaces as of [some 2023 blog post](https://typst.app/blog/2023/color-gradients). Some pseudo code for gamut clipping may be found in [CSS Color Module Level 4](https://www.w3.org/TR/css-color-4/#ok-lab) (it has some some weird behavior around sRGB’s primary blue `#0000ff`, but that is mostly harmless).