### PR TITLE
Register missing l3kernel prefixes

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -4,10 +4,10 @@ GS,gs1,Markus Kohm,,,,2013-03-16,2013-03-16,
 MOdiagram,modiagram,Clemens Niederberger,https://bitbucket.org/cgnieder/modiagram/,git@bitbucket.org:cgnieder/modiagram.git,https://bitbucket.org/cgnieder/modiagram/issues,2013-03-16,2013-03-16,
 UFca,citeall,Ulrike Fischer,,,,2015-04-09,2016-02-26,
 acro,acro,Clemens Niederberger,https://github.com/cgnieder/acro/,https://github.com/cgnieder/acro.git,https://github.com/cgnieder/acro/issues,2013-03-16,2020-04-14,
-affiliations,langsci-affiliations,Felix Kopecky,https://ctan.org/pkg/langsci-affiliations,https://github.com/langsci/langsci-affiliations,https://github.com/langsci/langsci-affiliations/issues,2021-02-18,2021-02-18,
-adforn,adforn,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 adfarrows,adfsymbols,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 adfbullets,adfsymbols,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+adforn,adforn,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+affiliations,langsci-affiliations,Felix Kopecky,https://ctan.org/pkg/langsci-affiliations,https://github.com/langsci/langsci-affiliations,https://github.com/langsci/langsci-affiliations/issues,2021-02-18,2021-02-18,
 akshar,akshar,Vu Van Dung,https://github.com/joulev/akshar,https://github.com/joulev/akshar.git,https://github.com/joulev/akshar/issues,2020-05-27,2020-05-27,
 algobox,algobox,Julien Rivaud,,,,2018-06-13,2018-06-13,
 alignment,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
@@ -25,9 +25,9 @@ babellatin,babel-latin,Keno Wehr,https://ctan.org/pkg/babel-latin,https://github
 backend,l3backend,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2019-06-04,2019-06-04,
 backslash,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 baskervald,baskervaldadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
+bearwear,bearwear,Ulrike Fischer,https://github.com/u-fischer/bearwear,https://github.com/u-fischer/bearwear,https://github.com/u-fischer/bearwear/issues,2020-04-24,2020-04-24,
 benchmark,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2026-01-28,2026-01-28,
 berenis,berenisadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
-bearwear,bearwear,Ulrike Fischer,https://github.com/u-fischer/bearwear,https://github.com/u-fischer/bearwear,https://github.com/u-fischer/bearwear/issues,2020-04-24,2020-04-24,
 beuron,beuron,Keno Wehr,https://ctan.org/pkg/beuron,,,2021-08-23,2021-08-23,
 bitset,l3kernel,The LaTeX3 Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2020-12-26,2020-12-26,
 block,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex2e.git,https://github.com/latex3/latex2e/issues,2023-10-17,2023-10-17,


### PR DESCRIPTION
Changes

- Register l3kernel prefixes "benchmark", "deprecation", "graphics", "legacy", "opacity", and "sys".
- Register l3draw prefix "draw"
- Sort `l3prefixes.csv` lines

Missing prefixes were found by

```shell
for prefix in $(rg -IN '^%<@@=(.*)>' -r '$1' l3kernel l3backend | sort -u); do \
    if ! rg -q "^$prefix" l3kernel/doc/l3prefixes.csv; then \
        echo "$prefix"; \
    fi; \
done
```

