### PR TITLE
\tex_undefine:D to \tex_undefined:D

### DIFF
--- a/l3kernel/l3fp-functions.dtx
+++ b/l3kernel/l3fp-functions.dtx
@@ -272,7 +272,7 @@
     \@@_id_if_invalid:nTF {#1}
       { \msg_error:nnn { fp } { id-invalid } {#1} }
       {
-        \cs_set_eq:cN { @@_#1_o:w } \tex_undefine:D
+        \cs_set_eq:cN { @@_#1_o:w } \tex_undefined:D
         \@@_function_set_parsing:Nn \cs_set_eq:NN {#1} 
       }
   }


### PR DESCRIPTION
It seems a typo to me. It's `\tex_undefined:D` everywhere else.