### PR TITLE
docs: fix l3expan documentation

### DIFF
--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -557,7 +557,7 @@
 %     \exp_args:Neee
 %   }
 %   \begin{syntax}
-%     \cs{exp_args:NNno} \meta{token_1} \meta{token_2} \Arg{token_3} \Arg{tokens}
+%     \cs{exp_args:NNno} \meta{token_1} \meta{token_2} \Arg{tokens_1} \Arg{tokens_2}
 %   \end{syntax}
 %   These functions absorb four arguments and expand the second, third
 %   and fourth as detailed by their argument specifier. The first
@@ -577,12 +577,13 @@
 %     \exp_args:Noox,
 %   }
 %   \begin{syntax}
-%     \cs{exp_args:NNNx} \meta{token_1} \meta{token_2} \meta{tokens_1} \Arg{tokens_2}
+%     \cs{exp_args:NNNx} \meta{token_1} \meta{token_2} \meta{token_3} \Arg{tokens}
 %   \end{syntax}
 %   These functions absorb four arguments and expand the second, third
 %   and fourth as detailed by their argument specifier. The first
 %   argument of the function is then the next item on the input stream,
 %   followed by the expansion of the second argument, etc.
+%   These functions are not expandable due to their |x|-type argument.
 % \end{function}
 %
 % \section{Unbraced expansion}
@@ -611,7 +612,7 @@
 %     \exp_last_unbraced:NNNNf,
 %   }
 %   \begin{syntax}
-%     \cs{exp_last_unbraced:No} \meta{token} \Arg{tokens_1}
+%     \cs{exp_last_unbraced:No} \meta{token} \Arg{tokens}
 %   \end{syntax}
 %   These functions absorb the number of arguments given by their
 %   specification, carry out the expansion

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -140,7 +140,7 @@
 %   to the \meta{parent control sequence}. So for example
 %   \begin{verbatim}
 %     \cs_set:Npn \foo:Nn #1#2 { code here }
-%     \cs_generate_variant:Nn \foo:Nn { c }
+%     \cs_generate_variant:Nn \foo:Nn { cn }
 %   \end{verbatim}
 %   creates a new function |\foo:cn| which expands its first
 %   argument into a control sequence name and passes the result to
@@ -208,10 +208,10 @@
 % \section{Introducing the variants}
 %
 % The |V| type returns the value of a register, which can be one of
-% |tl|, |clist|, |int|, |skip|, |dim|, |muskip|, or built-in \TeX{}
-% registers. The |v| type is the same except it first creates a
-% control sequence out of its argument before returning the
-% value.
+% |bitset|, |clist|, |dim|, |fp|, |int|, |muskip|, |skip|, |str|, |tl|, 
+% or built-in \TeX{} registers. 
+% The |v| type is the same except it first creates a control sequence 
+% out of its argument before returning the value.
 %
 % In general, the programmer should not need to be concerned with
 % expansion control. When simply using the content of a variable,

--- a/l3kernel/l3expan.dtx
+++ b/l3kernel/l3expan.dtx
@@ -140,7 +140,7 @@
 %   to the \meta{parent control sequence}. So for example
 %   \begin{verbatim}
 %     \cs_set:Npn \foo:Nn #1#2 { code here }
-%     \cs_generate_variant:Nn \foo:Nn { cn }
+%     \cs_generate_variant:Nn \foo:Nn { c }
 %   \end{verbatim}
 %   creates a new function |\foo:cn| which expands its first
 %   argument into a control sequence name and passes the result to


### PR DESCRIPTION
## Summary

This PR fixes several documentation issues in `l3expan.dtx`.

### Changes

* ~~Correct the variant-generation example in the documentation.~~
* Correct the list of variable types supported by `V`-type expansion.
* Update argument names in several examples to match the documented argument structure.
* Clarify the documented argument structure for `\exp_args:N..x` functions.

All changes are documentation-only and do not modify the implementation.
