### PR TITLE
Fix typos

### DIFF
--- a/l3kernel/l3keys.dtx
+++ b/l3kernel/l3keys.dtx
@@ -785,15 +785,15 @@
 % \texttt{N} (again redundant) or \texttt{c}. Thus for example
 % \begin{verbatim}
 %   \keys_define:n { mymodule } { key .code:n = \tl_show:n { "#1" } }
-%   \tl_set:Nn \l_mymodule_value_tl { value }
+%   \tl_set:Nn \l__mymodule_value_tl { value }
 %   \dime_set:Nn \l__mymodule_value_dim { 123pt }
 %   \keys_set:nn { mymodule } { key = value }
-%   \keys_set:nn { mymodule } { key:o = \l_mymodule_value_tl }
-%   \keys_set:nn { mymodule } { key:V = \l_mymodule_value_dim }
+%   \keys_set:nn { mymodule } { key:o = \l__mymodule_value_tl }
+%   \keys_set:nn { mymodule } { key:V = \l__mymodule_value_dim }
 %   \keys_set:nn { mymodule }
 %     {
 %       key:e =
-%         \l_mymodule_value_tl \c_space_tl
+%         \l__mymodule_value_tl \c_space_tl
 %         \dim_use:N \l__mymodule_value_dim
 %     }
 % \end{verbatim}


### PR DESCRIPTION
`\l_mymodule...` and `\l__mymodule...` were mixed. Unify them all to internal names `\l__mymodule...`.