### PR TITLE
Support comma list input for `\text_declare_<case>_exclusion:n`.

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,7 +10,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Changed
 
-- Support comma list input for `\text_declare_<case>_exclusion:n`
+- Support comma list input for `\text_declare_<case>_exclusion:n` in `l3text`
 
 ## [2026-05-26]
 

--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -8,6 +8,10 @@ this project uses date-based 'snapshot' version identifiers.
 
 ## [Unreleased]
 
+### Changed
+
+- Support comma list input for `\text_declare_<case>_exclusion:n`
+
 ## [2026-05-26]
 
 ### Added

--- a/l3kernel/l3text-case.dtx
+++ b/l3kernel/l3text-case.dtx
@@ -990,7 +990,10 @@
 \cs_new_protected:Npn \text_declare_uppercase_exclusion:n #1
   { \@@_declare_case_exclusion:nn { upper } {#1} }
 \cs_new_protected:Npn \@@_declare_case_exclusion:nn #1#2
-  { \tl_clear_new:c { l_@@_ #1 case_exclude_ \tl_to_str:n {#2} _tl } }
+  {
+    \clist_map_inline:nn {#2}
+      { \tl_clear_new:c { l_@@_ #1 case_exclude_ \tl_to_str:n {##1} _tl } }
+  }
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}

--- a/l3kernel/l3text-case.dtx
+++ b/l3kernel/l3text-case.dtx
@@ -992,7 +992,7 @@
 \cs_new_protected:Npn \@@_declare_case_exclusion:nn #1#2
   {
     \clist_map_inline:nn {#2}
-      { \tl_clear_new:c { l_@@_ #1 case_exclude_ \tl_to_str:n {##1} _tl } }
+      { \tl_clear_new:c { l_@@_ #1 case_exclude_ \tl_to_str:n { ##1 } _tl } }
   }
 %    \end{macrocode}
 % \end{macro}

--- a/l3kernel/l3text.dtx
+++ b/l3kernel/l3text.dtx
@@ -229,17 +229,17 @@
 %   locale.
 % \end{function}
 %
-% \begin{function}[added = 2025-06-24]
+% \begin{function}[added = 2025-06-24, updated = 2026-05-27]
 %   {
 %     \text_declare_lowercase_exclusion:n ,
 %     \text_declare_titlecase_exclusion:n ,
 %     \text_declare_uppercase_exclusion:n
 %   }
 %   \begin{syntax}
-%     \cs{text_declare_lowercase_exclusion:n} \Arg{word}
+%     \cs{text_declare_lowercase_exclusion:n} \Arg{words}
 %   \end{syntax}
-%   Declares that the \meta{word} is excluded from case changing for the
-%   appropriate operation.
+%   Declares that the \meta{words} (a comma list) are excluded from case
+%   changing for the appropriate operation.
 % \end{function}
 %
 % \begin{function}[EXP, added = 2022-07-04]{\text_case_switch:nnnn}

--- a/l3kernel/testfiles/m3text008.luatex.tlg
+++ b/l3kernel/testfiles/m3text008.luatex.tlg
@@ -1,0 +1,18 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Mingyu Hsia
+============================================================
+TEST 1: Text Lower Case Changing Exclusion by Comma List
+============================================================
+take one, AND two, OR three, BUT not four, AS five is out, FOR six is cold, SO seven is YET TO come.
+============================================================
+============================================================
+TEST 2: Text Title Case Changing Exclusion by Comma List
+============================================================
+Take One, and Two, or Three, but Not Four, as Five Is Out, for Six Is Cold, so Seven Is yet to Come.
+============================================================
+============================================================
+TEST 3: Text Upper Case Changing Exclusion by Comma List
+============================================================
+TAKE ONE, and TWO, or THREE, but NOT FOUR, as FIVE IS OUT, for SIX IS COLD, so SEVEN IS yet to COME.
+============================================================

--- a/l3kernel/testfiles/m3text008.lvt
+++ b/l3kernel/testfiles/m3text008.lvt
@@ -1,0 +1,46 @@
+%
+% Copyright (C) The LaTeX Project
+%
+\input regression-test.tex
+
+\documentclass{minimal}
+
+\START
+\AUTHOR{Mingyu Hsia}
+
+\ExplSyntaxOn
+
+\OMIT
+  \text_declare_lowercase_exclusion:n { AND, OR, BUT, AS, FOR, SO, YET, TO }
+  \text_declare_titlecase_exclusion:n { and, or, but, as, for, so, yet, to }
+  \text_declare_uppercase_exclusion:n { and, or, but, as, for, so, yet, to }
+\TIMO
+
+\TESTEXP { Text ~ Lower ~ Case ~ Changing ~ Exclusion ~ by ~ Comma ~ List }
+  {
+    \text_lowercase:n
+      {
+        Take ~ one, ~ AND ~ two, ~ OR ~ three, ~ BUT ~ not ~ four, ~ AS ~ five ~
+        is ~ out, ~ FOR ~ six ~ is ~ cold, ~ SO ~ seven ~ is ~ YET ~ TO ~ come.
+      }
+  }
+
+\TESTEXP { Text ~ Title ~ Case ~ Changing ~ Exclusion ~ by ~ Comma ~ List }
+  {
+    \text_titlecase_all:n
+      {
+        Take ~ one, ~ and ~ two, ~ or ~ three, ~ but ~ not ~ four, ~ as ~ five ~
+        is ~ out, ~ for ~ six ~ is ~ cold, ~ so ~ seven ~ is ~ yet ~ to ~ come.
+      }
+  }
+
+\TESTEXP { Text ~ Upper ~ Case ~ Changing ~ Exclusion ~ by ~ Comma ~ List }
+  {
+    \text_uppercase:n
+      {
+        Take ~ one, ~ and ~ two, ~ or ~ three, ~ but ~ not ~ four, ~ as ~ five ~
+        is ~ out, ~ for ~ six ~ is ~ cold, ~ so ~ seven ~ is ~ yet ~ to ~ come.
+      }
+  }
+
+\END

--- a/l3kernel/testfiles/m3text008.tlg
+++ b/l3kernel/testfiles/m3text008.tlg
@@ -1,0 +1,18 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Mingyu Hsia
+============================================================
+TEST 1: Text Lower Case Changing Exclusion by Comma List
+============================================================
+take one, AND two, OR three, BUT not four, AS five is out, FOR six is cold, SO seven is YET TO come.
+============================================================
+============================================================
+TEST 2: Text Title Case Changing Exclusion by Comma List
+============================================================
+Take One, and Two, or Three, but Not Four, as Five Is Out, for Six Is Cold, so Seven Is yet to Come.
+============================================================
+============================================================
+TEST 3: Text Upper Case Changing Exclusion by Comma List
+============================================================
+TAKE ONE, and TWO, or THREE, but NOT FOUR, as FIVE IS OUT, for SIX IS COLD, so SEVEN IS yet to COME.
+============================================================

--- a/l3kernel/testfiles/m3text008.uptex.tlg
+++ b/l3kernel/testfiles/m3text008.uptex.tlg
@@ -1,0 +1,18 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Mingyu Hsia
+============================================================
+TEST 1: Text Lower Case Changing Exclusion by Comma List
+============================================================
+take one, AND two, OR three, BUT not four, AS five is out, FOR six is cold, SO seven is YET TO come.
+============================================================
+============================================================
+TEST 2: Text Title Case Changing Exclusion by Comma List
+============================================================
+Take One, and Two, or Three, but Not Four, as Five Is Out, for Six Is Cold, so Seven Is yet to Come.
+============================================================
+============================================================
+TEST 3: Text Upper Case Changing Exclusion by Comma List
+============================================================
+TAKE ONE, and TWO, or THREE, but NOT FOUR, as FIVE IS OUT, for SIX IS COLD, so SEVEN IS yet to COME.
+============================================================

--- a/l3kernel/testfiles/m3text008.xetex.tlg
+++ b/l3kernel/testfiles/m3text008.xetex.tlg
@@ -1,0 +1,18 @@
+This is a generated file for the LaTeX (2e + expl3) validation system.
+Don't change this file in any respect.
+Author: Mingyu Hsia
+============================================================
+TEST 1: Text Lower Case Changing Exclusion by Comma List
+============================================================
+take one, AND two, OR three, BUT not four, AS five is out, FOR six is cold, SO seven is YET TO come.
+============================================================
+============================================================
+TEST 2: Text Title Case Changing Exclusion by Comma List
+============================================================
+Take One, and Two, or Three, but Not Four, as Five Is Out, for Six Is Cold, so Seven Is yet to Come.
+============================================================
+============================================================
+TEST 3: Text Upper Case Changing Exclusion by Comma List
+============================================================
+TAKE ONE, and TWO, or THREE, but NOT FOUR, as FIVE IS OUT, for SIX IS COLD, so SEVEN IS yet to COME.
+============================================================


### PR DESCRIPTION
Now one can input the excluded list like `\text_declare_titlecase_exclusion:n { and, for, to, of, }` :-)