### PR TITLE
Add L3 prefix for qdraw package

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -156,7 +156,7 @@ istqb,istqb,Vít Starý Novotný,https://github.com/istqborg/istqb_product_base/
 iwonamath,iwonamath,Boris Veytsman,https://github.com/borisveytsman/iwonamath,https://github.com/borisveytsman/iwonamath,https://github.com/borisveytsman/iwonamath/issues,2023-09-04,2023-09-04,
 jiazhu,jiazhu,Qing Lee,https://github.com/CTeX-org/ctex-kit,https://github.com/CTeX-org/ctex-kit.git,https://github.com/CTeX-org/ctex-kit/issues,2020-05-17,2020-05-17,
 job,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2021-04-23,2021-04-23,
-jsonparse,jsonparse,Jasper Habicht,https://github.com/jasperhabicht/jsonparse,https://github.com/jasperhabicht/jsonparse/jsponsparse.git,https://github.com/jasperhabicht/jsonparse/issues,2024-04-14,2024-04-14,
+jsonparse,jsonparse,Jasper Habicht,https://github.com/jasperhabicht/jsonparse,https://github.com/jasperhabicht/jsonparse.git,https://github.com/jasperhabicht/jsonparse/issues,2024-04-14,2024-04-14,
 kernel,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 keys,"l3kernel,l3keys2e,ltkeys",The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 keythms,keytheorems,Matthew Bertucci,https://github.com/mbertucci47/keytheorems,https://github.com/mbertucci47/keytheorems,https://github.com/mbertucci47/keytheorems/issues,2024-09-10,2024-09-10,
@@ -167,7 +167,7 @@ knot,spath3,Andrew Stacey,https://github.com/loopspace/spath3,https://github.com
 langsci,langscibook,Language Science Press,https://langsci-press.org,https://github.com/langsci/langscibook,https://github.com/langsci/langscibook/issues,2021-07-20,2021-07-21,
 left,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
 legacy,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2026-01-28,2026-01-28,
-leporello,leporello,Jasper Habicht,https://github.com/jasperhabicht/leporello,https://github.com/jasperhabicht/leporello/leporello.git,https://github.com/jasperhabicht/leporello/issues,2025-07-28,2025-07-28,
+leporello,leporello,Jasper Habicht,https://github.com/jasperhabicht/leporello,https://github.com/jasperhabicht/leporello.git,https://github.com/jasperhabicht/leporello/issues,2025-07-28,2025-07-28,
 libris,libris,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
 liftarm,liftarm,Matthias Floré,,,,2024-05-25,2024-05-25,
 lltxmath,lualatex-math,Philipp Stephani,https://github.com/phst/lualatex-math,https://github.com/phst/lualatex-math.git,https://github.com/phst/lualatex-math/issues,2012-11-07,2012-11-07,
@@ -254,6 +254,7 @@ ptex,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https:
 ptxcd,ptxcd,Marei Peischl,,,,2020-07-27,2020-07-27,Used for specific corporate design templates
 ptxtools,"depp, ptxtools",Marei Peischl,https://gitlab.com/islandoftex/texmf/depp,https://gitlab.com/islandoftex/texmf/depp.git,https://gitlab.com/islandoftex/texmf/depp,2024-07-09,2024-07-09,
 pxpic,pxpic,Jonathan P. Spratte,https://github.com/Skillmon/ltx_pxpic,git@github.com:Skillmon/ltx_pxpic.git,https://github.com/Skillmon/ltx_pxpic/issues,2026-02-07,2026-02-07,
+qdraw,qdraw,Jasper Habicht,https://github.com/jasperhabicht/qdraw,https://github.com/jasperhabicht/qdraw.git,https://github.com/jasperhabicht/qdraw/issues,2026-05-18,2026-05-18,
 qrbill,qrbill,Marei Peischl,https://github.com/peiTeX/qrbill,https://github.com/peiTeX/qrbill.git,https://github.com/peiTeX/qrbill/issues,2020-06-27,2020-06-27,
 quark,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 rainbow,beamertheme-rainbow,samcarter,https://github.com/samcarter/beamertheme-rainbow,https://github.com/samcarter/beamertheme-rainbow,https://github.com/samcarter/beamertheme-rainbow/issues,2023-07-04,2023-07-04,
@@ -267,7 +268,7 @@ right,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https
 rivbook,rivbook,Julien Rivaud,,,,2018-06-13,2018-06-14,
 rivmath,rivmath,Julien Rivaud,,,,2018-06-13,2018-06-13,
 romande,romandeadf,Clea F. Rees,https://codeberg.org/cfr/nfssext,https://codeberg.org/cfr/nfssext.git,https://codeberg.org/cfr/nfssext/issues,2025-05-12,2025-05-12,Mirrored at https://github.com/cfr42/nfssext
-rpgicons,rpgicons,Jasper Habicht,https://github.com/jasperhabicht/rpgicons,https://github.com/jasperhabicht/rpgicons/rpgicons.git,https://github.com/jasperhabicht/rpgicons/issues,2024-04-29,2024-04-29,
+rpgicons,rpgicons,Jasper Habicht,https://github.com/jasperhabicht/rpgicons,https://github.com/jasperhabicht/rpgicons.git,https://github.com/jasperhabicht/rpgicons/issues,2024-04-29,2024-04-29,
 sanuml,sanitize-umlaut,Thomas F. Sturm,https://github.com/T-F-S/sanitize-umlaut,https://github.com/T-F-S/sanitize-umlaut.git,https://github.com/T-F-S/sanitize-umlaut/issues,2022-07-19,2022-07-19,
 sblarticle,sblarticle,David Purton,https://github.com/dcpurton/sbltex,https://github.com/dcpurton/sbltex.git,https://github.com/dcpurton/sbltex/issues,2026-04-06,2026-04-06,
 sblbook,sblbook,David Purton,https://github.com/dcpurton/sbltex,https://github.com/dcpurton/sbltex.git,https://github.com/dcpurton/sbltex/issues,2026-04-06,2026-04-06,


### PR DESCRIPTION
See https://github.com/jasperhabicht/qdraw/

Also fix URLs for jsonparse, leporello, and rpgicons