### PR TITLE
Update `typos` config

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -1,7 +1,10 @@
 # https://github.com/crate-ci/typos/blob/master/docs/reference.md
 
 [files]
+# list of gitignore patterns
+# https://git-scm.com/docs/gitignore#_pattern_format
 extend-exclude = [
+  ".git",
   "*.csv",
   "*.eps",
   "*.lvt",
@@ -11,14 +14,22 @@ extend-exclude = [
   "support/**",
   "!support/regression-test.cfg",
   "texmf/**",
+  # binary files
+  "*.jpg",
+  "*.png",
+  "*.xlsx",
   # historical dirs and files
   "*-????-??-??.sty",
   "articles/**",
   "xpackages/**",
   "l3kernel/doc/l3news*.tex",
 ]
+# to run on hidden dirs and files
+ignore-hidden = false
 
 [default]
+# list of Rust regex patterns
+# https://docs.rs/regex/latest/regex/index.html#syntax
 extend-ignore-re = [
   "_[aA]lph:",
   "_juxt[_:]", # csnames in l3fp-parse.dtx
@@ -39,6 +50,7 @@ locale = "en-us"
 OT1 = "OT1"
 
 [default.extend-words]
+loosing = "loosing"
 millimetres = "millimetres"
 nanometres = "nanometres"
 nd = "nd"


### PR DESCRIPTION
- Add "loosing" to ignored word list, which was complained by `typos` v1.34.0 (see job log snippet below).
- Extend list of included and excluded files checked by `typos`.
- Add some comments to `typos` config.

```
2025-06-30 15:04:04 (61.2 MB/s) - ‘typos-v1.34.0-x86_64-unknown-linux-musl.tar.gz’ saved [7677712/7677712]

./typos
jq: jq-1.7
$ ./typos . --config .github/typos.toml
Warning: "loosing" should be "losing".
error: `loosing` should be `losing`
  --> ./l3kernel/l3unicode.dtx:489:69
    |
489 | % For integer values, everything is done using token lists to avoid loosing
    |                                                                     ^^^^^^^
    |
```
(full [job log](https://github.com/muzimuzhi/latex3/actions/runs/15976561034/job/45060461881))