### PR TITLE
Minor doc improvement

### DIFF
--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -459,7 +459,7 @@
 %     \exp_args:Nee
 %   }
 %   \begin{syntax}
-%     \cs{exp_args:Noo} \meta{token} \Arg{tokens_1} \Arg{tokens_2}
+%     \cs{exp_args:Nnc} \meta{token} \Arg{tokens_1} \Arg{tokens_2}
 %   \end{syntax}
 %   These functions absorb three arguments and expand the second and
 %   third as detailed by their argument specifier. The first argument
@@ -577,7 +577,7 @@
 %     \exp_args:Noox,
 %   }
 %   \begin{syntax}
-%     \cs{exp_args:NNnx} \meta{token_1} \meta{token_2} \Arg{tokens_1} \Arg{tokens_2}
+%     \cs{exp_args:NNNx} \meta{token_1} \meta{token_2} \meta{tokens_1} \Arg{tokens_2}
 %   \end{syntax}
 %   These functions absorb four arguments and expand the second, third
 %   and fourth as detailed by their argument specifier. The first
@@ -611,7 +611,7 @@
 %     \exp_last_unbraced:NNNNf,
 %   }
 %   \begin{syntax}
-%     \cs{exp_last_unbraced:Nno} \meta{token} \Arg{tokens_1} \Arg{tokens_2}
+%     \cs{exp_last_unbraced:No} \meta{token} \Arg{tokens_1}
 %   \end{syntax}
 %   These functions absorb the number of arguments given by their
 %   specification, carry out the expansion

--- a/l3kernel/l3text.dtx
+++ b/l3kernel/l3text.dtx
@@ -326,7 +326,7 @@
 %
 % \begin{function}[rEXP, added = 2025-06-22]{\text_map_tokens:nn}
 %   \begin{syntax}
-%     \cs{text_map_tokens:nn} \Arg{text} \meta{code}
+%     \cs{text_map_tokens:nn} \Arg{text} \Arg{code}
 %   \end{syntax}
 %   This takes the user input in \meta{text} and expands it as with
 %   \cs{text_expand:n}; it then maps over the \emph{graphemes} within the
@@ -334,7 +334,7 @@
 %   Broadly a grapheme is a \enquote{user perceived character}:
 %   the Unicode Consortium describe the decomposition of input to
 %   graphemes in depth, and the approach used here implements that
-%   algorithm. The \meta{function} should accept one argument as
+%   algorithm. The \meta{code} should accept one argument as
 %   \meta{balanced text}: this may comprise codepoints or it may be a
 %   control sequence.
 %   With $8$-bit engines, the codepoint(s) themselves may of course be
@@ -386,7 +386,7 @@
 %   See also \cs{text_words_map_inline:nn}.
 % \end{function} 
 %
-% \begin{function}[rEXP, added = 2025-06-22]{\text_words_map_function:nN}
+% \begin{function}[rEXP, added = 2025-06-22]{\text_words_map_tokens:nn}
 %   \begin{syntax}
 %     \cs{text_words_map_tokens:nn} \Arg{text} \Arg{code}
 %   \end{syntax}
@@ -395,7 +395,7 @@
 %   result, passing each word to the \meta{code} as a trailing brace
 %   group. Word boundaries are
 %   determined using the standard algorithm described by the Unicode
-%   Consortium. The \meta{function} should accept one argument as
+%   Consortium. The \meta{code} should accept one argument as
 %   \meta{balanced text}: this may comprise codepoints or it may be a
 %   control sequence. With $8$-bit engines, the codepoint(s) themselves
 %   may of course be made up of multiple bytes: the mapping will pass the


### PR DESCRIPTION
- Update sample syntaxes for `\exp_...` doc groups
- Correct typos for `\text_(words)_map_tokens:nn` docs