### PR TITLE
Fix function variant names in expl3.dtx

### DIFF
--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -800,13 +800,13 @@
 % \end{verbatim}
 %
 % Another example: you may wish to declare a function
-% |\demo_cmd_b:ecece|, a variant of an existing function
-% |\demo_cmd_b:nNnNn|, that fully
-% expands arguments 1,~3 and~5, and produces commands to pass as
-% arguments 2 and~4 using~\tn{csname}.
+% |\demo_cmd_b:cnne|, a variant of an existing function
+% |\demo_cmd_b:Nnnn|, that fully
+% expands argument 4, and produces commands to pass as
+% argument 1 using~\tn{csname}.
 % The definition you need is simply
 % \begin{verbatim}
-%   \cs_generate_variant:Nn \demo_cmd_b:nNnNn { ecece }
+%   \cs_generate_variant:Nn \demo_cmd_b:Nnnn { cnne }
 % \end{verbatim}
 %
 % This extension mechanism is written so that if the same new form of

--- a/l3kernel/expl3.dtx
+++ b/l3kernel/expl3.dtx
@@ -800,13 +800,13 @@
 % \end{verbatim}
 %
 % Another example: you may wish to declare a function
-% |\demo_cmd_b:enene|, a variant of an existing function
-% |\demo_cmd_b:nnnnn|, that fully
+% |\demo_cmd_b:ecece|, a variant of an existing function
+% |\demo_cmd_b:nNnNn|, that fully
 % expands arguments 1,~3 and~5, and produces commands to pass as
 % arguments 2 and~4 using~\tn{csname}.
 % The definition you need is simply
 % \begin{verbatim}
-%   \cs_generate_variant:Nn \demo_cmd_b:nnnnn { enene }
+%   \cs_generate_variant:Nn \demo_cmd_b:nNnNn { ecece }
 % \end{verbatim}
 %
 % This extension mechanism is written so that if the same new form of


### PR DESCRIPTION
The example describes arguments 2 and 4 as constructing control sequences using \csname, which requires c variants. Since c is a variant of an N argument, the base function signature and the generated variant have been updated accordingly.