### PR TITLE
Consistently use the YYYY-MM-DD format in `l3prefixes.csv`

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -219,7 +219,7 @@ pgf,pgf,The PGF/TikZ Team,https://pgf-tikz.github.io,https://github.com/pgf-tikz
 pgfmxfp,pgfmath-xfp,Jonathan P. Spratte,https://github.com/Skillmon/ltx_pgfmath-xfp,https://github.com/Skillmon/ltx_pgfmath-xfp,https://github.com/Skillmon/ltx_pgfmath-xfp/issues,2021-05-20,2021-05-20,
 phone,phonenumbers,Keno Wehr,https://ctan.org/pkg/phonenumbers,https://github.com/wehro/phonenumbers,https://github.com/wehro/phonenumbers/issues,2021-08-23,2021-08-23,
 pi,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
-piton,piton,François Pantigny,,,,29/09/2022,29/09/2022,
+piton,piton,François Pantigny,,,,2022-09-29,2022-09-29,
 pkgploader,pkgploader,Michiel Helvensteijn,,,,2014-02-05,2014-02-05,
 platex,platex,Japanese TeX Development Community,https://github.com/texjporg/platex,https://github.com/texjporg/platex.git,https://github.com/texjporg/platex/issues,2020-09-30,2020-09-30,
 polyglossia,polyglossia,Arthur Reutenauer,https://www.polyglossia.org/,https://github.com/reutenauer/polyglossia,https://github.com/reutenauer/polyglossia/issues,2019-09-03,,


### PR DESCRIPTION
This PR normalizes the dates in the columns "First registered" and "Last update" of the file `l3prefixes.csv` to the YYYY-MM-DD format. This PR updates just a single row for the package _piton_, which used the format DD/MM/YYYY in these columns before this PR. This improves the ability of external tools, [such as _expltools_][1], to automatically parse this file.

 [1]: https://github.com/Witiko/expltools/blob/91740bdb325860197a2c72479d2b407b2f517d30/explcheck/src/generate-explcheck-latex3.lua#L221-L223