### PR TITLE
adapt mediabox setting to DocumentMetadata change in LaTeX 2025-11-01

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -7,6 +7,9 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed 
+ - l3pdf.dtx: adapt mediabox setting to LaTeX 2025-11-01
+ 
 ## [2025-10-24]
 
 ### Changed

--- a/l3kernel/l3pdf.dtx
+++ b/l3kernel/l3pdf.dtx
@@ -794,8 +794,8 @@ end,'global')
           {
             { \cs_if_exist_p:N \stockheight }
             { \cs_if_exist_p:N \stockwidth }
-            { \cs_if_exist_p:N \IfDocumentMetadataTF }
-            { \IfDocumentMetadataTF { \c_true_bool } { \c_false_bool } }
+            { \cs_if_exist_p:N \IfPDFManagementActiveTF }
+            { \IfPDFManagementActiveTF { \c_true_bool } { \c_false_bool } }
             { \int_compare_p:nNn \tex_mag:D = { 1000 } }
           }
           {


### PR DESCRIPTION
the build fails because l3prefixes contains errors like 

~~~~
! Infinite glue shrinkage found in box being split.
<argument> Infinite shrink error above ignored ! 
~~~~