### PR TITLE
Avoid "(guessed encoding ...)" euptex stderr

### DIFF
--- a/l3kernel/config-ptex.lua
+++ b/l3kernel/config-ptex.lua
@@ -1,6 +1,11 @@
 checkengines = {"ptex"}
 -- Make sure that any .tlg files are engine-specific
 stdengine = "pdftex"
+
+-- avoid "(guessed encoding #5: ASCII = utf8)" euptex stderr
+specialformats.latex.ptex.options =
+  specialformats.latex.ptex.options .. " -no-guess-input-enc"
+
 includetests =
   {
     "m3box001",


### PR DESCRIPTION
When checking tests using `ptex` engine, the terminal is flushed with `(guessed encoding #3: ASCII = utf8)` stderr given by `euptex`.

This PR adds `-no-guess-input-enc` `euptex` option to avoid such outputs.

Not sure if it should be added to `l3build` defaults, so I first open a PR here. The `l3build` defaults for `ptex` engine is:
```lua
specialformats.latex.ptex = specialformats.latex.ptex or
   {binary = "euptex", options = "-kanji-internal=euc"}
```

Before

```
$ cd /path/to/latex3-repo
$ cd l3kernel
$ l3build check -cconfig-ptex -eptex
Creating/installing dev-version in latex-dev
Building format for ptex
Running checks on
  m3box001 (1/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3char001 (2/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3coffins001 (3/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3int002 (4/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3ior001 (5/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #7: ASCII = utf8)  m3iow001 (6/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #8: ASCII = utf8)(guessed encoding #6: ASCII = utf8)  m3pdf001 (7/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3sort001 (8/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3str-convert005 (9/13)
(guessed encoding #3: UTF-8 = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3str002 (10/13)
(guessed encoding #3: UTF-8 = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3text002 (11/13)
(guessed encoding #3: UTF-8 = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3text003 (12/13)
(guessed encoding #3: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)  m3text005 (13/13)
(guessed encoding #3: UTF-8 = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #6: ASCII = utf8)(guessed encoding #7: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)(guessed encoding #5: ASCII = utf8)
  All checks passed
```

(On GitHub Actions, stderr is buffered and only shown at the every end of the "Run l3build" step.)

After

```
$ l3build check -cconfig-ptex -eptex
Creating/installing dev-version in latex-dev
Building format for ptex
Running checks on
  m3box001 (1/13)
  m3char001 (2/13)
  m3coffins001 (3/13)
  m3int002 (4/13)
  m3ior001 (5/13)
  m3iow001 (6/13)
  m3pdf001 (7/13)
  m3sort001 (8/13)
  m3str-convert005 (9/13)
  m3str002 (10/13)
  m3text002 (11/13)
  m3text003 (12/13)
  m3text005 (13/13)

  All checks passed
```