### PR TITLE
Misc updates for (basic) HiTeX support

### DIFF
--- a/l3kernel/CHANGELOG.md
+++ b/l3kernel/CHANGELOG.md
@@ -10,6 +10,7 @@ this project uses date-based 'snapshot' version identifiers.
 
 ### Added
 
+- Basic HiTeX support: names for new primitives, engine and format detections
 - `\sys_if_engine_hitex:(TF)`
 - `\sys_if_engine_unicode:(TF)`
 - `\sys_if_output_hnt:(TF)`

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -149,9 +149,9 @@
 %   \end{texnote}
 % \end{function}
 %
-% \begin{variable}[added = 2015-09-19]{\c_sys_engine_str}
+% \begin{variable}[added = 2015-09-19, updated = 2026-07-21]{\c_sys_engine_str}
 %   The current engine given as a lower case string: one of
-%   |luatex|, |pdftex|, |ptex|, |uptex| or |xetex|.
+%   |hitex|, |luatex|, |pdftex|, |ptex|, |uptex| or |xetex|.
 % \end{variable}
 %
 % \begin{variable}[added = 2020-08-20, updated = 2026-07-21]{\c_sys_engine_exec_str}

--- a/l3kernel/l3sys.dtx
+++ b/l3kernel/l3sys.dtx
@@ -160,10 +160,10 @@
 %   |luahbtex|, |pdftex|, |eptex|, |euptex| or |xetex|.
 % \end{variable}
 %
-% \begin{variable}[added = 2020-08-20]{\c_sys_engine_format_str}
+% \begin{variable}[added = 2020-08-20, updated = 2026-07-22]{\c_sys_engine_format_str}
 %   The name of the preloaded format for the current \TeX{} run given
 %   as a lower case string: one of
-%   |lualatex| (or |dvilualatex|),
+%   |hilatex|, |lualatex| (or |dvilualatex|),
 %   |pdflatex| (or |latex|), |platex|, |uplatex| or |xelatex| for \LaTeX{},
 %   similar names for plain \TeX{} (except \pdfTeX{} in DVI mode yields
 %   |etex|), and |cont-en| for Con\TeX{}t (i.e., the
@@ -619,6 +619,7 @@
           { \str_if_eq_p:Vn \fmtname { plain } }
           { \str_if_eq_p:Vn \fmtname { LaTeX2e } }
           {
+            \sys_if_engine_hitex:T  { hi }
             \sys_if_engine_pdftex:T
               { \int_compare:nNnT { \tex_pdfoutput:D } = { 1 } { pdf } }
             \sys_if_engine_xetex:T  { xe }


### PR DESCRIPTION
Follow-up to #1944

- Update `\c_sys_engine_str` doc
- Extend `\c_sys_engine_format_str`
- Add a general Changelog entry

TODO: Extend `\c_sys_engine_version_str` once the new primitive `\HiTeXversion` ([texlive r79737](https://svn.tug.org:8369/texlive?revision=79737&view=revision)) is available.