### PR TITLE
Enhance docs for `V`/`v` arg specifiers

### DIFF
--- a/l3kernel/doc/source3body.tex
+++ b/l3kernel/doc/source3body.tex
@@ -223,9 +223,11 @@ following argument specifiers:
     get the content of a variable without needing to worry about the
     underlying \TeX{} structure containing the data. A \texttt{V}
     argument will be a single token (similar to \texttt{N}), for example
-    |\foo:V| |\MyVariable|; on the other hand, using \texttt{v} a
-    csname is constructed first, and then the value is recovered, for
-    example |\foo:v| |{MyVariable}|.
+    |\foo:V| \cs[no-index]{l_my_\meta{type}}; on the other hand, using
+    \texttt{v} a csname is constructed first, and then the value is
+    recovered, for example |\foo:v { l_my_|\meta{type} |}|.
+    Can be applied to variables which have a \cs{\meta{type}_use:N}
+    function (other than boxes and floating points).
   \item[\texttt{o}] This means \emph{expansion once}. In general, the
     \texttt{V} and \texttt{v} specifiers are favored over \texttt{o}
     for recovering stored information. However, \texttt{o} is useful

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -642,22 +642,22 @@
 %     \end{quote}
 %     (Token list variables are expandable and we could omit the
 %     accessor function \cs{tl_use:N}.  Other variable types require the
-%     appropriate \cs{\meta{var}_use:N} functions to be used in this
+%     appropriate \cs{\meta{type}_use:N} functions to be used in this
 %     context.)
 %   \item[V]  Value of a variable.\\
-%     This means that the contents of the register in question is used
+%     This means that the contents of the variable in question is used
 %     as the argument, be it an integer, a length-type register, a token
 %     list variable or similar. The value is passed to the function as a
 %     braced token list.  Can be applied to variables which have a
-%     \cs{\meta{var}_use:N} function (other than boxes),
+%     \cs{\meta{type}_use:N} function (other than boxes and floating points),
 %     and which therefore deliver a single \enquote{value}.
-%   \item[v] Value of a register, constructed from a character string
+%   \item[v] Value of a variable, constructed from a character string
 %     used as a command name.\\
 %     This is a combination of |c| and |V| which first constructs a
 %     control sequence from the argument and then passes the value of
-%     the resulting register to the function.  Can be applied to
-%     variables which have a \cs{\meta{var}_use:N} function (other than
-%     boxes), and which therefore deliver a single
+%     the resulting variable to the function.  Can be applied to
+%     variables which have a \cs{\meta{type}_use:N} function (other than
+%     boxes and floating points), and which therefore deliver a single
 %     \enquote{value}.
 %   \item[e]  Fully-expanded token or braced token list.\\
 %     This means that the argument is expanded as in the replacement


### PR DESCRIPTION
Before (only for changes in `source3body.tex`)

<img width="937" height="145" alt="image" src="https://github.com/user-attachments/assets/f892a96d-c79a-454e-8ffe-2ebccbbce6d8" />

After

<img width="928" height="213" alt="image" src="https://github.com/user-attachments/assets/bfe9bf5d-6387-411a-8fe8-cfdc216a8f70" />

------

Related:
- https://github.com/Witiko/expltools/issues/189