### PR TITLE
Update `\tl_trim_spaces:n` comment

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -39,7 +39,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Changed
 - Preserve `intarray` variables across multiple dumps (issue \#1597)
-- Adjust`\tl_(g)set_rescan:Nnn` to support LuaMetaTeX
+- Adjust `\tl_(g)set_rescan:Nnn` to support LuaMetaTeX
 
 ### Deprecated
 - `\regex_match:(N|n)n(TF)`

--- a/l3kernel/l3prop.dtx
+++ b/l3kernel/l3prop.dtx
@@ -49,7 +49,7 @@
 %
 % \begin{documentation}
 %
-% \pkg{expl3} implements a \enquote{property list} data type, which contain
+% \pkg{expl3} implements a \enquote{property list} data type, which contains
 % an unordered list of entries each of which consists of a \meta{key} (string)
 % and an associated \meta{value} (token list). The \meta{key} and \meta{value}
 % may both be given as any balanced text, and the \meta{key} is processed using

--- a/l3kernel/l3tl.dtx
+++ b/l3kernel/l3tl.dtx
@@ -3194,10 +3194,9 @@
 %     \tl_gtrim_right_spaces:N, \tl_gtrim_right_spaces:c
 %   }
 %   Trimming spaces from around the input is deferred to an internal
-%   function whose first argument is the token list to trim,
-%   and whose second argument is a
-%   \meta{continuation}, which receives as a braced argument
-%   \cs{@@_trim_mark:} \meta{trimmed token list}.  The control sequence
+%   function whose first argument is a \meta{continuation}, which receives
+%   as a braced argument \cs{@@_trim_mark:} \meta{trimmed token list}, and
+%   whose second argument is the token list to trim.  The control sequence
 %   \cs{@@_trim_mark:} expands to nothing in a single expansion.  In the case
 %   at hand, we take \cs{__kernel_exp_not:w} \cs{exp_after:wN} as our
 %   continuation, so that space trimming behaves correctly within an
@@ -3261,8 +3260,13 @@
 %   a single space as its argument: |#1| is \verb*+ +.
 %   Removing leading spaces is done with \cs{@@_trim_spaces_auxi:w},
 %   which loops until \cs{@@_trim_mark:}\verb*+ + matches the end of the token
-%   list: then |##1| is the token list and |##3| is
-%   \cs{@@_trim_spaces_auxii:w}. This hands the relevant tokens to the
+%   list: then |##1| is
+%   \begin{quote}
+%     \cs{@@_trim_mark:} \meta{left-trimmed token list} \cs{s_@@_nil}
+%     \cs{@@_trim_mark:} \cs{@@_trim_spaces_auxi:w}
+%   \end{quote}
+%   and |##3| is \cs{@@_trim_spaces_auxii:w}.
+%   This hands the relevant tokens to the
 %   loop \cs{@@_trim_spaces_auxiii:w}, responsible for trimming
 %   trailing spaces. The end is reached when \verb*+ +\cs{s_@@_nil}
 %   matches the one present in the definition of \cs{tl_trim_spaces:n}.
@@ -3274,9 +3278,10 @@
 %   Trimming just leading spaces (see \cs{@@_trim_left_spaces:nn}) also
 %   starts with \cs{@@_trim_spaces_auxi:w}, but when it loops until
 %   \cs{@@_trim_mark:}\verb*+ + matches the end of the token list, |##1|
-%   is the token list \emph{but} |##3| is \cs{@@_trim_spaces_auxv:w}.
-%   Like \cs{@@_trim_spaces_auxiv:w}, this directly hands the relevant
-%   tokens to the exit \meta{continuation}.
+%   is the same as in the \cs{@@_trim_spaces:nn} case, \emph{but} |##3|
+%   is \cs{@@_trim_spaces_auxv:w}.
+%   Like \cs{@@_trim_spaces_auxiv:w}, it hands the relevant
+%   tokens to the \meta{continuation}.
 %   Trimming just trailing spaces (see \cs{@@_trim_right_spaces:nn})
 %   starts with the (second) loop \cs{@@_trim_spaces_auxiii:w}.
 %    \begin{macrocode}


### PR DESCRIPTION
To sync with its new, speed-up implementation, see 0fdf1714 (speed up trim spaces (#<span></span>1679), 2025-02-04).