### PR TITLE
L3keys syntax changes

### DIFF
--- a/l3kernel/doc/l3syntax-changes.tex
+++ b/l3kernel/doc/l3syntax-changes.tex
@@ -191,8 +191,8 @@ No change.
 
 \begin{itemize}
   \item Colons (|:|) are no longer allowed in key names in \pkg{l3keys},
-    instead one can use \texttt{:\meta{expansion}} after the key name to
-    control the expansion of the value.
+    instead one can use |:| followed by a single letter expansion specifier
+    after the key name to control the expansion of the value.
 \end{itemize}
 
 \end{document}


### PR DESCRIPTION
The change of |:|-handling in `l3keys` in the 2025-07-20 release warrants an entry in `l3syntax-changes.tex`, imho. This PR adds that.