### PR TITLE
fix typo in l3file.dtx

### DIFF
--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -475,7 +475,7 @@
 %   This function writes the given \meta{tokens} immediately to the same
 %   output as used by \tn{show} and \tn{showtokens}. At the start of a \TeX{}
 %   run this will be the terminal, but may be redirected to a file if the
-%   primitive \tn{showsteam} has been set.
+%   primitive \tn{showstream} has been set.
 %   \begin{texnote}
 %     At present, there is no \pkg{expl3} interface to set \tn{showstream}, but
 %     use of the \cs{iow_show:n} function is encouraged in places where direct


### PR DESCRIPTION
`\showsteam` -> `\showstream`