### PR TITLE
Fix a bug in `\GetDocumentCommandArgSpec`.

### DIFF
--- a/l3packages/xparse/xparse.dtx
+++ b/l3packages/xparse/xparse.dtx
@@ -1429,6 +1429,8 @@
 %   command is optimized: in the latter case, we can reconstruct the
 %   spec.
 %    \begin{macrocode}
+\cs_generate_variant:Nn \cs_prefix_spec:N { c }
+\cs_generate_variant:Nn \str_case:nn { ee }
 \cs_gset_protected:Npn \@@_get_arg_spec:NTF #1#2#3
   {
     \__kernel_cmd_if_xparse:NTF #1
@@ -1445,7 +1447,15 @@
                           { \cs_to_str:N #1 \c_space_tl code }
                       } / 2
                   }
-                  { m }
+                  {
+                    \str_case:ee
+                      { \cs_prefix_spec:c { \cs_to_str:N #1 \c_space_tl code } }
+                      {
+                        { \long } { + }
+                        { \string\protected\long } { + }
+                      }
+                    m
+                  }
               }
               { \tl_item:Nn #1 { 2 } }
           }


### PR DESCRIPTION
Commands with argument specification `+m` were incorrectly reported to have argument specification `m`.  In fact, more generally, commands with an arbitrary number of `+m` arguments were reported to have that number of `m` arguments.

Analysis: all these commands use `\cmd_start_optimized`. `\cmd_get_arg_spec:NTF` (called by `\GetDocumentCommandArgSpec` and friends) explicitly checked for the situation, but then simply returned the appropriate number of `m`s without checking the `\long` status of the command.

Fix: I have added the code prefixing the `m` with a `+` whenever the command is `\long`.

Implementation detail 1: I have used `\str_case:` to check whether `\long` appears in the return value of `\cs_prefix_spec:` because `\str_if_in:` is not expandable.  The method is feasible because `\cs_prefix_spec:` has only three possible return values: `\long `, `\protected\long ` and empty.

Implementation detail 2: the return value of `\cs_prefix_spec:` contains a space at the end, but not between `\protected` and `\long`.  Thus `\string` in front of `\protected`.