### PR TITLE
Fix documentation typo in l3draw.dtx

### DIFF
--- a/l3experimental/l3draw/l3draw.dtx
+++ b/l3experimental/l3draw/l3draw.dtx
@@ -683,7 +683,7 @@
 %     \item \texttt{stroke} Draws a line along the current path
 %     \item \texttt{draw} A synonym for \texttt{stroke}
 %     \item \texttt{fill} Fills the interior of the path with the current
-%       file color
+%       fill color
 %     \item \texttt{clip} Clips any content outside of the path
 %   \end{itemize}
 %   Actions are applied in the order given irrespective of the input order.


### PR DESCRIPTION
Corrected the term 'current file color' to 'current fill color' in documentation.