### PR TITLE
Update `typos` config: ignore `1filll`

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -42,6 +42,7 @@ extend-ignore-re = [
   "\\bIEEE Comput\\.",
   "\\bopenin_any\\b",
   "\\bpre-empted\\b",
+  "\\dfilll\\b",
 ]
 
 locale = "en-us"


### PR DESCRIPTION
Although the spelling error appears in the commented line, the pattern "1filll" is worth recording.

https://github.com/latex3/latex3/blob/a9fc524d7a7c66f17bedc05117045ecf7fdb2780/l3kernel/l3doc.dtx#L3632