### PR TITLE
Add new L3 prefix entry for hawkdraw and remove qdraw

### DIFF
--- a/l3kernel/doc/l3prefixes.csv
+++ b/l3kernel/doc/l3prefixes.csv
@@ -136,6 +136,7 @@ group,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https
 gtl,gtl,Bruno Le Floch,https://github.com/blefloch/latex-gtl,https://github.com/blefloch/latex-gtl.git,https://github.com/blefloch/latex-gtl/issues,2015-09-22,2015-09-22,
 gzt,gzt,Denis Bitouzé,https://github.com/dbitouze/gzt,git@github.com:dbitouze/gzt.git,,2020-05-13,2020-05-13,
 hash,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2018-05-12,2018-05-12,
+hawkdraw,hawkdraw,Jasper Habicht,https://github.com/jasperhabicht/hawkdraw,https://github.com/jasperhabicht/hawkdraw.git,https://github.com/jasperhabicht/hawkdraw/issues,2026-05-26,2026-05-26,
 hbox,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 hcoffin,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-28,2012-09-28,
 head,latex2e,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex2e.git,https://github.com/latex3/latex2e/issues,2025-06-12,2025-06-12,
@@ -254,7 +255,6 @@ ptex,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https:
 ptxcd,ptxcd,Marei Peischl,,,,2020-07-27,2020-07-27,Used for specific corporate design templates
 ptxtools,"depp, ptxtools",Marei Peischl,https://gitlab.com/islandoftex/texmf/depp,https://gitlab.com/islandoftex/texmf/depp.git,https://gitlab.com/islandoftex/texmf/depp,2024-07-09,2024-07-09,
 pxpic,pxpic,Jonathan P. Spratte,https://github.com/Skillmon/ltx_pxpic,git@github.com:Skillmon/ltx_pxpic.git,https://github.com/Skillmon/ltx_pxpic/issues,2026-02-07,2026-02-07,
-qdraw,qdraw,Jasper Habicht,https://github.com/jasperhabicht/qdraw,https://github.com/jasperhabicht/qdraw.git,https://github.com/jasperhabicht/qdraw/issues,2026-05-18,2026-05-18,
 qrbill,qrbill,Marei Peischl,https://github.com/peiTeX/qrbill,https://github.com/peiTeX/qrbill.git,https://github.com/peiTeX/qrbill/issues,2020-06-27,2020-06-27,
 quark,l3kernel,The LaTeX Project,https://www.latex-project.org/latex3.html,https://github.com/latex3/latex3.git,https://github.com/latex3/latex3/issues,2012-09-27,2012-09-27,
 rainbow,beamertheme-rainbow,samcarter,https://github.com/samcarter/beamertheme-rainbow,https://github.com/samcarter/beamertheme-rainbow,https://github.com/samcarter/beamertheme-rainbow/issues,2023-07-04,2023-07-04,


### PR DESCRIPTION
After CTAN decided not to accept `qdraw` I decided to rename the relevant package to `hawkdraw`. Thus, the prefix also changes. Sorry for the inconvenience!