### PR TITLE
fix casing and add lower case ss to example

### DIFF
--- a/l3kernel/l3str.dtx
+++ b/l3kernel/l3str.dtx
@@ -790,7 +790,7 @@
 %   \end{quote}
 %   The folding approach implemented by \cs{str_casefold:n} follows the
 %   \enquote{full} scheme defined by the Unicode Consortium
-%   (\emph{e.g.}~\SS{} folds to \texttt{SS}). As case-folding is
+%   (\emph{e.g.}~\SS{} and \ss{} both fold to \texttt{ss}). As case-folding is
 %   a language-insensitive process, there is no special treatment of
 %   Turkic input (i.e., \texttt{I} always folds to \texttt{i} and
 %   not to \texttt{\i}).


### PR DESCRIPTION
I noticed that the casing of one of the examples given for `\str_casefold:n` was incorrect. Also, since CM/LM don't support the uppercase `\SS`, I added the lowercase `\ss` to the example as well. Also it might be more surprising that a lowercase ß is folded into `ss`.

Aside: Maybe we should also make the uppercase ẞ appear in the PDF instead of the fallback "SS".