### PR TITLE
Fix macro typo in `l3fp`

### DIFF
--- a/l3kernel/l3fp-basics.dtx
+++ b/l3kernel/l3fp-basics.dtx
@@ -2177,7 +2177,7 @@
         \int_compare:nNnTF
           { \@@_array_count:n {##1} } = { \@@_array_count:n {##2} }
           { \@@_tuple_mapthread_o:nww { \@@_binary_type_o:Nww #1 } }
-          { \@@_invalid_operation_o:nww #1 }
+          { \@@_invalid_operation_o:Nww #1 }
         \s_@@_tuple \@@_tuple_chk:w {##1} \@@_sep:
         \s_@@_tuple \@@_tuple_chk:w {##2} \@@_sep:
       }


### PR DESCRIPTION
Addresses #1911.