### PR TITLE
Clean up unused l3draw message and variables

### DIFF
--- a/l3experimental/l3draw/l3draw-layers.dtx
+++ b/l3experimental/l3draw/l3draw-layers.dtx
@@ -206,8 +206,6 @@
 \msg_new:nnnn { draw } { main-layer }
   { Material~cannot~be~added~to~'main'~layer. }
   { The~main~layer~may~only~be~accessed~at~the~top~level. }
-\msg_new:nnn { draw } { main-reserved }
-  { The~'main'~layer~is~reserved. }
 \msg_new:nnnn { draw } { unknown-layer }
   { Layer~'#1'~has~not~been~created. }
   { You~have~tried~to~use~layer~'#1',~but~it~was~never~set~up. }

--- a/l3experimental/l3draw/l3draw-scopes.dtx
+++ b/l3experimental/l3draw/l3draw-scopes.dtx
@@ -285,14 +285,10 @@
 % \subsection{Scopes}
 %
 % \begin{variable}{\l_@@_linewidth_dim}
-% \begin{variable}{\l_@@_fill_color_tl, \l_@@_stroke_color_tl}
 %   Storage for local variables.
 %    \begin{macrocode}
 \dim_new:N \l_@@_linewidth_dim
-\tl_new:N \l_@@_fill_color_tl
-\tl_new:N \l_@@_stroke_color_tl
 %    \end{macrocode}
-% \end{variable}
 % \end{variable}
 %
 % \begin{macro}{\draw_scope_begin:, \draw_scope_begin:}


### PR DESCRIPTION
The only use of the message `main-reserved` was removed in
bbd5432d (Automatically manage layer creation in drawings, 2026-05-20).

The variables `\l__draw_(fill|stroke)_color_tl` were introduced in
c2cf368e (Save/restore drawing color with scope, 2018-02-26)
then shortly deprecated in
9c2db40e (Tidy up some forgotten data structures, 2018-03-02).