### PR TITLE
Cleanup l3prefixes.tex

### DIFF
--- a/l3kernel/doc/l3prefixes.tex
+++ b/l3kernel/doc/l3prefixes.tex
@@ -27,11 +27,13 @@ for those people who are interested.
 \fi
 
 \documentclass{article}
-\usepackage{expl3}
 \usepackage{array}
 \usepackage{booktabs}
 \usepackage{longtable}
 \ExplSyntaxOn
+\tl_new:N \l__prefix_table_tl
+\tl_new:N \l__prefix_tmp_tl
+\ior_new:N \g__prefix_ior
 \cs_new_protected:Npn \__prefix_readi:w #1 " #2 " #3 \q_stop
   {
     \quark_if_nil:nTF {#2}
@@ -42,16 +44,15 @@ for those people who are interested.
   { \__prefix_readiii:nnw {#1} {#3} #2 , \q_stop }
 \cs_new_protected:Npn \__prefix_readiii:nnw #1 #2 #3 , #4 \q_stop
   {
-    \tl_put_right:Nn \l_tmpb_tl { #1 & #3 & #2 \\ }
+    \tl_put_right:Nn \l__prefix_table_tl { #1 & #3 & #2 \\ }
     \tl_if_blank:nF {#4}
-      { \clist_map_inline:nn {#4} { \tl_put_right:Nn \l_tmpb_tl { & ##1 \\ } } }
+      { \clist_map_inline:nn {#4} { \tl_put_right:Nn \l__prefix_table_tl { & ##1 \\ } } }
   }
-\ior_new:N \l_tmpa_ior
-\ior_open:Nn \l_tmpa_ior { l3prefixes.csv }
-\ior_get:NN \l_tmpa_ior \l_tmpa_tl % Throw away
+\ior_open:Nn \g__prefix_ior { l3prefixes.csv }
+\ior_get:NN \g__prefix_ior \l__prefix_tmp_tl % Throw away
 \cs_new_protected:Npn \PrintTable
   {
-    \tl_set:Nn \l_tmpb_tl
+    \tl_set:Nn \l__prefix_table_tl
       {
         \begin { longtable } { @{} *{2}{>{\ttfamily}l} l @{} }
         \toprule
@@ -63,11 +64,11 @@ for those people who are interested.
         \bottomrule
         \endfoot
       }
-    \ior_map_inline:Nn \l_tmpa_ior
+    \ior_map_inline:Nn \g__prefix_ior
       { \__prefix_readi:w ##1 " \q_nil " \q_stop }
-    \tl_put_right:Nn \l_tmpb_tl { \end { longtable } }
-    \tl_replace_all:Nnn \l_tmpb_tl { LaTeX3 } { \LaTeX3 }
-    \tl_use:N \l_tmpb_tl
+    \tl_put_right:Nn \l__prefix_table_tl { \end { longtable } }
+    \tl_replace_all:Nnn \l__prefix_table_tl { LaTeX3 } { \LaTeX3 }
+    \tl_use:N \l__prefix_table_tl
   }
 \ExplSyntaxOff
 \begin{document}


### PR DESCRIPTION
- Fix use of local ior variable.
- Avoid using expl3 scratch variables.
- Drop loading of expl3 package.