### PR TITLE
Support LuaMetaTeX's def. of \meaning

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+- Track LuaMetaTeX changes in `\meaning` output
+
 ## [2025-06-30]
 
 ### Added

--- a/l3kernel/l3.ins
+++ b/l3kernel/l3.ins
@@ -177,6 +177,7 @@ and all files in that bundle must be distributed together.
 \generate{\file{expl3.lua}{
   \from{l3luatex.dtx}{lua}
   \from{l3names.dtx}{lua}
+  \from{l3basics.dtx}{lua}
   \from{l3sys.dtx}{lua}
   \from{l3token.dtx}{lua}
   \from{l3intarray.dtx}{lua}

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -3370,10 +3370,15 @@
 %
 % \subsection{Decomposing a macro definition}
 %
+%    \begin{macrocode}
+%<@@=cs>
+%    \end{macrocode}
+%
 % \begin{macro}{\cs_prefix_spec:N}
 % \begin{macro}{\cs_parameter_spec:N}
 % \begin{macro}{\cs_replacement_spec:N}
 % \begin{macro}{\@@_prefix_arg_replacement:wN}
+% \begin{macro}{\@@_meaning:N}
 %   We sometimes want to test if a control sequence can be expanded to
 %   reveal a hidden value. However, we cannot just expand the macro
 %   blindly as it may have arguments and none might be
@@ -3394,7 +3399,7 @@
     \token_if_macro:NTF #1
       {
         \exp_after:wN \@@_prefix_arg_replacement:wN
-          \token_to_meaning:N #1 \s_@@_stop \use_i:nnn
+          \@@_meaning:N #1 \s_@@_stop \use_i:nnn
       }
       { \scan_stop: }
   }
@@ -3403,7 +3408,7 @@
     \token_if_macro:NTF #1
       {
         \exp_after:wN \@@_prefix_arg_replacement:wN
-          \token_to_meaning:N #1 \s_@@_stop \use_ii:nnn
+          \@@_meaning:N #1 \s_@@_stop \use_ii:nnn
       }
       { \scan_stop: }
   }
@@ -3412,11 +3417,53 @@
     \token_if_macro:NTF #1
       {
         \exp_after:wN \@@_prefix_arg_replacement:wN
-          \token_to_meaning:N #1 \s_@@_stop \use_iii:nnn
+          \@@_meaning:N #1 \s_@@_stop \use_iii:nnn
       }
       { \scan_stop: }
   }
 %    \end{macrocode}
+%   LuaMeta\TeX{}'s version of \tn{meaning} doesn't give the same output
+%   as the classical one. So we abstract out the idea at a low level, as
+%   we need the details to be correct here.
+%    \begin{macrocode}
+\cs_if_exist:NF \@@_meaning:N
+  { \cs_new_eq:NN \@@_meaning:N \cs_meaning:N }
+%</code>
+%    \end{macrocode}
+%   This is a modified version of code suggested by Max Chernoff
+%   (\url{https://chat.stackexchange.com/transcript/message/67947633#67947633}).
+%   We aim to provide the classical \TeX{}82 appearance but covering \eTeX{}:
+%   due to changes in the engine, the only useful prefix here is |\protected|.
+%   This does not cover tokens other than control sequences, so we only use
+%   it for the internal needed here.
+%    \begin{macrocode}
+%<*lua>
+if status.luatex_engine == "luametatex" then
+  luacmd('@@_meaning:N', function()
+    local csname = scan_csname(true)
+    local parameters = get_macro(csname, false, true)
+    local body = get_macro(csname)
+    if parameters == body then
+      -- If parameters and body are the same, we assume that there
+      -- are no parameters. (Probably a LuaMetaTeX bug...)
+      parameters = ""
+    end
+    local cstoken = token_create(csname)
+    local prefixes = {}
+    if token["getprotected"](cstoken) then
+      prefixes[#prefixes + 1] = "\\protected"
+    end
+    local prefix = table_concat(prefixes, " ")
+    if prefix ~= "" then
+      prefix = prefix .. " "
+    end
+    sprint(-2, string.formatters["%smacro:%s->%s"](prefix, parameters, body))
+  end, 'global')
+end
+%</lua>
+%<*code>
+%    \end{macrocode}
+% \end{macro}
 % \end{macro}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -563,11 +563,11 @@ ltxutils.filesize = filesize
 %
 % \begin{macro}[int]{luacmd}
 % An internal function for defining control sequences form Lua which behave
-% like primitives. This acts as a wrapper around |token.set_lua| which accepts
+% like primitives. This acts as a wrapper around |token.setlua| which accepts
 % a function instead of an index into the functions table.
 %    \begin{macrocode}
 local luacmd do
-  local set_lua = token.set_lua
+  local set_lua = token.setlua or token.set_lua
   local undefined_cs = command_id'undefined_cs'
 
   if not context and not luatexbase then require'ltluatex' end
@@ -591,7 +591,7 @@ local luacmd do
     function luacmd(name, func, ...)
       local tok = token_create(name)
       if tok.command == undefined_cs then
-        token.set_lua(name, register(func), ...)
+        set_lua(name, register(func), ...)
       else
         functions[tok.index or tok.mode] = func
       end

--- a/l3kernel/l3luatex.dtx
+++ b/l3kernel/l3luatex.dtx
@@ -336,6 +336,7 @@ local string   = string
 local tex      = tex
 local texio    = texio
 local tonumber = tonumber
+local token    = token
 %    \end{macrocode}
 %
 %   Local copies of standard functions.
@@ -358,11 +359,13 @@ local package_loaded    = package.loaded
 local package_searchers = package.searchers
 local table_concat      = table.concat
 
+local scan_csname  = token.scancsname
 local scan_int     = token.scan_int or token.scan_integer
 local scan_string  = token.scan_string
 local scan_keyword = token.scan_keyword
 local put_next     = token.put_next
 local token_create = token.create
+local get_macro    = token.getmacro
 local token_new    = token.new
 local set_macro    = token.set_macro
 %    \end{macrocode}

--- a/l3kernel/testfiles-context/m3context001.lvt
+++ b/l3kernel/testfiles-context/m3context001.lvt
@@ -7,6 +7,8 @@
 \ExplSyntaxOn
 \cs_new_eq:NN \fpeval \fp_eval:n
 \cs_new_eq:NN \regexreplace \regex_replace_all:nnN
+\cs_new_eq:NN \Prefixes \cs_prefix_spec:N
+\cs_new_protected_nopar:Npn \testcmd { } % Deliberately not \long as that would not show in LuaMetaTeX
 \ExplSyntaxOff
 \starttext
 \START
@@ -16,6 +18,7 @@
     \def\test{text}
     \regexreplace{x}{q}\test
     \TYPE{\test}
+    \TYPE{\Prefixes\testcmd}
 \OMIT
 \stoptext
 

--- a/l3kernel/testfiles-context/m3context001.tlg
+++ b/l3kernel/testfiles-context/m3context001.tlg
@@ -3,3 +3,4 @@ Don't change this file in any respect.
 Hello
 1.414213562373095
 teqt
+\protected 


### PR DESCRIPTION
This is done using an internal function as the Lua emulation doesn't 100% match TeX82's `\meaning`: we need to use `\meaning` for various things, so this is important.