### PR TITLE
\UseInstance's and \UseTemplate's arguments in braces

### DIFF
--- a/l3packages/xtemplate/xtemplate.dtx
+++ b/l3packages/xtemplate/xtemplate.dtx
@@ -2,7 +2,7 @@
 %
 %% File: xtemplate.dtx
 %
-% Copyright (C) 1999 Frank Mittelbach, Chris Rowley, David Carlisle
+% Copyright (C) 1999, 2025 Frank Mittelbach, Chris Rowley, David Carlisle
 %           (C) 2004-2010 Frank Mittelbach, The LaTeX Project
 %           (C) 2011-2025 The LaTeX Project
 %
@@ -477,7 +477,7 @@
 % \begin{function}{\UseInstance}
 %   \begin{syntax}
 %     \cs{UseInstance}
-%     ~~\Arg{object type} \Arg{instance} \meta{arguments}
+%     ~~\Arg{object type} \Arg{instance} \Arg{arguments}
 %   \end{syntax}
 %   Uses an \meta{instance} of the \meta{object type}, which will require
 %   \meta{arguments} as determined by the number specified for the
@@ -488,7 +488,7 @@
 % \begin{function}{\UseTemplate}
 %   \begin{syntax}
 %     \cs{UseTemplate} \Arg{object type} \Arg{template}
-%     ~~\Arg{settings} \meta{arguments}
+%     ~~\Arg{settings} \Arg{arguments}
 %   \end{syntax}
 %   Uses the \meta{template} of the specified \meta{object type},
 %   applying the \meta{settings} and absorbing \meta{arguments} as


### PR DESCRIPTION
AFAICS, `\UseInstance`'s and `\UseTemplate`'s arguments are usually in braces (for instance `\UseInstance{blockenv}{itemize} {#1}` in `latex-lab-testphase-block.sty` or `\UseTemplate { titlepage } { talk } {#1}` in `ltx-talk.cls`).