### PR TITLE
Update V-type expansion docs

### DIFF
--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -649,16 +649,14 @@
 %     as the argument, be it an integer, a length-type register, a token
 %     list variable or similar. The value is passed to the function as a
 %     braced token list.  Can be applied to variables which have a
-%     \cs{\meta{type}_use:N} function (other than boxes and floating points),
-%     and which therefore deliver a single \enquote{value}.
+%     \cs{\meta{type}_use:N} function (other than boxes and floating points).
 %   \item[v] Value of a variable, constructed from a character string
 %     used as a command name.\\
 %     This is a combination of |c| and |V| which first constructs a
 %     control sequence from the argument and then passes the value of
 %     the resulting variable to the function.  Can be applied to
 %     variables which have a \cs{\meta{type}_use:N} function (other than
-%     boxes and floating points), and which therefore deliver a single
-%     \enquote{value}.
+%     boxes and floating points).
 %   \item[e]  Fully-expanded token or braced token list.\\
 %     This means that the argument is expanded as in the replacement
 %     text of a~\tn{message}, and the expansion is passed to the function as


### PR DESCRIPTION
Bitsets and clists can also be V-expanded but neither of them "deliver a single value".

See
- https://github.com/latex3/latex3/issues/1575