### PR TITLE
Remove excess spaces in a l3msg example

### DIFF
--- a/l3kernel/l3msg.dtx
+++ b/l3kernel/l3msg.dtx
@@ -96,7 +96,7 @@
 % of \verb*| |.
 % \begin{verbatim}
 %   \char_set_catcode_space:n { `\ }
-%   \msg_new:nnn { foo } { bar }
+%   \msg_new:nnn {foo} {bar}
 %      {Some message text using '#1' and usual message shorthands \{ \ \ \}.}
 %   \char_set_catcode_ignore:n { `\ }
 % \end{verbatim}


### PR DESCRIPTION
`l3msg` functions don't trim spaces from `⟨module⟩` and `⟨message⟩` arguments.

Found when trying to define `\msg_new:nnn(n)` wrappers which restores catcode of space locally, see https://github.com/T-F-S/tcolorbox/pull/360.