### PR TITLE
Correct a l3doc var name

### DIFF
--- a/l3kernel/l3doc.dtx
+++ b/l3kernel/l3doc.dtx
@@ -2757,7 +2757,7 @@ and all files in that bundle must be distributed together.
       }
       {
         \hbox_set:Nn \l_tmpa_box
-          { \seq_use:Nn \g__@@_variants_seq { \textrm| \nolinebreak[2] } }
+          { \seq_use:Nn \g_@@_variants_seq { \textrm| \nolinebreak[2] } }
         \textrm(
 %    \end{macrocode}
 %


### PR DESCRIPTION
Not really a correction, because DocStrip converts both `_@@` and `__@@` to `__<module>`. Therefore no code behavior is changed.