### PR TITLE
Correct doc typos

### DIFF
--- a/l3experimental/l3draw/l3draw.dtx
+++ b/l3experimental/l3draw/l3draw.dtx
@@ -453,7 +453,7 @@
 %   \end{syntax}
 %   Expands to the coordinates of a unit vector in the direction of the
 %   \meta{point} from the origin. If the \meta{point} is at the origin,
-%   a vertical unit vector is returned
+%   a vertical unit vector is returned.
 % \end{function}
 %
 % \begin{function}[EXP]{\draw_point_transform:n}

--- a/l3kernel/l3box.dtx
+++ b/l3kernel/l3box.dtx
@@ -453,7 +453,7 @@
 %   and then stores the result inside the \meta{box}. In contrast
 %   to \cs{hbox_set_to_wd:Nnn} this function does not absorb the argument
 %   when finding the \meta{content}, and so can be used in circumstances
-%   where the \meta{content} may not be a simple argument
+%   where the \meta{content} may not be a simple argument.
 % \end{function}
 %
 % \begin{function}{\hbox_unpack:N, \hbox_unpack:c}
@@ -573,7 +573,7 @@
 %   and then stores the result inside the \meta{box}. In contrast
 %   to \cs{vbox_set_to_ht:Nnn} this function does not absorb the argument
 %   when finding the \meta{content}, and so can be used in circumstances
-%   where the \meta{content} may not be a simple argument
+%   where the \meta{content} may not be a simple argument.
 % \end{function}
 %
 %

--- a/l3kernel/l3file.dtx
+++ b/l3kernel/l3file.dtx
@@ -991,7 +991,7 @@
 %   not found. The branching version runs the \meta{true code} after the
 %   assignment to \meta{tl var} if the file is found, and \meta{false code}
 %   otherwise. The file content will be tokenized using the current
-%   category code régime,
+%   category code régime.
 % \end{function}
 %
 % \begin{function}[updated = 2017-06-26]{\file_input:n, \file_input:V}

--- a/l3kernel/l3tl-analysis.dtx
+++ b/l3kernel/l3tl-analysis.dtx
@@ -400,9 +400,9 @@
 %
 % \begin{macro}{\@@_analysis:n}
 %   Everything is done within a group, and all definitions are
-%   local. We use \cs{group_align_safe_begin/end:} to avoid problems in
-%   case \cs{@@_analysis:n} is used within an alignment and its argument
-%   contains alignment tab tokens.
+%   local. We use \cs[no-index]{group_align_safe_begin/end:} to avoid
+%   problems in case \cs{@@_analysis:n} is used within an alignment and
+%   its argument contains alignment tab tokens.
 %    \begin{macrocode}
 \cs_new_protected:Npn \@@_analysis:n #1
   {


### PR DESCRIPTION
Missing periods were found by
```
rg '[^\s\.}]\n%\s*\\end\{function\}' --multiline -g '*.dtx'
```