### PR TITLE
Add first registered date to all prefixes in `l3prefixes.csv`

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -113,7 +113,7 @@ fmwao,widows-and-orphans,Frank Mittelbach,https://www.latex-project.org/,https:/
 fnote,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex2e.git,https://github.com/latex3/latex2e/issues,2023-10-17,2023-10-17,
 fnpct,fnpct,Clemens Niederberger,https://github.com/cgnieder/fnpct/,https://github.com/cgnieder/fnpct.git,https://github.com/cgnieder/fnpct/issues,2013-03-16,2020-04-14,
 fontscale,fontscale,Oliver Beery,https://github.com/beeryoliver/fontscale,https://github.com/beeryoliver/fontscale.git,https://github.com/beeryoliver/fontscale/issues,2024-04-18,2024-04-18,
-fontsizes,fontsizes,Julien Rivaud,,,,,2018-06-13,
+fontsizes,fontsizes,Julien Rivaud,,,,2018-06-13,2018-06-13,
 fontspec,fontspec,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/fontspec.git,https://github.com/latex3/fontspec/issues,2013-03-16,2024-02-15,
 fp,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 fun,functional,Jianrui Lyu,https://github.com/lvjr/functional,https://github.com/lvjr/functional.git,https://github.com/lvjr/functional/issues,2022-04-02,2022-04-02,


### PR DESCRIPTION
This PR ensures that the column "First registered" is specified for all prefixes in the file `l3prefixes.csv`. This PR updates just a single row for the prefix _fontsizes_, which was registered in commit 084d6b4b66715bcbd3f56c8bf18a894777233306 with just the column "Last update" specified and not "First registered".