### PR TITLE
Symbolic expr support for built-in variadic functions

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -8,6 +8,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Added
+
+- Symbolic support for variadic functions (issue \#1306)
+
 ### Changed
 
 - Extend docs for `\keys_if_exist:n(TF)` (see issue \#1902)

--- a/l3kernel/l3fp-parse.dtx
+++ b/l3kernel/l3fp-parse.dtx
@@ -1810,7 +1810,17 @@
 %    \begin{macrocode}
 \cs_new:Npn \@@_parse_apply_function:NNNwN #1#2#3#4@#5
   {
-    #3 #2 #4 @
+    \@@_if_has_symbolic:nTF {#4}
+      {
+        \cs_if_eq:NNTF #3 \@@_function_o:w
+          { #3 #2 #4 @ }
+          {
+            \@@_exp_after_symbolic_f:nw { \exp_after:wN \exp_stop_f: }
+              \s_@@_symbolic \@@_symbolic_chk:w
+              \@@_types_variadic:NNw #3 #2 , { #4 } \@@_sep:
+          }
+      }
+      { #3 #2 #4 @ }
     \exp:w \exp_end_continue_f:w #5 #1
   }
 %    \end{macrocode}

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -726,8 +726,7 @@
 %
 % \subsection{Road-map}
 %
-% The following functions are not implemented: |min|, |max|, |?:|,
-% comparisons, |round|, |atan|, |acot|.
+% The following functions are not implemented: |?:|, comparisons.
 %
 %    \begin{macrocode}
 %</code>

--- a/l3kernel/l3fp-symbolic.dtx
+++ b/l3kernel/l3fp-symbolic.dtx
@@ -394,7 +394,8 @@
 %   {
 %     \@@_symbolic_unary_to_tl:NNw,
 %     \@@_symbolic_binary_to_tl:Nww,
-%     \@@_symbolic_function_to_tl:Nw
+%     \@@_symbolic_function_to_tl:Nw,
+%     \@@_symbolic_variadic_to_tl:NNw
 %   }
 %   Converting a symbolic expression to a token list is possible.
 %    \begin{macrocode}
@@ -406,6 +407,7 @@
         { \@@_types_unary:NNw } { \@@_symbolic_unary_to_tl:NNw }
         { \@@_types_binary:Nww } { \@@_symbolic_binary_to_tl:Nww }
         { \@@_function_o:w } { \@@_symbolic_function_to_tl:Nw }
+        { \@@_types_variadic:NNw } { \@@_symbolic_variadic_to_tl:NNw }
       }
       { #2, #3 @ }
       { \tl_to_str:n {#2} }
@@ -433,6 +435,34 @@
       {
         \@@_types_cs_to_op:N #1
         ( \@@_array_to_clist:n {#2} )
+      }
+  }
+\cs_new:Npn \@@_symbolic_variadic_to_tl:NNw #1#2 , #3 @
+  {
+    \use:e
+      {
+        \cs_if_eq:NNTF #1 \@@_minmax_o:Nw
+          { \if_meaning:w 2 #2 max \else: min \fi: }
+          {
+            \cs_if_eq:NNTF #1 \@@_round_o:Nw
+              {
+                \cs_if_eq:NNTF #2 \@@_round_to_nearest:NNN { round }
+                { \cs_if_eq:NNTF #2 \@@_round_to_zero:NNN { trunc }
+                  { \cs_if_eq:NNTF #2 \@@_round_to_ninf:NNN { floor } { ceil } } }
+              }
+              {
+                \cs_if_eq:NNTF #1 \@@_acot_o:Nw
+                  { \if_meaning:w \use_i:nn #2 acot \else: acotd \fi: }
+                  {
+                    \cs_if_eq:NNTF #1 \@@_atan_o:Nw
+                      { \if_meaning:w \use_i:nn #2 atan \else: atand \fi: }
+                      {
+                        \cs_if_eq:NNTF #1 \@@_rand_o:Nw { rand } { randint }
+                      }
+                  }
+              }
+          }
+        ( \@@_array_to_clist:n {#3} )
       }
   }
 %    \end{macrocode}

--- a/l3kernel/l3fp-types.dtx
+++ b/l3kernel/l3fp-types.dtx
@@ -175,6 +175,18 @@
 % \end{macro}
 % \end{macro}
 %
+% \begin{macro}[EXP]{\@@_types_variadic:NNw}
+%   Variadic functions (such as \texttt{min}, \texttt{max}, or \texttt{round})
+%   cannot be easily evaluated when one of the arguments is symbolic.
+%   This macro acts as a placeholder header within the symbolic object, 
+%   preserving the function identifier~|#1|, its modifiers/variants~|#2|, 
+%   and the raw token list of arguments~|#3|.
+%    \begin{macrocode}
+\cs_new:Npn \@@_types_variadic:NNw #1#2#3 @
+  { #1 #2 #3 @ }
+%    \end{macrocode}
+% \end{macro}
+%
 %    \begin{macrocode}
 %</code>
 %    \end{macrocode}

--- a/l3kernel/testfiles/m3fp-symbolic002.lvt
+++ b/l3kernel/testfiles/m3fp-symbolic002.lvt
@@ -11,7 +11,7 @@
 
 \begin{document}
 \START
-\AUTHOR{Yukai Chou}
+\AUTHOR{Yukai Chou, peaR}
 \ExplSyntaxOn
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -31,6 +31,18 @@
     \TYPE { \fp_to_tl:n { \l_tmpa_fp } } % symbolic, B & C evaluated
     \fp_set_function:nnn { A } { i } { sqrt(i * i) }
     \TYPE { \fp_to_tl:n { \l_tmpa_fp } } % numeric
+  }
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+\TEST { Multivariate~functions~in~symbolic~expression }
+  {
+    \fp_new_variable:n { p }
+    \fp_set:Nn \l_tmpa_fp { min(-p, -p/2, 0) }
+    \fp_show:N \l_tmpa_fp
+    \fp_set_function:nnn { A } { x, y, z } { max(x, y, z, 0) }
+    \fp_set:Nn \l_tmpa_fp { A(2, 3, 4) }
+    \fp_show:N \l_tmpa_fp
   }
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%

--- a/l3kernel/testfiles/m3fp-symbolic002.tlg
+++ b/l3kernel/testfiles/m3fp-symbolic002.tlg
@@ -1,6 +1,6 @@
 This is a generated file for the LaTeX (2e + expl3) validation system.
 Don't change this file in any respect.
-Author: Yukai Chou
+Author: Yukai Chou, peaR
 ============================================================
 TEST 1: Functions in symbolic expression
 ============================================================
@@ -30,7 +30,24 @@ Defining \__fp_parse_word_i:N on line ...
 3
 ============================================================
 ============================================================
-TEST 2: Conversions
+TEST 2: Multivariate functions in symbolic expression
+============================================================
+Defining \__fp_parse_word_p:N on line ...
+> \l_tmpa_fp=min(-(p), (-(p))/(2), 0).
+<recently read> }
+l. ...  }
+Defining \__fp_parse_word__i:N on line ...
+Defining \__fp_parse_word_x:N on line ...
+Defining \__fp_parse_word__ii:N on line ...
+Defining \__fp_parse_word_y:N on line ...
+Defining \__fp_parse_word__iii:N on line ...
+Defining \__fp_parse_word_z:N on line ...
+> \l_tmpa_fp=4.
+<recently read> }
+l. ...  }
+============================================================
+============================================================
+TEST 3: Conversions
 ============================================================
 ! Use of \??? doesn't match its definition.
 <argument> \???  
@@ -71,13 +88,13 @@ nan
 (A(1))+((B(1, 2))^(2))
 ============================================================
 ============================================================
-TEST 3: Unary minus and not
+TEST 4: Unary minus and not
 ============================================================
 -((A(1))+((B(1, 2))^(2)))
 !((A(1))+((B(1, 2))^(2)))
 ============================================================
 ============================================================
-TEST 4: Various function names
+TEST 5: Various function names
 ============================================================
 ! LaTeX Error: Floating point identifier '' invalid.
 For immediate help type H <return>.
@@ -122,7 +139,7 @@ Defining \__fp_parse_word_inf:N on line ...
 (((1)/(inf(pi(tmpa(1)))))+(aux(-1)))+(chk(1))
 ============================================================
 ============================================================
-TEST 5: Show a variable holding symbolic expression
+TEST 6: Show a variable holding symbolic expression
 ============================================================
 Defining \__fp_parse_word_x:N on line ...
 Defining \__fp_parse_word_F:N on line ...
@@ -176,7 +193,7 @@ l. ...  }
 l. ...  }
 ============================================================
 ============================================================
-TEST 6: Function parameters are created locally
+TEST 7: Function parameters are created locally
 ============================================================
 Defining \__fp_parse_word_FUNCA:N on line ...
 Defining \__fp_parse_word__i:N on line ...
@@ -195,7 +212,7 @@ Defining \__fp_parse_word_a:N on line ...
 42
 ============================================================
 ============================================================
-TEST 7: Function parameters are cleared locally
+TEST 8: Function parameters are cleared locally
 ============================================================
 Defining \__fp_parse_word_E:N on line ...
 Defining \__fp_parse_word_PS:N on line ...
@@ -205,7 +222,7 @@ Defining \__fp_parse_word__i:N on line ...
 l. ...  }
 ============================================================
 ============================================================
-TEST 8: Set and clear both act locally
+TEST 9: Set and clear both act locally
 ============================================================
 Defining \__fp_parse_word_FUNCP:N on line ...
 ((FUNCP(3, 4))*(10))-(7)
@@ -225,7 +242,7 @@ Defining \__fp_parse_word_j:N on line ...
 ((FUNCP(3, 4))*(10))-(7)
 ============================================================
 ============================================================
-TEST 9: Set needs declaration first
+TEST 10: Set needs declaration first
 ============================================================
 ! LaTeX Error: Floating point identifier 'undefined' is undefined.
 For immediate help type H <return>.


### PR DESCRIPTION
The first of three upcoming PRs to address #1306. This adds symbolic support for various built-in variadic functions as stated in the `l3fp-symbolic` roadmap.