### PR TITLE
Correct metadata for xgalley build.lua

### DIFF
--- a/l3trial/xgalley/build.lua
+++ b/l3trial/xgalley/build.lua
@@ -4,7 +4,7 @@
 
 -- Identify the bundle and module: the module may be empty in the case where
 -- there is no subdivision
-bundle = "l3experimental"
+bundle = "l3trial"
 module = "xgalley"
 
 -- Location of main directory: use Unix-style path separators


### PR DESCRIPTION
Follow-up to 10f484dbe9 (Correct metadata for l3galley/xgalley, 2026-03-30).