### PR TITLE
Drop `\iow_log:e` and `\iow_term:e` from bootstrapping

### DIFF
--- a/l3kernel/l3.ins
+++ b/l3kernel/l3.ins
@@ -108,7 +108,7 @@ and all files in that bundle must be distributed together.
         \from{l3box.dtx}        {code}
         \from{l3color.dtx}      {code}
         \from{l3graphics.dtx}   {code}
-         \from{l3opacity.dtx}   {code}
+        \from{l3opacity.dtx}    {code}
         \from{l3pdf.dtx}        {code}
         \from{l3coffins.dtx}    {code}
         \from{l3luatex.dtx}     {code}
@@ -149,7 +149,7 @@ and all files in that bundle must be distributed together.
   \file{l3str-enc-iso885916.def} {\from{l3str-convert.dtx}{iso885916}}%
 }
 
-\generate{\file{l3debug.def}      {\from{l3debug.dtx}      {def}}}
+\generate{\file{l3debug.def}      {\from{l3debug.dtx}     {def}}}
 
 \generate{\file{l3docstrip.tex}   {\from{l3docstrip.dtx}  {program}}}
 

--- a/l3kernel/l3basics.dtx
+++ b/l3kernel/l3basics.dtx
@@ -2684,18 +2684,6 @@
 %    \end{macrocode}
 % \end{macro}
 %
-% \begin{macro}[documented-as=\iow_log:n]{\iow_log:e, \iow_term:e}
-%    We define a routine to write only to the log file. And a
-%    similar one for writing to both the log file and the terminal.
-%    These will be redefined later by \pkg{l3file}.
-%    \begin{macrocode}
-\cs_gset_protected:Npn \iow_log:e
-  { \tex_immediate:D \tex_write:D -1 }
-\cs_gset_protected:Npn \iow_term:e
-  { \tex_immediate:D \tex_write:D 16 }
-%    \end{macrocode}
-% \end{macro}
-%
 % \begin{macro}{\__kernel_chk_if_free_cs:N, \__kernel_chk_if_free_cs:c}
 %   This command is called by \cs{cs_new_nopar:Npn} and \cs{cs_new_eq:NN}
 %   etc.\

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -1935,16 +1935,15 @@
 % \begin{macro}{\iow_show:n, \iow_show:e}
 % \begin{macro}{\iow_term:n, \iow_term:e, \iow_term:x}
 %   Writing to the log, the \tn{showstream}, and the terminal directly are
-%   relatively easy; as we need the two \texttt{e}-type variants for
-%   bootstrapping, they are redefined here.
+%   relatively easy.
 %    \begin{macrocode}
 \cs_new_protected:Npn \iow_log:n  { \iow_now:Nn \c_log_iow }
-\cs_set_protected:Npn \iow_log:e  { \iow_now:Ne \c_log_iow }
+\cs_new_protected:Npn \iow_log:e  { \iow_now:Ne \c_log_iow }
 \cs_generate_variant:Nn \iow_log:n { x }
 \cs_new_protected:Npn \iow_show:n  { \iow_now:Nn \tex_showstream:D }
 \cs_new_protected:Npn \iow_show:e  { \iow_now:Ne \tex_showstream:D }
 \cs_new_protected:Npn \iow_term:n { \iow_now:Nn \c_term_iow }
-\cs_set_protected:Npn \iow_term:e { \iow_now:Ne \c_term_iow }
+\cs_new_protected:Npn \iow_term:e { \iow_now:Ne \c_term_iow }
 \cs_generate_variant:Nn \iow_term:n { x }
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -1934,15 +1934,15 @@
 % \begin{macro}{\iow_log:n, \iow_log:e, \iow_log:x}
 % \begin{macro}{\iow_show:n, \iow_show:e}
 % \begin{macro}{\iow_term:n, \iow_term:e, \iow_term:x}
-%   Writing to the log and the terminal directly are relatively easy;
-%   as we need the two \texttt{e}-type variants for bootstrapping,
-%   they are redefinitions here.
+%   Writing to the log, the \tn{showstream}, and the terminal directly are
+%   relatively easy; as we need the two \texttt{e}-type variants for
+%   bootstrapping, they are redefined here.
 %    \begin{macrocode}
 \cs_new_protected:Npn \iow_log:n  { \iow_now:Nn \c_log_iow }
 \cs_set_protected:Npn \iow_log:e  { \iow_now:Ne \c_log_iow }
 \cs_generate_variant:Nn \iow_log:n { x }
 \cs_new_protected:Npn \iow_show:n  { \iow_now:Nn \tex_showstream:D }
-\cs_set_protected:Npn \iow_show:e  { \iow_now:Ne \tex_showstream:D }
+\cs_new_protected:Npn \iow_show:e  { \iow_now:Ne \tex_showstream:D }
 \cs_new_protected:Npn \iow_term:n { \iow_now:Nn \c_term_iow }
 \cs_set_protected:Npn \iow_term:e { \iow_now:Ne \c_term_iow }
 \cs_generate_variant:Nn \iow_term:n { x }


### PR DESCRIPTION
It seems now `\iow_log:e` and `\iow_term:e` are no longer needed in bootstrapping.

Starting from finding the `\iow_show:e` was unnecessarily defined with `\cs_set...` rather than `\cs_new...`, I then was curious about how `\iow_(log|term):e` were used in bootstrapping and finally found they are not needed now.

`\iow_(log|term):x` were added to `l3basics.dtx` by d912fc688d ([Big bang] Complete l3basics: some rearrangements made, 2011-05-09), to support expl3 debugging at that time (`\chk_if_free_cs:N`). As now debugging is extracted to `l3debug.dtx` and the debugging configuration can only be loaded after `expl3-code.tex`, the requirement for having `\iow_(log|term):(e|x)` in bootstrapping had disappeared.